### PR TITLE
Fix some minor list spacing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,52 +3,55 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 
-### Added
-- 
+### Fixed
+- **cf-core:** Fix improper usage of `:not` to target non-nav `li` elements.
+- **cf-core:** Remove `margin-bottom` from last-child `li` elements.
 
-### Changed
-- 
-
-### Removed
-- 
 
 ## 3.1.1 - 2016-01-04
 
 ### Changed
 - **capital-framework:** Improved contributing docs in readme.
 
+
 ## 3.1.0 - 2016-01-04
 
 ### Changed
-- **capital-framework:** Edit gulp styles task to use Less' paths option instead of npm import plugin.
-- **cf-core:** Update normalize.css @import paths to play nicer with Less paths option.
-- **cf-grid:** Update normalize.css @import paths to play nicer with Less paths option.
+- **capital-framework:** Edit Gulp styles task to use Less' `paths` option instead of npm import plugin.
+- **cf-core:** Update `normalize.css` `@import` paths to play nicer with Less paths option.
+- **cf-grid:** Update `normalize.css` `@import` paths to play nicer with Less paths option.
 - **cf-icons:** Replace icon fonts to fix "Failed to decode downloaded font" error.
+
 
 ## 3.0.8 - 2015-12-22
 
 ### Added
 - Ability to publish CF from local machine (instead of only Travis).
 
+
 ## 3.0.7 - 2015-12-22
 
 ### Removed
 - Topdoc comments from component source files.
+
 
 ## 3.0.6 - 2015-12-18
 
 ### Added
 - Initial WCAG accessibility tests.
 
+
 ## 3.0.5 - 2015-12-18
 
 ### Changed
 - Individual components' readme template.
 
+
 ## 3.0.3 - 2015-12-18
 
 ### Added
-- Add automatic changelog updating to Travis CI release script. 
+- Add automatic changelog updating to Travis CI release script.
+
 
 ## 3.0.0 - 2015-12-17
 

--- a/src/cf-core/package.json
+++ b/src/cf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Capital Framework core styles",
   "less": "src/cf-core.less",
   "style": "cf-core.css",

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -386,11 +386,11 @@ p + ol {
 
 li {
     margin-bottom: unit(8px / @base-font-size-px, em);
-}
 
-li:last-child,
-nav li {
-    margin-bottom: 0;
+    &:last-child,
+    nav & {
+        margin-bottom: 0;
+    }
 }
 
 //

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -384,12 +384,12 @@ p + ol {
     margin-top: unit(-5px / @base-font-size-px, em);
 }
 
-:not(nav) li {
+li {
     margin-bottom: unit(8px / @base-font-size-px, em);
 }
 
-// Override for IE8 and under, which doesn't suppor the :not selector.
-.lt-ie9 nav li {
+li:last-child,
+nav li {
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
Fixes an incorrect usage of the `:not` selector and removes the bottom margin when `li` is the last child.

Also some minor CHANGELOG formatting cleanup.


## Testing

1. Pull changes.
2. Run `npm link` from `src/cf-core` directory.
3. Run `npm install` in one of your projects to update cf-core.
4. View and confirm correct list item spacing.


## Review

- @jimmynotjim 
- @contolini (Am I doing this contribution workflow correctly?)
- @cfpb/front-end-team-admin 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
