### PR TITLE
Added initial grunt build command

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -36,8 +36,9 @@ Once thie generator has finished you'll have a folder full of files and folders.
 Here's a quick guide on working with these files:
 
 - Edit files within the `src` directory.
-- Point your terminal to `dist`, run `grunt build` to create your initial files
-- Next run `python -m SimpleHTTPServer`.
+- Run `grunt build-cf` to create the initial files from `/src` to `/dist`
+- `cd dist`
+- In the `/dist/` directory, run `python -m SimpleHTTPServer`.
 
   You can now navigate to `localhost:8000` and view the demo page.
 

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -36,7 +36,9 @@ Once thie generator has finished you'll have a folder full of files and folders.
 Here's a quick guide on working with these files:
 
 - Edit files within the `src` directory.
-- Point your terminal to `dist` and run `python -m SimpleHTTPServer`.
+- Point your terminal to `dist`, run `grunt build` to create your initial files
+- Next run `python -m SimpleHTTPServer`.
+
   You can now navigate to `localhost:8000` and view the demo page.
 
 #### Editing the Less and JS


### PR DESCRIPTION
Running simpleHTTPServer without the initial grunt build yields a blank page - this step (while indicated later, it's helpful to run it in line if you're running it the first time)