### PR TITLE
Fixed bug in large gutter modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Fixed
 - **cf-core:** Fix improper usage of `:not` to target non-nav `li` elements.
 - **cf-core:** Remove `margin-bottom` from last-child `li` elements.
+- **cf-layout** - Fixed a bug where columns nested 2 levels deep in a large-gutter modifier gain the extra wide gutters.
+
+### Added
+-
+
+### Changed
+-
+
+### Removed
+-
 
 
 ## 3.1.1 - 2016-01-04
@@ -51,7 +61,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Added
 - Add automatic changelog updating to Travis CI release script.
+<<<<<<< 8dc552a02b842ced693f36bba7559c9785aa5406
 
+=======
+>>>>>>> Fixed a bug where columns nested 2 levels deep in a large-gutter modifier gain the extra wide gutters.
 
 ## 3.0.0 - 2015-12-17
 

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -89,7 +89,7 @@
             margin-left: -@grid_gutter-width;
             margin-right: -@grid_gutter-width;
 
-            & .content-l_col {
+            > .content-l_col {
                 border-left-width: @grid_gutter-width;
                 border-right-width: @grid_gutter-width;
             }


### PR DESCRIPTION
Fixed a bug where columns nested 2 levels deep in a large-gutter modifier gain the extra wide gutters.

## Changes

- Limited extra wide gutters to direct children of the large-gutter modifier

## Testing

Test this markup in a project

```
             <div class="content-l
                                content-l__large-gutters">
                <section class="content-l_col
                                content-l_col-1-2">
                    <h2>Look, I'm 1/2 the page!</h2>
                    <div class="content-l">
                        <div class="content-l_col
                                    content-l_col-1-2">
                            I'm a 1/4 column
                        </div>
                        <div class="content-l_col
                                    content-l_col-1-2">
                            I'm a 1/4 column
                        </div>
                    </div>
                </section>

                <section class="content-l_col
                                content-l_col-1-2">
                    <h2>I'm also 1/2 the page</h2>
                    <div class="content-l">
                        <div class="content-l_col
                                    content-l_col-1-2">
                            I'm a 1/4 column
                        </div>
                        <div class="content-l_col
                                    content-l_col-1-2">
                            I'm a 1/4 column
                        </div>
                    </div>
                </section>
            </div>
```

## Review

- @Scotchester 
- @KimberlyMunoz 
- @cfarm
- @contolini 

## Screenshots

__Before:__

![screen shot 2016-02-03 at 2 10 31 pm](https://cloud.githubusercontent.com/assets/1280430/12793743/e63f4068-ca7f-11e5-963d-216fc1e382d7.png)

__After:__

![screen shot 2016-02-03 at 2 09 50 pm](https://cloud.githubusercontent.com/assets/1280430/12793739/df209908-ca7f-11e5-98f8-83afa25f3b8f.png)


## Todos

- None

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
