### PR TITLE
keep usage.md file on component build

### DIFF
--- a/scripts/gulp/copy.js
+++ b/scripts/gulp/copy.js
@@ -23,7 +23,6 @@ gulp.task( 'copy:components:source', function() {
       var component = file.path.split('/').pop(),
           src = [
                   file.path + '/**',
-                  '!' + file.path + '/usage.md',
                   '!' + file.path + '/package.json',
                   '!' + file.path + '/node_modules',
                   '!' + file.path + '/node_modules/**',


### PR DESCRIPTION
This copies the `usage.md` file into the component on build so that it can be consumed by the documentation site. This is the simplest solution, but it may be preferable to put this file in the `src` directory.

## Testing

Pull down this branch, run `npm run build` and take a gander at the output in the `tmp` directory.

## Review

Any combination of the following:

- @jimmynotjim 
- @contolini
- @cfarm 
- @KimberlyMunoz 
- @Scotchester 