### PR TITLE
Bugfix for proper font-families

### DIFF
--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -6,14 +6,8 @@
 //
 // Webfonts
 //
-
-@webfont-regular: Arial;
-@webfont-italic: Arial;
-@webfont-medium: Arial;
-@webfont-demi: Arial;
-
 .webfont-regular() {
-    font-family: @webfont-regular, Arial, sans-serif;
+    font-family: @webfont-regular;
     font-style: normal;
     font-weight: normal;
 
@@ -29,7 +23,7 @@
 }
 
 .webfont-italic() {
-    font-family: @webfont-italic, Arial, sans-serif;
+    font-family: @webfont-italic;
     font-style: italic;
     font-weight: normal;
     .lt-ie9 & {
@@ -38,7 +32,7 @@
 }
 
 .webfont-medium() {
-    font-family: @webfont-medium, Arial, sans-serif;
+    font-family: @webfont-medium;
     font-style: normal;
     font-weight: 500;
     .lt-ie9 & {
@@ -47,7 +41,7 @@
 }
 
 .webfont-demi() {
-    font-family: @webfont-demi, Arial, sans-serif;
+    font-family: @webfont-demi;
     font-style: normal;
     font-weight: bold;
     .lt-ie9 & {
@@ -61,7 +55,7 @@
 
 body {
     color: @text;
-    font-family: Georgia, "Times New Roman", serif;
+    font-family: @font-serif;
     font-size: unit(@base-font-size-px / 16 * 100, %);
     line-height: @base-line-height;
 }
@@ -549,7 +543,7 @@ select[multiple] {
     display: inline-block;
     margin: 0;
     padding: unit(6 / @base-font-size-px, em);
-    font-family: Arial, sans-serif;
+    font-family: @font-input;
     font-size: unit(@font-size / @base-font-size-px, em);
     background: @input-bg;
     border: 1px solid @input-border;

--- a/src/cf-core/src/cf-vars.less
+++ b/src/cf-core/src/cf-vars.less
@@ -36,6 +36,23 @@
 @mobile-max:                    @bp-xs-max;
 @tablet-min:                    @bp-sm-min;
 
+
+// Font variables
+
+// Base Fonts
+@font-sans-serif:   Arial, sans-serif;
+@font-serif:        Georgia, "Times New Roman", serif;
+
+// Webfonts
+@webfont-regular:   @font-sans-serif;
+@webfont-italic:    @font-sans-serif;
+@webfont-medium:    @font-sans-serif;
+@webfont-demi:      @font-sans-serif;
+
+// Inputs
+@font-input:        @webfont-regular;
+
+
 // Color variables
 // $color- variables are from 18F's US Web Design Standards
 // https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss


### PR DESCRIPTION
Bugfix for proper font-families. Currently, the webfont mixins assume the fallbacks should be Arial and sans-serif, making it difficult for non-bureau projects to overwrite.

__:warning:WARNING:warning::__ This will most likely break the font-stack for any existing projects using the webfont mixins. This update should probably be merged with the next major release because it will not be backwards compatible, despite only fixing a bug.

## Additions

- Adds sans and serif font vars to the cf-vars file

## Changes

- Moves webfont vars to the cf-vars file
- Updates the base text inputs in cf-core to use the regular webfont (necessary for a forthcoming bugfix to input-with-btn)

## Testing

- `npm link` and build your project. Everything should look as expected, but any elems set with the webfont mixins will be missing the fallbacks to Avenir. This PR requires updating your cf-theme-overrides files to the following:
```
@webfont-regular: 'AvenirNextLTW01-Regular', Arial, sans-serif;
@webfont-italic: 'AvenirNextLTW01-Italic', Arial, sans-serif;
@webfont-medium: 'AvenirNextLTW01-Medium', Arial, sans-serif;
@webfont-demi: 'AvenirNextLTW01-Demi', Arial, sans-serif;
```

## Review

- @anselmbradford 
- @KimberlyMunoz 
- @cfarm 
- @Scotchester 
- @ascott1 
- @contolini 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
