### PR TITLE
Adding font-size vars for consistent sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+- [MINOR] **cf-core** Added font-size vars
 
 ### Changed
-- 
+-
 
 ### Removed
-- 
+-
 
 ## 3.1.2 - 2016-02-10
 

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -66,7 +66,7 @@ body {
     line-height: @base-line-height;
 }
 
-.heading-1( @fs: 34px ) {
+.heading-1( @fs: @size-alpha ) {
     @font-size: @fs;
     .webfont-regular();
 
@@ -75,7 +75,7 @@ body {
     line-height: 1.25;
 }
 
-.heading-2( @fs: 26px ) {
+.heading-2( @fs: @size-beta ) {
     @font-size: @fs;
     .webfont-regular();
 
@@ -84,7 +84,7 @@ body {
     line-height: 1.25;
 }
 
-.heading-3( @fs: 22px )  {
+.heading-3( @fs: @size-gamma )  {
     @font-size: @fs;
     .webfont-regular();
 
@@ -93,7 +93,7 @@ body {
     line-height: 1.25;
 }
 
-.heading-4( @fs: 18px )  {
+.heading-4( @fs: @size-delta )  {
     @font-size: @fs;
     .webfont-medium();
 
@@ -102,7 +102,7 @@ body {
     line-height: 1.25;
 }
 
-.heading-5( @fs: 14px )  {
+.heading-5( @fs: @size-epsilon )  {
     @font-size: @fs;
     .webfont-demi();
 
@@ -113,7 +113,7 @@ body {
     text-transform: uppercase;
 }
 
-.heading-6( @fs: 12px )  {
+.heading-6( @fs: @size-zeta )  {
     @font-size: @fs;
     .webfont-demi();
 
@@ -350,7 +350,7 @@ h6,
 
 .superheading {
     // For when you want a heading that's bigger than a normal H1
-    @font-size: 48px;
+    @font-size: @size-kilo;
 
     .webfont-regular();
 

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -350,7 +350,7 @@ h6,
 
 .superheading {
     // For when you want a heading that's bigger than a normal H1
-    @font-size: @size-kilo;
+    @font-size: @size-xl;
 
     .webfont-regular();
 

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -66,7 +66,7 @@ body {
     line-height: @base-line-height;
 }
 
-.heading-1( @fs: @size-alpha ) {
+.heading-1( @fs: @size-i ) {
     @font-size: @fs;
     .webfont-regular();
 
@@ -75,7 +75,7 @@ body {
     line-height: 1.25;
 }
 
-.heading-2( @fs: @size-beta ) {
+.heading-2( @fs: @size-ii ) {
     @font-size: @fs;
     .webfont-regular();
 
@@ -84,7 +84,7 @@ body {
     line-height: 1.25;
 }
 
-.heading-3( @fs: @size-gamma )  {
+.heading-3( @fs: @size-iii )  {
     @font-size: @fs;
     .webfont-regular();
 
@@ -93,7 +93,7 @@ body {
     line-height: 1.25;
 }
 
-.heading-4( @fs: @size-delta )  {
+.heading-4( @fs: @size-iv )  {
     @font-size: @fs;
     .webfont-medium();
 
@@ -102,7 +102,7 @@ body {
     line-height: 1.25;
 }
 
-.heading-5( @fs: @size-epsilon )  {
+.heading-5( @fs: @size-v )  {
     @font-size: @fs;
     .webfont-demi();
 
@@ -113,7 +113,7 @@ body {
     text-transform: uppercase;
 }
 
-.heading-6( @fs: @size-zeta )  {
+.heading-6( @fs: @size-vi )  {
     @font-size: @fs;
     .webfont-demi();
 

--- a/src/cf-core/src/cf-vars.less
+++ b/src/cf-core/src/cf-vars.less
@@ -12,6 +12,21 @@
 @base-font-size-px:             16px;
 @base-line-height-px:           22px;
 @base-line-height:              unit(@base-line-height-px / @base-font-size-px);
+
+@size-giga:     96px;
+@size-mega:     72px;
+@size-kilo:     48px; // Super-size
+
+@size-alpha:    34px; // h1-size
+@size-beta:     26px; // h2-size
+@size-gamma:    22px; // h3-size
+@size-delta:    18px; // h4-size
+@size-epsilon:  14px; // h5-site
+@size-zeta:     12px; // h6-size
+
+@size-milli:    12px;
+@size-micro:    10px;
+
 @bp-xs-max:                     600px;
 @bp-sm-min:                     @bp-xs-max + 1px;
 @bp-sm-max:                     900px;

--- a/src/cf-core/src/cf-vars.less
+++ b/src/cf-core/src/cf-vars.less
@@ -13,7 +13,7 @@
 @base-line-height-px:           22px;
 @base-line-height:              unit(@base-line-height-px / @base-font-size-px);
 
-@size-l:   48px; // Super-size
+@size-xl:  48px; // Super-size
 
 @size-i:   34px; // h1-size
 @size-ii:  26px; // h2-size

--- a/src/cf-core/src/cf-vars.less
+++ b/src/cf-core/src/cf-vars.less
@@ -13,19 +13,15 @@
 @base-line-height-px:           22px;
 @base-line-height:              unit(@base-line-height-px / @base-font-size-px);
 
-@size-giga:     96px;
-@size-mega:     72px;
-@size-kilo:     48px; // Super-size
+@size-l:   48px; // Super-size
 
-@size-alpha:    34px; // h1-size
-@size-beta:     26px; // h2-size
-@size-gamma:    22px; // h3-size
-@size-delta:    18px; // h4-size
-@size-epsilon:  14px; // h5-site
-@size-zeta:     12px; // h6-size
+@size-i:   34px; // h1-size
+@size-ii:  26px; // h2-size
+@size-iii: 22px; // h3-size
+@size-iv:  18px; // h4-size
+@size-v:   14px; // h5-site
+@size-vi:  12px; // h6-size
 
-@size-milli:    12px;
-@size-micro:    10px;
 
 @bp-xs-max:                     600px;
 @bp-sm-min:                     @bp-xs-max + 1px;


### PR DESCRIPTION
Adding font-size vars for consistent sizing

## Additions

- Added new variables matched to the corresponding heading level.

## Changes

- Updated `heading-#` mixins to use new variables in place of px values.

## Testing

- Source locally with `npm link` and build your project, headings should all be the same size.

## Review

- @KimberlyMunoz 
- @Scotchester 
- @cfarm 
- @contolini 

## Notes

- Now easier to use font-sizes without exposing the `@font-size` var.
- Naming based on http://csswizardry.com/2012/02/pragmatic-practical-font-sizing-in-css/.
- Adds `@size-giga`, `@size-mega`, `@size-milli`, `@size-micro` for future use.
- Fixes [cfgov-refresh #1387](https://github.com/cfpb/cfgov-refresh/issues/1387)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)