### PR TITLE
Remove block borders when __flush modifers used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,14 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Fixed
-- **cf-core:** Fix improper usage of `:not` to target non-nav `li` elements.
-- **cf-core:** Remove `margin-bottom` from last-child `li` elements.
-- **cf-layout** - Fixed a bug where columns nested 2 levels deep in a large-gutter modifier gain the extra wide gutters.
-
-### Added
--
-
-### Changed
--
-
-### Removed
--
+- [PATCH] **cf-core:** Fix improper usage of `:not` to target non-nav `li` elements.
+- [PATCH] **cf-core:** Remove `margin-bottom` from last-child `li` elements.
+- [PATCH] **cf-layout** - Fixed a bug where columns nested 2 levels deep in a
+  large-gutter modifier gain the extra wide gutters.
+- [PATCH] **cf-layout:** Remove `block` borders when `__flush` modifiers are also applied.
 
 ### Changed
-- [PATCH] **cf-layout:** Hero fixes:
+- [PATCH] **cf-layout:** Hero updates:
   - Use new breakpoint variables
   - Subheading should not be medium on smaller screens
   - CTA links should match size and weight of subheading
@@ -35,8 +28,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - **capital-framework:** Edit Gulp styles task to use Less' `paths` option instead of npm import plugin.
-- **cf-core:** Update `normalize.css` `@import` paths to play nicer with Less paths option.
-- **cf-grid:** Update `normalize.css` `@import` paths to play nicer with Less paths option.
+- **cf-core:** Update `normalize.css` `@import` paths to play nicer with Less `paths` option.
+- **cf-grid:** Update `normalize.css` `@import` paths to play nicer with Less `paths` option.
 - **cf-icons:** Replace icon fonts to fix "Failed to decode downloaded font" error.
 
 
@@ -68,10 +61,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Added
 - Add automatic changelog updating to Travis CI release script.
-<<<<<<< 8dc552a02b842ced693f36bba7559c9785aa5406
 
-=======
->>>>>>> Fixed a bug where columns nested 2 levels deep in a large-gutter modifier gain the extra wide gutters.
 
 ## 3.0.0 - 2015-12-17
 

--- a/src/cf-layout/package.json
+++ b/src/cf-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-layout",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Capital Framework layouts",
   "less": "src/cf-layout.less",
   "style": "cf-layout.css",

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -312,7 +312,7 @@
 .content__flush-all-on-small {
     .respond-to-max(@bp-sm-max, {
         padding: 0;
-        border-width: 0;
+        border: none;
     });
 }
 

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -371,7 +371,7 @@
             margin-left: -@grid_gutter-width;
         });
 
-        respond-to-max(@bp-xs-max, {
+        .respond-to-max(@bp-xs-max, {
             &.block__border,
             &.block__border-right,
             &.block__border-left {

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -366,18 +366,18 @@
         margin-right: -(@grid_gutter-width / 2);
         margin-left: -(@grid_gutter-width / 2);
 
-        .respond-to-min(@bp-sm-min, {
-            margin-right: -@grid_gutter-width;
-            margin-left: -@grid_gutter-width;
-        });
-
         .respond-to-max(@bp-xs-max, {
             &.block__border,
             &.block__border-right,
             &.block__border-left {
-                border-right: none;
-                border-left: none;
+              border-right: none;
+              border-left: none;
             }
+        });
+
+        .respond-to-min(@bp-sm-min, {
+            margin-right: -@grid_gutter-width;
+            margin-left: -@grid_gutter-width;
         });
     }
 
@@ -389,11 +389,19 @@
 
         &.block__border,
         &.block__border-top,
-        &.block__border-right,
-        &.block__border-bottom,
-        &.block__border-left {
-            border: none;
+        &.block__border-bottom {
+            border-top: none;
+            border-bottom: none;
         }
+
+        .respond-to-max(@bp-xs-max, {
+            &.block__border,
+            &.block__border-right,
+            &.block__border-left {
+                border-right: none;
+                border-left: none;
+            }
+        });
 
         .respond-to-min(@bp-sm-min, {
             margin-right: -@grid_gutter-width;

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -17,10 +17,10 @@
 // .block
 @block__bg:                     lighten(#3a8899, 55%);
 @block__border:                 #3a8899;
-@block__border-top:             #3a8899;
-@block__border-right:           #3a8899;
-@block__border-bottom:          #3a8899;
-@block__border-left:            #3a8899;
+@block__border-top:             @block__border;
+@block__border-right:           @block__border;
+@block__border-bottom:          @block__border;
+@block__border-left:            @block__border;
 
 // .content_main
 @content_main-border:           #3a8899;

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -16,11 +16,11 @@
 
 // .block
 @block__bg:                     lighten(#3a8899, 55%);
+@block__border:                 #3a8899;
 @block__border-top:             #3a8899;
 @block__border-right:           #3a8899;
 @block__border-bottom:          #3a8899;
 @block__border-left:            #3a8899;
-@block__border:                 #3a8899;
 
 // .content_main
 @content_main-border:           #3a8899;

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -371,12 +371,14 @@
             margin-left: -@grid_gutter-width;
         });
 
-        &.block__border,
-        &.block__border-right,
-        &.block__border-left {
-            border-right: none;
-            border-left: none;
-        }
+        respond-to-max(@bp-xs-max, {
+            &.block__border,
+            &.block__border-right,
+            &.block__border-left {
+                border-right: none;
+                border-left: none;
+            }
+        });
     }
 
     &__flush {

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -15,12 +15,12 @@
 // Color variables
 
 // .block
+@block__bg:                     lighten(#3a8899, 55%);
 @block__border-top:             #3a8899;
 @block__border-right:           #3a8899;
 @block__border-bottom:          #3a8899;
 @block__border-left:            #3a8899;
 @block__border:                 #3a8899;
-@block__bg:                     lighten(#3a8899, 55%);
 
 // .content_main
 @content_main-border:           #3a8899;
@@ -346,10 +346,20 @@
 
     &__flush-top {
         margin-top: 0 !important;
+
+        &.block__border,
+        &.block__border-top {
+            border-top: none;
+        }
     }
 
     &__flush-bottom {
         margin-bottom: 0 !important;
+
+        &.block__border,
+        &.block__border-bottom {
+            border-bottom: none;
+        }
     }
 
     &__flush-sides {
@@ -360,6 +370,13 @@
             margin-right: -@grid_gutter-width;
             margin-left: -@grid_gutter-width;
         });
+
+        &.block__border,
+        &.block__border-right,
+        &.block__border-left {
+            border-right: none;
+            border-left: none;
+        }
     }
 
     &__flush {
@@ -367,6 +384,14 @@
         margin-right: -(@grid_gutter-width / 2);
         margin-bottom: 0 !important;
         margin-left: -(@grid_gutter-width / 2);
+
+        &.block__border,
+        &.block__border-top,
+        &.block__border-right,
+        &.block__border-bottom,
+        &.block__border-left {
+            border: none;
+        }
 
         .respond-to-min(@bp-sm-min, {
             margin-right: -@grid_gutter-width;


### PR DESCRIPTION
Removes corresponding borders on `block`s when `__flush` modifiers are also applied.


## Testing

1. Pull changes.
2. Run `npm link` from `src/cf-core` directory.
3. Run `npm install` in one of your projects to update cf-core.
4. View and confirm correct list item spacing.


## Review

- @cfpb/front-end-team-admin 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
