### PR TITLE
Improve CF docs

### DIFF
--- a/components/index.md
+++ b/components/index.md
@@ -5,11 +5,6 @@ title:  "Components"
 
 Capital Framework is divided into a series of components. These components can be used individually, but are designed to work together. For information on how to get started using Capital Framework, please read the [Getting Started](../getting-started/) page. 
 
-
-## [cf-core](https://cfpb.github.io/cf-core/docs/)
-
-cf-core contains core styles for starting a Capital Framework project. It includes Normalize.css, variables, media query and utility mixins, class utilities, typography, and standard base styling. 
-
 ## [cf-buttons](https://cfpb.github.io/cf-buttons/docs/)
 
 cf-buttons contains button styles including default, secondary, destructive, disabled, super, and compound buttons, button links, buttons with icons, and button groups.
@@ -37,3 +32,7 @@ cf-layout contains a set of HTML & CSS layout helpers, such as common layout pat
 ## [cf-pagination](https://cfpb.github.io/cf-pagination/docs/)
 
 cf-pagination contains basic pagination styling for working with multipage displays such as search results or blog archives.
+
+## [cf-core](https://cfpb.github.io/cf-core/docs/)
+
+cf-core contains core styles for starting a Capital Framework project. It includes Normalize.css, variables, media query and utility mixins, class utilities, typography, and standard base styling. 

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -6,7 +6,7 @@ title:  "Contributing"
 ## Demos and docs
 
 Each component should build out a demo and docs page using
-[grunt-topdoc](https://github.com/topcoat/grunt-topdoc). The demo page is a simple html page with no extra styling which is useful for browser testing the component. The docs page is a generated style guide documenting the component markup and CSS.
+[grunt-topdoc](https://github.com/topcoat/grunt-topdoc). The demo page is a simple HTML page with no extra styling which is useful for browser testing the component. The docs page is a generated style guide documenting the component markup and CSS.
 
 These pages are generated using the grunt-topdoc task which uses templates from cf-component-demo. Components are set up to generate these pages along with the default Grunt tasks.
 
@@ -17,7 +17,7 @@ Components should be cross browser tested. When contributing code please publicl
 
 ## JavaScript testing
 
-JavaScript tests can be run with the `grunt test` command. Before making a pull request please publicly track that all tests have passed
+JavaScript tests can be run with the `npm test` command. Before making a pull request please publicly track that all tests have passed
 using the [testing checklist snippet](testing-snippet.html).
 
 New unit tests should be written using [QUnit](https://qunitjs.com/) for any functionality added.
@@ -27,11 +27,9 @@ New unit tests should be written using [QUnit](https://qunitjs.com/) for any fun
 
 Components should conform to [Section 508](http://www.section508.gov/)
 and [WCAG 2.0 level AA](http://www.w3.org/TR/WCAG20/) guidelines.
-When contributing code please publicly track the tests you have run using the
-[testing checklist snippet](testing-snippet.html).
-
-As each component is different we ask that you update the snippet to track
-the accessibility guidlines you have tested for.
+Travis CI runs [pa11y](http://pa11y.org/) tests to ensure WCAG 2.0 compliancy.
+You can run pa11y locally by starting a local server to serve the component's
+demo page and running `pa11y localhost:8080/demo -s WCAG2AA`.
 
 
 ## Coding style

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -3,11 +3,17 @@ layout: default
 title:  "Getting started"
 ---
 
-Capital Framework provides a set of modular HTML, CSS, and JavaScript patterns that can be used both collectively and individually. Our recommended workflow is to use the cf-generator Yeoman generator to scaffold out a new Capital Framework project. This allows you to pick and choose your modules as well as providing a solid front end build process.
+Capital Framework provides a set of modular HTML, CSS, and JavaScript patterns that can be used both collectively and individually. There are several ways to integrate Capital Framework into your project:
 
-## Using the Yeoman generator
+1. [Using the generator](#using-the-generator)
+1. [Using Bower](#using-bower)
+1. [Downloading the compiled CSS](#downloading-the-compiled-css)
 
-To use the Yeoman generator, you will need [Node.js](http://nodejs.org/), [Yeoman](http://yeoman.io/), [Grunt](http://gruntjs.com/), and [Bower](http://bower.io/).
+Our recommended workflow is to use the generator to scaffold out a new Capital Framework project. This allows you to pick and choose your modules as well as providing a solid front end build process.
+
+## Using the generator
+
+To use the generator, you will need [Node.js](http://nodejs.org/), [Yeoman](http://yeoman.io/), [Grunt](http://gruntjs.com/), and [Bower](http://bower.io/).
 
 ### Installing dependencies
 
@@ -39,7 +45,6 @@ Here's a quick guide on working with these files:
 - To view your site, go to the dist directory and start a local server: `cd dist && python -m SimpleHTTPServer`. You can now navigate to `localhost:8000` in your web browser.
 - Edit files within the `src` directory and re-run `grunt build` to view changes.
 
-
 #### Editing the Less and JS
 
 The generator has created a starter Less file at `src/static/css/main.less`.
@@ -62,3 +67,21 @@ with a color from `brand-palette.less` or any color of your choosing.
 The same applies when you need to add custom styles to your project.
 You can add any custom `.less` files to your project that you may need,
 just remember to import them in `main.less` using the correct path.
+
+## Using Bower
+
+First install [Bower](http://bower.io/), then run `bower install capital-framework`.
+This will download Capital Framework to your project's `bower_components` directory.
+You can then import the framework into your application's primary Less file:
+
+{% highlight css %}
+@import (less) bower_components/capital-framework/src/capital-framework.less.
+{% endhighlight %}
+
+Not using Less? The compiled CSS file can be found in
+`bower_components/capital-framework/assets/css/main.min.css`.
+
+## Downloading the compiled CSS
+
+Capital Framework's compiled CSS can be [downloaded here](http://cfpb.github.io/capital-framework/assets/cf.zip).
+Download it and integrate it into your project as you please.

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -35,11 +35,10 @@ The generator will prompt you to complete information about the project and choo
 Once the generator has finished you'll have a folder full of files and folders.
 Here's a quick guide on working with these files:
 
-- Run `grunt compile-cf` to create the initial build.
-- Edit files within the `src` directory and rebuild with grunt.
-- To view your files, `cd dist`, then in the `/dist/` directory, run `python -m SimpleHTTPServer`.
+- Run `grunt build` to process the files in `src` and output them to `dist`.
+- To view your site, go to the dist directory and start a local server: `cd dist && python -m SimpleHTTPServer`. You can now navigate to `localhost:8000` in your web browser.
+- Edit files within the `src` directory and re-run `grunt build` to view changes.
 
-You can now navigate to `localhost:8000` and view the demo page.
 
 #### Editing the Less and JS
 


### PR DESCRIPTION
Cleaned up the docs to make them more relevant.

## Additions

- Bower usage steps.
- Guidance on running pa11y tests.

## Removals

- Mentions of `compile-cf` grunt task.

## Changes

- Misc. verbiage on the getting-started page.
- Moved cf-core to the bottom of the components list. It's the least interesting component, no reason to show it first.

## Review

- @Scotchester 
- @ascott1 