### PR TITLE
Fixed import order

### DIFF
--- a/src/capital-framework-generated.less
+++ b/src/capital-framework-generated.less
@@ -1,7 +1,6 @@
 // This is the same as the other source file but we need to include the special
 // Less file that generates the cf-grid classes.
 
-@import (less) '../../cf-core/src/cf-core.less';
 @import (less) '../../cf-icons/src/cf-icons.less';
 @import (less) '../../cf-buttons/src/cf-buttons.less';
 @import (less) '../../cf-forms/src/cf-forms.less';
@@ -9,4 +8,5 @@
 @import (less) '../../cf-layout/src/cf-layout.less';
 @import (less) '../../cf-typography/src/cf-typography.less';
 @import (less) '../../cf-pagination/src/cf-pagination.less';
+@import (less) '../../cf-core/src/cf-core.less';
 @import (less) '../../cf-expandables/src/cf-expandables.less';

--- a/src/capital-framework.less
+++ b/src/capital-framework.less
@@ -1,4 +1,3 @@
-@import (less) '../../cf-core/src/cf-core.less';
 @import (less) '../../cf-icons/src/cf-icons.less';
 @import (less) '../../cf-buttons/src/cf-buttons.less';
 @import (less) '../../cf-forms/src/cf-forms.less';
@@ -7,3 +6,4 @@
 @import (less) '../../cf-typography/src/cf-typography.less';
 @import (less) '../../cf-pagination/src/cf-pagination.less';
 @import (less) '../../cf-expandables/src/cf-expandables.less';
+@import (less) '../../cf-core/src/cf-core.less';


### PR DESCRIPTION
## Changed

- cf-core components need to be last in the cascade to be honored

## Notes

A final round of testing https://github.com/cfpb/cfgov-refresh/pull/608 revealed an issue with Capital Framework and the cascade. This PR is only part of what needs to happen to fix the issue.

Long and short is, prior to 1.0.0, we purposefully ignored cf-core in the Grunt concat tasks and then imported cf-core at the end. Without that ignore rule, cf-core is imported at the top, even if the import rule is at the end of `capital-framework.less` as this PR is suggesting because each of the components imports it as well. The issue with this is the utilities and other components to `cf-core` are at the top of the cascade which means something like `u-show-on-mobile` is overwritten by something like `expandable_header`.

One solution would be to keep the import order, but to change the rules of `cf-core` to include `!important`. I don't think anyone will disagree when I say that's not a great solution.

A better solution is to remove the dependency imports for each of the component files and add a `main.less` or something similar to each repo that imports the component and dependencies. This still has a downside that a user could wind up pulling in two `main.less` files from two components and the order would be off. Ex importing `cf-icons/main.less` and `cf-expandables/main.less` would have the same result as above where `expandable_header` overwrites `u-show-on-mobile`.

A final solution is to include directions in each README to import the components you need *as well* as that component's dependencies, ensuring `cf-core` is always last. We could point them to th version of `capital-framework.less` in this PR as a reference. This seems to be the safest and most reliable, but also requires breaking updates to each component. Not a great way to start off v1 :(