### PR TITLE
New @import build process

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,15 +13,17 @@
     "url": "https://github.com/cfpb/capital-framework.git"
   },
   "license": "CC0",
+  "main": "src/capital-framework.less",
   "dependencies": {
-    "cf-core": "cfpb/cf-core#~0.8.0",
-    "cf-buttons": "cfpb/cf-buttons",
-    "cf-expandables": "cfpb/cf-expandables#~0.6.1",
-    "cf-forms": "cfpb/cf-forms#~1.1.0",
-    "cf-grid": "cfpb/cf-grid#~0.9.0",
-    "cf-icons": "cfpb/cf-icons",
-    "cf-pagination": "cfpb/cf-pagination#~0.4.1",
-    "cf-layout": "cfpb/cf-layout#~0.1.0"
+    "cf-core": "cfpb/cf-core#dev",
+    "cf-buttons": "cfpb/cf-buttons#dev",
+    "cf-expandables": "cfpb/cf-expandables#dev",
+    "cf-forms": "cfpb/cf-forms#dev",
+    "cf-grid": "cfpb/cf-grid#dev",
+    "cf-icons": "cfpb/cf-icons#dev",
+    "cf-pagination": "cfpb/cf-pagination#dev",
+    "cf-typography": "cfpb/cf-typography#dev",
+    "cf-layout": "cfpb/cf-layout#dev"
   },
   "exportsOverride": {
     "cf-*": {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "capital-framework",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Project-wide documentation for Capital Framework.",
   "homepage": "http://cfpb.github.io/capital-framework/",
   "author": {
@@ -15,15 +15,15 @@
   "license": "CC0",
   "main": "src/capital-framework.less",
   "dependencies": {
-    "cf-core": "cfpb/cf-core#dev",
-    "cf-buttons": "cfpb/cf-buttons#dev",
-    "cf-expandables": "cfpb/cf-expandables#dev",
-    "cf-forms": "cfpb/cf-forms#dev",
-    "cf-grid": "cfpb/cf-grid#dev",
-    "cf-icons": "cfpb/cf-icons#dev",
-    "cf-pagination": "cfpb/cf-pagination#dev",
-    "cf-typography": "cfpb/cf-typography#dev",
-    "cf-layout": "cfpb/cf-layout#dev"
+    "cf-core": "^1.0.0",
+    "cf-buttons": "^1.6.1",
+    "cf-expandables": "^1.0.0",
+    "cf-forms": "^1.3.0",
+    "cf-grid": "^1.0.0",
+    "cf-icons": "^1.0.0",
+    "cf-pagination": "^1.0.0",
+    "cf-typography": "^1.0.0",
+    "cf-layout": "^1.0.0"
   },
   "exportsOverride": {
     "cf-*": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capital-framework",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Project-wide documentation for Capital Framework.",
   "homepage": "https://cfpb.github.io/capital-framework/",
   "author": {

--- a/src/capital-framework.less
+++ b/src/capital-framework.less
@@ -1,0 +1,8 @@
+@import (less) '../../cf-core/src/cf-core.less';
+@import (less) '../../cf-icons/src/cf-icons.less';
+@import (less) '../../cf-buttons/src/cf-buttons.less';
+@import (less) '../../cf-forms/src/cf-forms.less';
+@import (less) '../../cf-grid/src/cf-grid.less';
+@import (less) '../../cf-layout/src/cf-layout.less';
+@import (less) '../../cf-typography/src/cf-typography.less';
+@import (less) '../../cf-pagination/src/cf-pagination.less';

--- a/src/capital-framework.less
+++ b/src/capital-framework.less
@@ -6,3 +6,4 @@
 @import (less) '../../cf-layout/src/cf-layout.less';
 @import (less) '../../cf-typography/src/cf-typography.less';
 @import (less) '../../cf-pagination/src/cf-pagination.less';
+@import (less) '../../cf-expandables/src/cf-expandables.less';


### PR DESCRIPTION
This implements the changes discussed in https://github.com/cfpb/capital-framework/issues/151.

## Additions

- New one-stop-shop `src/capital-framework.less` file that imports all components.
- `@import` rules to pull in dependencies.

## Changes

- Updated all deps.
- Bumped to `1.0.0`.

## Testing

- You can't. :neutral_face: There's a chicken vs. the egg scenario here. This project's dependencies now point to the 1.x.x version of other CF components. But those versions aren't in Bower/npm yet because their PRs are still pending.
- The `dev` branch was thoroughly tested prior to this PR and more testing will occur afterward. There will likely be some kinks to work out after this merge but that's okay -- semver will shield current projects from any bugs.

## Review

- @Scotchester 
- @anselmbradford 
