### PR TITLE
Normalize markdown formatting across usage.md files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Changed
-- Normalize markdown formatting across usage.md files
+- [PATCH] **All components:** Normalize markdown formatting across usage.md files.
 
 ## 3.2.0 - 2016-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 
-### Added
-- 
-
 ### Changed
-- 
-
-### Removed
-- 
+- Normalize markdown formatting across usage.md files
 
 ## 3.2.0 - 2016-02-26
 

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -2,228 +2,228 @@
 
 ### Default state
 
-  <a href="#" class="btn" title="Test button">Anchor Tag</a>
-  <button class="btn" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn">
-
-````
 <a href="#" class="btn" title="Test button">Anchor Tag</a>
 <button class="btn" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn">
-````
+
+```
+<a href="#" class="btn" title="Test button">Anchor Tag</a>
+<button class="btn" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn">
+```
 
 ### Hovered state
 
-  <a href="#" class="btn hover" title="Test button">Anchor Tag</a>
-  <button class="btn hover" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn hover">
-
-````
 <a href="#" class="btn hover" title="Test button">Anchor Tag</a>
 <button class="btn hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn hover">
-````
+
+```
+<a href="#" class="btn hover" title="Test button">Anchor Tag</a>
+<button class="btn hover" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn hover">
+```
 
 ### Focused state
 
-  <a href="#" class="btn focus" title="Test button">Anchor Tag</a>
-  <button class="btn focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn focus">
-
-````
 <a href="#" class="btn focus" title="Test button">Anchor Tag</a>
 <button class="btn focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn focus">
-````
+
+```
+<a href="#" class="btn focus" title="Test button">Anchor Tag</a>
+<button class="btn focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn focus">
+```
 
 ### Active state
 
-  <a href="#" class="btn active" title="Test button">Anchor Tag</a>
-  <button class="btn active" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn active">
-
-````
 <a href="#" class="btn active" title="Test button">Anchor Tag</a>
 <button class="btn active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn active">
-````
+
+```
+<a href="#" class="btn active" title="Test button">Anchor Tag</a>
+<button class="btn active" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn active">
+```
 
 ## Secondary button
 
 ### Default state
 
-  <a href="#" class="btn btn__secondary">Anchor Tag</a>
-  <button class="btn btn__secondary" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__secondary">
-
-````
 <a href="#" class="btn btn__secondary">Anchor Tag</a>
 <button class="btn btn__secondary" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary">
-````
+
+```
+<a href="#" class="btn btn__secondary">Anchor Tag</a>
+<button class="btn btn__secondary" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__secondary">
+```
 
 ### Hovered state
 
-  <a href="#" class="btn btn__secondary hover">Anchor Tag</a>
-  <button class="btn btn__secondary hover" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__secondary hover">
-
-````
 <a href="#" class="btn btn__secondary hover">Anchor Tag</a>
 <button class="btn btn__secondary hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary hover">
-````
+
+```
+<a href="#" class="btn btn__secondary hover">Anchor Tag</a>
+<button class="btn btn__secondary hover" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__secondary hover">
+```
 
 ### Focused state
 
-  <a href="#" class="btn btn__secondary focus">Anchor Tag</a>
-  <button class="btn btn__secondary focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__secondary focus">
-
-````
 <a href="#" class="btn btn__secondary focus">Anchor Tag</a>
 <button class="btn btn__secondary focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary focus">
-````
+
+```
+<a href="#" class="btn btn__secondary focus">Anchor Tag</a>
+<button class="btn btn__secondary focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__secondary focus">
+```
 
 ### Active state
 
-  <a href="#" class="btn btn__secondary active">Anchor Tag</a>
-  <button class="btn btn__secondary active" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__secondary active">
-
-````
 <a href="#" class="btn btn__secondary active">Anchor Tag</a>
 <button class="btn btn__secondary active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary active">
-````
+
+```
+<a href="#" class="btn btn__secondary active">Anchor Tag</a>
+<button class="btn btn__secondary active" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__secondary active">
+```
 
 ## Destructive action button
 
 ### Default state
 
-  <a href="#" class="btn btn__warning">Anchor Tag</a>
-  <button class="btn btn__warning" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__warning">
-
-````
 <a href="#" class="btn btn__warning">Anchor Tag</a>
 <button class="btn btn__warning" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning">
-````
+
+```
+<a href="#" class="btn btn__warning">Anchor Tag</a>
+<button class="btn btn__warning" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__warning">
+```
 
 ### Hovered state
 
-  <a href="#" class="btn btn__warning hover">Anchor Tag</a>
-  <button class="btn btn__warning hover" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__warning hover">
-
-````
 <a href="#" class="btn btn__warning hover">Anchor Tag</a>
 <button class="btn btn__warning hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning hover">
-````
+
+```
+<a href="#" class="btn btn__warning hover">Anchor Tag</a>
+<button class="btn btn__warning hover" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__warning hover">
+```
 
 ### Focused state
 
-  <a href="#" class="btn btn__warning focus">Anchor Tag</a>
-  <button class="btn btn__warning focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__warning focus">
-
-````
 <a href="#" class="btn btn__warning focus">Anchor Tag</a>
 <button class="btn btn__warning focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning focus">
-````
+
+```
+<a href="#" class="btn btn__warning focus">Anchor Tag</a>
+<button class="btn btn__warning focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__warning focus">
+```
 
 ### Active state
 
-  <a href="#" class="btn btn__warning active">Anchor Tag</a>
-  <button class="btn btn__warning active" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__warning active">
-
-````
 <a href="#" class="btn btn__warning active">Anchor Tag</a>
 <button class="btn btn__warning active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning active">
-````
+
+```
+<a href="#" class="btn btn__warning active">Anchor Tag</a>
+<button class="btn btn__warning active" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__warning active">
+```
 
 ## Disabled button
 
 ### Default/hovered/active state
 
-  <a href="#" class="btn btn__disabled">Anchor Tag</a>
-  <button class="btn btn__disabled" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__disabled">
-  <button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
-
-````
 <a href="#" class="btn btn__disabled">Anchor Tag</a>
 <button class="btn btn__disabled" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__disabled">
 <button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
-````
+
+```
+<a href="#" class="btn btn__disabled">Anchor Tag</a>
+<button class="btn btn__disabled" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__disabled">
+<button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
+```
 
 ### Focused state
 
-  <a href="#" class="btn btn__disabled focus">Anchor Tag</a>
-  <button class="btn btn__disabled focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__disabled focus">
-  <button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
-
-````
 <a href="#" class="btn btn__disabled focus">Anchor Tag</a>
 <button class="btn btn__disabled focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__disabled focus">
 <button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
-````
+
+```
+<a href="#" class="btn btn__disabled focus">Anchor Tag</a>
+<button class="btn btn__disabled focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__disabled focus">
+<button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
+```
 
 ## Super button
 
 ### Default state
 
-  <a href="#" class="btn btn__super">Anchor Tag</a>
-  <button class="btn btn__super" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__super">
-
-````
 <a href="#" class="btn btn__super">Anchor Tag</a>
 <button class="btn btn__super" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super">
-````
+
+```
+<a href="#" class="btn btn__super">Anchor Tag</a>
+<button class="btn btn__super" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__super">
+```
 
 ### Hovered state
 
-  <a href="#" class="btn btn__super hover">Anchor Tag</a>
-  <button class="btn btn__super hover" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__super hover">
-
-````
 <a href="#" class="btn btn__super hover">Anchor Tag</a>
 <button class="btn btn__super hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super hover">
-````
+
+```
+<a href="#" class="btn btn__super hover">Anchor Tag</a>
+<button class="btn btn__super hover" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__super hover">
+```
 
 ### Focused state
 
-  <a href="#" class="btn btn__super focus">Anchor Tag</a>
-  <button class="btn btn__super focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__super focus">
-
-````
 <a href="#" class="btn btn__super focus">Anchor Tag</a>
 <button class="btn btn__super focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super focus">
-````
+
+```
+<a href="#" class="btn btn__super focus">Anchor Tag</a>
+<button class="btn btn__super focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__super focus">
+```
 
 ### Active state
 
-  <a href="#" class="btn btn__super active">Anchor Tag</a>
-  <button class="btn btn__super active" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__super active">
-
-````
 <a href="#" class="btn btn__super active">Anchor Tag</a>
 <button class="btn btn__super active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super active">
-````
+
+```
+<a href="#" class="btn btn__super active">Anchor Tag</a>
+<button class="btn btn__super active" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__super active">
+```

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -2,32 +2,32 @@
 
 ### Default body type
 
-  <p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-
-````
 <p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-````
+
+```
+<p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+```
 
 
 ## Margins
 
 ### Consistent vertical margins
 
-  <p>Paragraph margin example</p>
-  <p>Paragraph margin example</p>
+<p>Paragraph margin example</p>
+<p>Paragraph margin example</p>
 
-````
+```
 <p>Paragraph margin example</p>
 <p>Paragraph margin example</p>
-````
+```
 
 
 ## Default link
 
 ### Default state
 
-  <a href="#">Default link style</a>
-
-````
 <a href="#">Default link style</a>
-````
+
+```
+<a href="#">Default link style</a>
+```

--- a/src/cf-expandables/usage.md
+++ b/src/cf-expandables/usage.md
@@ -2,34 +2,6 @@
 
 ### Default state
 
-  <div class="expandable expandable__padded">
-      <button class="expandable_header expandable_target" title="Expand content">
-          <span class="expandable_header-left expandable_label">
-              Expandable Header
-          </span>
-          <span class="expandable_header-right expandable_link">
-              <span class="expandable_cue-open">
-                  Show
-                  <span class="cf-icon cf-icon-plus-round"></span>
-              </span>
-              <span class="expandable_cue-close">
-                  Hide
-                  <span class="cf-icon cf-icon-minus-round"></span>
-              </span>
-          </span>
-      </button>
-      <div class="expandable_content">
-          <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing
-              elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-              temporibus magnam debitis quidem. Ducimus ratione
-              corporis nesciunt earum vel est quaerat blanditiis
-              dolore ipsa?
-          </p>
-      </div>
-  </div>
-
-````
 <div class="expandable expandable__padded">
     <button class="expandable_header expandable_target" title="Expand content">
         <span class="expandable_header-left expandable_label">
@@ -56,31 +28,38 @@
         </p>
     </div>
 </div>
-````
+
+```
+<div class="expandable expandable__padded">
+    <button class="expandable_header expandable_target" title="Expand content">
+        <span class="expandable_header-left expandable_label">
+            Expandable Header
+        </span>
+        <span class="expandable_header-right expandable_link">
+            <span class="expandable_cue-open">
+                Show
+                <span class="cf-icon cf-icon-plus-round"></span>
+            </span>
+            <span class="expandable_cue-close">
+                Hide
+                <span class="cf-icon cf-icon-minus-round"></span>
+            </span>
+        </span>
+    </button>
+    <div class="expandable_content">
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing
+            elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+            temporibus magnam debitis quidem. Ducimus ratione
+            corporis nesciunt earum vel est quaerat blanditiis
+            dolore ipsa?
+        </p>
+    </div>
+</div>
+```
 
 ### Barebones expandable
 
-  <div class="expandable">
-      <button class="expandable_target" title="Expand content">
-          <span class="expandable_cue-open">
-              Show
-          </span>
-          <span class="expandable_cue-close">
-              Hide
-          </span>
-      </button>
-      <div class="expandable_content">
-          <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing
-              elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-              temporibus magnam debitis quidem. Ducimus ratione
-              corporis nesciunt earum vel est quaerat blanditiis
-              dolore ipsa?
-          </p>
-      </div>
-  </div>
-
-````
 <div class="expandable">
     <button class="expandable_target" title="Expand content">
         <span class="expandable_cue-open">
@@ -100,50 +79,31 @@
         </p>
     </div>
 </div>
-````
+
+```
+<div class="expandable">
+    <button class="expandable_target" title="Expand content">
+        <span class="expandable_cue-open">
+            Show
+        </span>
+        <span class="expandable_cue-close">
+            Hide
+        </span>
+    </button>
+    <div class="expandable_content">
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing
+            elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+            temporibus magnam debitis quidem. Ducimus ratione
+            corporis nesciunt earum vel est quaerat blanditiis
+            dolore ipsa?
+        </p>
+    </div>
+</div>
+```
 
 ### Animated cues
 
-  <div class="expandable">
-      <button class="expandable_target" title="Expand content">
-          <span class="expandable_cue-open expandable_cue-open__animated">
-              <span class="cf-icon cf-icon-down"></span>
-          </span>
-          <span class="expandable_cue-close expandable_cue-close__animated">
-              <span class="cf-icon cf-icon-up"></span>
-          </span>
-      </button>
-      <div class="expandable_content">
-          <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing
-              elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-              temporibus magnam debitis quidem. Ducimus ratione
-              corporis nesciunt earum vel est quaerat blanditiis
-              dolore ipsa?
-          </p>
-      </div>
-  </div>
-  <div class="expandable expandable__expanded">
-      <button class="expandable_target" title="Expand content">
-          <span class="expandable_cue-open expandable_cue-open__animated">
-              <span class="cf-icon cf-icon-down"></span>
-          </span>
-          <span class="expandable_cue-close expandable_cue-close__animated">
-              <span class="cf-icon cf-icon-up"></span>
-          </span>
-      </button>
-      <div class="expandable_content">
-          <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing
-              elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-              temporibus magnam debitis quidem. Ducimus ratione
-              corporis nesciunt earum vel est quaerat blanditiis
-              dolore ipsa?
-          </p>
-      </div>
-  </div>
-
-````
 <div class="expandable">
     <button class="expandable_target" title="Expand content">
         <span class="expandable_cue-open expandable_cue-open__animated">
@@ -182,93 +142,50 @@
         </p>
     </div>
 </div>
-````
+
+```
+<div class="expandable">
+    <button class="expandable_target" title="Expand content">
+        <span class="expandable_cue-open expandable_cue-open__animated">
+            <span class="cf-icon cf-icon-down"></span>
+        </span>
+        <span class="expandable_cue-close expandable_cue-close__animated">
+            <span class="cf-icon cf-icon-up"></span>
+        </span>
+    </button>
+    <div class="expandable_content">
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing
+            elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+            temporibus magnam debitis quidem. Ducimus ratione
+            corporis nesciunt earum vel est quaerat blanditiis
+            dolore ipsa?
+        </p>
+    </div>
+</div>
+<div class="expandable expandable__expanded">
+    <button class="expandable_target" title="Expand content">
+        <span class="expandable_cue-open expandable_cue-open__animated">
+            <span class="cf-icon cf-icon-down"></span>
+        </span>
+        <span class="expandable_cue-close expandable_cue-close__animated">
+            <span class="cf-icon cf-icon-up"></span>
+        </span>
+    </button>
+    <div class="expandable_content">
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing
+            elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+            temporibus magnam debitis quidem. Ducimus ratione
+            corporis nesciunt earum vel est quaerat blanditiis
+            dolore ipsa?
+        </p>
+    </div>
+</div>
+```
 
 ### Expandable groups
 
-  <div class="expandable-group">
-      <div class="expandable-group_header">Expandable group header</div>
-      <div class="expandable expandable__padded">
-          <button class="expandable_header expandable_target" title="Expand content">
-              <span class="expandable_header-left expandable_label">
-                  Expandable Header 1
-              </span>
-              <span class="expandable_header-right expandable_link">
-                  <span class="expandable_cue-open">
-                      Show
-                      <span class="cf-icon cf-icon-plus-round"></span>
-                  </span>
-                  <span class="expandable_cue-close">
-                      Hide
-                      <span class="cf-icon cf-icon-minus-round"></span>
-                  </span>
-              </span>
-          </button>
-          <div class="expandable_content">
-              <p>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing
-                  elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                  temporibus magnam debitis quidem. Ducimus ratione
-                  corporis nesciunt earum vel est quaerat blanditiis
-                  dolore ipsa?
-              </p>
-          </div>
-      </div>
-      <div class="expandable expandable__padded">
-          <button class="expandable_header expandable_target" title="Expand content">
-              <span class="expandable_header-left expandable_label">
-                  Expandable Header 2
-              </span>
-              <span class="expandable_header-right expandable_link">
-                  <span class="expandable_cue-open">
-                      Show
-                      <span class="cf-icon cf-icon-plus-round"></span>
-                  </span>
-                  <span class="expandable_cue-close">
-                      Hide
-                      <span class="cf-icon cf-icon-minus-round"></span>
-                  </span>
-              </span>
-          </button>
-          <div class="expandable_content">
-              <p>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing
-                  elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                  temporibus magnam debitis quidem. Ducimus ratione
-                  corporis nesciunt earum vel est quaerat blanditiis
-                  dolore ipsa?
-              </p>
-          </div>
-      </div>
-      <div class="expandable expandable__padded">
-          <button class="expandable_header expandable_target" title="Expand content">
-              <span class="expandable_header-left expandable_label">
-                  Expandable Header 3
-              </span>
-              <span class="expandable_header-right expandable_link">
-                  <span class="expandable_cue-open">
-                      Show
-                      <span class="cf-icon cf-icon-plus-round"></span>
-                  </span>
-                  <span class="expandable_cue-close">
-                      Hide
-                      <span class="cf-icon cf-icon-minus-round"></span>
-                  </span>
-              </span>
-          </button>
-          <div class="expandable_content">
-              <p>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing
-                  elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                  temporibus magnam debitis quidem. Ducimus ratione
-                  corporis nesciunt earum vel est quaerat blanditiis
-                  dolore ipsa?
-              </p>
-          </div>
-      </div>
-  </div>
-
-````
 <div class="expandable-group">
     <div class="expandable-group_header">Expandable group header</div>
     <div class="expandable expandable__padded">
@@ -350,93 +267,93 @@
         </div>
     </div>
 </div>
-````
+
+```
+<div class="expandable-group">
+    <div class="expandable-group_header">Expandable group header</div>
+    <div class="expandable expandable__padded">
+        <button class="expandable_header expandable_target" title="Expand content">
+            <span class="expandable_header-left expandable_label">
+                Expandable Header 1
+            </span>
+            <span class="expandable_header-right expandable_link">
+                <span class="expandable_cue-open">
+                    Show
+                    <span class="cf-icon cf-icon-plus-round"></span>
+                </span>
+                <span class="expandable_cue-close">
+                    Hide
+                    <span class="cf-icon cf-icon-minus-round"></span>
+                </span>
+            </span>
+        </button>
+        <div class="expandable_content">
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing
+                elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+                temporibus magnam debitis quidem. Ducimus ratione
+                corporis nesciunt earum vel est quaerat blanditiis
+                dolore ipsa?
+            </p>
+        </div>
+    </div>
+    <div class="expandable expandable__padded">
+        <button class="expandable_header expandable_target" title="Expand content">
+            <span class="expandable_header-left expandable_label">
+                Expandable Header 2
+            </span>
+            <span class="expandable_header-right expandable_link">
+                <span class="expandable_cue-open">
+                    Show
+                    <span class="cf-icon cf-icon-plus-round"></span>
+                </span>
+                <span class="expandable_cue-close">
+                    Hide
+                    <span class="cf-icon cf-icon-minus-round"></span>
+                </span>
+            </span>
+        </button>
+        <div class="expandable_content">
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing
+                elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+                temporibus magnam debitis quidem. Ducimus ratione
+                corporis nesciunt earum vel est quaerat blanditiis
+                dolore ipsa?
+            </p>
+        </div>
+    </div>
+    <div class="expandable expandable__padded">
+        <button class="expandable_header expandable_target" title="Expand content">
+            <span class="expandable_header-left expandable_label">
+                Expandable Header 3
+            </span>
+            <span class="expandable_header-right expandable_link">
+                <span class="expandable_cue-open">
+                    Show
+                    <span class="cf-icon cf-icon-plus-round"></span>
+                </span>
+                <span class="expandable_cue-close">
+                    Hide
+                    <span class="cf-icon cf-icon-minus-round"></span>
+                </span>
+            </span>
+        </button>
+        <div class="expandable_content">
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing
+                elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+                temporibus magnam debitis quidem. Ducimus ratione
+                corporis nesciunt earum vel est quaerat blanditiis
+                dolore ipsa?
+            </p>
+        </div>
+    </div>
+</div>
+```
 
 ### Accordion-style group
 
-  <div class="expandable-group" data-accordion="true">
-      <div class="expandable-group_header">Expandable group header</div>
-      <div class="expandable expandable__padded">
-          <button class="expandable_header expandable_target" title="Expand content">
-              <span class="expandable_header-left expandable_label">
-                  Expandable Header 1
-              </span>
-              <span class="expandable_header-right expandable_link">
-                  <span class="expandable_cue-open">
-                      Show
-                      <span class="cf-icon cf-icon-plus-round"></span>
-                  </span>
-                  <span class="expandable_cue-close">
-                      Hide
-                      <span class="cf-icon cf-icon-minus-round"></span>
-                  </span>
-              </span>
-          </button>
-          <div class="expandable_content">
-              <p>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing
-                  elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                  temporibus magnam debitis quidem. Ducimus ratione
-                  corporis nesciunt earum vel est quaerat blanditiis
-                  dolore ipsa?
-              </p>
-          </div>
-      </div>
-      <div class="expandable expandable__padded">
-          <button class="expandable_header expandable_target" title="Expand content">
-              <span class="expandable_header-left expandable_label">
-                  Expandable Header 2
-              </span>
-              <span class="expandable_header-right expandable_link">
-                  <span class="expandable_cue-open">
-                      Show
-                      <span class="cf-icon cf-icon-plus-round"></span>
-                  </span>
-                  <span class="expandable_cue-close">
-                      Hide
-                      <span class="cf-icon cf-icon-minus-round"></span>
-                  </span>
-              </span>
-          </button>
-          <div class="expandable_content">
-              <p>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing
-                  elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                  temporibus magnam debitis quidem. Ducimus ratione
-                  corporis nesciunt earum vel est quaerat blanditiis
-                  dolore ipsa?
-              </p>
-          </div>
-      </div>
-      <div class="expandable expandable__padded">
-          <button class="expandable_header expandable_target" title="Expand content">
-              <span class="expandable_header-left expandable_label">
-                  Expandable Header 3
-              </span>
-              <span class="expandable_header-right expandable_link">
-                  <span class="expandable_cue-open">
-                      Show
-                      <span class="cf-icon cf-icon-plus-round"></span>
-                  </span>
-                  <span class="expandable_cue-close">
-                      Hide
-                      <span class="cf-icon cf-icon-minus-round"></span>
-                  </span>
-              </span>
-          </button>
-          <div class="expandable_content">
-              <p>
-                  Lorem ipsum dolor sit amet, consectetur adipisicing
-                  elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                  temporibus magnam debitis quidem. Ducimus ratione
-                  corporis nesciunt earum vel est quaerat blanditiis
-                  dolore ipsa?
-              </p>
-          </div>
-      </div>
-  </div>
-
-````
 <div class="expandable-group" data-accordion="true">
     <div class="expandable-group_header">Expandable group header</div>
     <div class="expandable expandable__padded">
@@ -518,4 +435,87 @@
         </div>
     </div>
 </div>
-````
+
+```
+<div class="expandable-group" data-accordion="true">
+    <div class="expandable-group_header">Expandable group header</div>
+    <div class="expandable expandable__padded">
+        <button class="expandable_header expandable_target" title="Expand content">
+            <span class="expandable_header-left expandable_label">
+                Expandable Header 1
+            </span>
+            <span class="expandable_header-right expandable_link">
+                <span class="expandable_cue-open">
+                    Show
+                    <span class="cf-icon cf-icon-plus-round"></span>
+                </span>
+                <span class="expandable_cue-close">
+                    Hide
+                    <span class="cf-icon cf-icon-minus-round"></span>
+                </span>
+            </span>
+        </button>
+        <div class="expandable_content">
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing
+                elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+                temporibus magnam debitis quidem. Ducimus ratione
+                corporis nesciunt earum vel est quaerat blanditiis
+                dolore ipsa?
+            </p>
+        </div>
+    </div>
+    <div class="expandable expandable__padded">
+        <button class="expandable_header expandable_target" title="Expand content">
+            <span class="expandable_header-left expandable_label">
+                Expandable Header 2
+            </span>
+            <span class="expandable_header-right expandable_link">
+                <span class="expandable_cue-open">
+                    Show
+                    <span class="cf-icon cf-icon-plus-round"></span>
+                </span>
+                <span class="expandable_cue-close">
+                    Hide
+                    <span class="cf-icon cf-icon-minus-round"></span>
+                </span>
+            </span>
+        </button>
+        <div class="expandable_content">
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing
+                elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+                temporibus magnam debitis quidem. Ducimus ratione
+                corporis nesciunt earum vel est quaerat blanditiis
+                dolore ipsa?
+            </p>
+        </div>
+    </div>
+    <div class="expandable expandable__padded">
+        <button class="expandable_header expandable_target" title="Expand content">
+            <span class="expandable_header-left expandable_label">
+                Expandable Header 3
+            </span>
+            <span class="expandable_header-right expandable_link">
+                <span class="expandable_cue-open">
+                    Show
+                    <span class="cf-icon cf-icon-plus-round"></span>
+                </span>
+                <span class="expandable_cue-close">
+                    Hide
+                    <span class="cf-icon cf-icon-minus-round"></span>
+                </span>
+            </span>
+        </button>
+        <div class="expandable_content">
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipisicing
+                elit. Neque ipsa voluptatibus soluta nobis unde quisquam
+                temporibus magnam debitis quidem. Ducimus ratione
+                corporis nesciunt earum vel est quaerat blanditiis
+                dolore ipsa?
+            </p>
+        </div>
+    </div>
+</div>
+```

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -2,132 +2,132 @@
 
 ### Label header
 
-  <label class="form-label-header">
-      Form label header
-  </label>
-
-````
 <label class="form-label-header">
     Form label header
 </label>
-````
+
+```
+<label class="form-label-header">
+    Form label header
+</label>
+```
 
 ### Super input
 
-  <input class="input__super" type="text" value="Super input" title="Test input"></input>
-  <button class="btn btn__super">Super</button>
-
-````
 <input class="input__super" type="text" value="Super input" title="Test input"></input>
 <button class="btn btn__super">Super</button>
-````
+
+```
+<input class="input__super" type="text" value="Super input" title="Test input"></input>
+<button class="btn btn__super">Super</button>
+```
 
 ## Input states
 
 ### Error state
 
-  <input class="error" type="text" value="Invalid input" title="Test input">
-
-````
 <input class="error" type="text" value="Invalid input" title="Test input">
-````
+
+```
+<input class="error" type="text" value="Invalid input" title="Test input">
+```
 
 ### Warning state
 
-  <input class="warning" type="text" value="Invalid input" title="Test input">
-
-````
 <input class="warning" type="text" value="Invalid input" title="Test input">
-````
+
+```
+<input class="warning" type="text" value="Invalid input" title="Test input">
+```
 
 ### Success state
 
-  <input class="success" type="text" value="Validated input" title="Test input">
-
-````
 <input class="success" type="text" value="Validated input" title="Test input">
-````
+
+```
+<input class="success" type="text" value="Validated input" title="Test input">
+```
 
 ### Disabled state
 
-  <input class="disabled" disabled="true" autocomplete="off" type="text" value="Validated input" title="Test input">
-
-````
 <input class="disabled" disabled="true" autocomplete="off" type="text" value="Validated input" title="Test input">
-````
+
+```
+<input class="disabled" disabled="true" autocomplete="off" type="text" value="Validated input" title="Test input">
+```
 
 ## Form icons
 
 ### Form input icons
 
-  <input type="text" value="" title="Test input">
-  <span class="cf-form_input-icon cf-icon cf-icon-email"></span>
-
-````
 <input type="text" value="" title="Test input">
 <span class="cf-form_input-icon cf-icon cf-icon-email"></span>
-````
+
+```
+<input type="text" value="" title="Test input">
+<span class="cf-form_input-icon cf-icon cf-icon-email"></span>
+```
 
 ### Form input error icon
 
-  <input class="error" type="text" value="Invalid input" title="Test input">
-  <span class="cf-form_input-icon cf-icon cf-icon-delete-round" role="alert"></span>
-
-````
 <input class="error" type="text" value="Invalid input" title="Test input">
 <span class="cf-form_input-icon cf-icon cf-icon-delete-round" role="alert"></span>
-````
+
+```
+<input class="error" type="text" value="Invalid input" title="Test input">
+<span class="cf-form_input-icon cf-icon cf-icon-delete-round" role="alert"></span>
+```
 
 ### Form input warning icon
 
-  <input class="warning" type="text" value="Invalid input" title="Test input">
-  <span class="cf-form_input-icon cf-icon cf-icon-error-round" role="alert"></span>
-
-````
 <input class="warning" type="text" value="Invalid input" title="Test input">
 <span class="cf-form_input-icon cf-icon cf-icon-error-round" role="alert"></span>
-````
+
+```
+<input class="warning" type="text" value="Invalid input" title="Test input">
+<span class="cf-form_input-icon cf-icon cf-icon-error-round" role="alert"></span>
+```
 
 ### Form input success icon
 
-  <input class="success" type="text" value="Validated input" title="Test input">
-  <span class="cf-form_input-icon cf-icon cf-icon-approved-round"></span>
-
-````
 <input class="success" type="text" value="Validated input" title="Test input">
 <span class="cf-form_input-icon cf-icon cf-icon-approved-round"></span>
-````
+
+```
+<input class="success" type="text" value="Validated input" title="Test input">
+<span class="cf-form_input-icon cf-icon cf-icon-approved-round"></span>
+```
 
 ## Form group
 
 ### Form group block
 
-  <div class="form-group">
-      <div class="form-group_item">
-          <input type="text" title="Test input">
-      </div>
-      <div class="form-group_item">
-          <input type="text" title="Test input">
-      </div>
-  </div>
-  <div class="form-group">
-      <div class="form-group_item">
-          <input type="text" title="Test input">
-      </div>
-      <div class="form-group_item">
-          <input type="text" title="Test input">
-      </div>
-  </div>
-  <div class="form-group">
-      <div class="form-group_item">
-          <input type="text" title="Test input">
-      </div>
-      <div class="form-group_item">
-          <input type="text" title="Test input">
-      </div>
-  </div>
+<div class="form-group">
+    <div class="form-group_item">
+        <input type="text" title="Test input">
+    </div>
+    <div class="form-group_item">
+        <input type="text" title="Test input">
+    </div>
+</div>
+<div class="form-group">
+    <div class="form-group_item">
+        <input type="text" title="Test input">
+    </div>
+    <div class="form-group_item">
+        <input type="text" title="Test input">
+    </div>
+</div>
+<div class="form-group">
+    <div class="form-group_item">
+        <input type="text" title="Test input">
+    </div>
+    <div class="form-group_item">
+        <input type="text" title="Test input">
+    </div>
+</div>
 
-````
+```
 <div class="form-group">
     <div class="form-group_item">
         <input type="text" title="Test input">
@@ -152,30 +152,30 @@
         <input type="text" title="Test input">
     </div>
 </div>
-````
+```
 
 ### Real world example
 
-  <div class="form-group">
-      <label class="form-label-header">Form group</label>
-      <div class="form-group_item">
-          <input type="text" value="Form group item" title="Test input">
-      </div>
-      <div class="form-group_item">
-          <input type="text" value="Form group item" title="Test input">
-      </div>
-  </div>
-  <div class="form-group">
-      <label class="form-label-header">Form group</label>
-      <div class="form-group_item">
-          <input type="text" value="Form group item" title="Test input">
-      </div>
-      <div class="form-group_item">
-          <input type="text" value="Form group item" title="Test input">
-      </div>
-  </div>
+<div class="form-group">
+    <label class="form-label-header">Form group</label>
+    <div class="form-group_item">
+        <input type="text" value="Form group item" title="Test input">
+    </div>
+    <div class="form-group_item">
+        <input type="text" value="Form group item" title="Test input">
+    </div>
+</div>
+<div class="form-group">
+    <label class="form-label-header">Form group</label>
+    <div class="form-group_item">
+        <input type="text" value="Form group item" title="Test input">
+    </div>
+    <div class="form-group_item">
+        <input type="text" value="Form group item" title="Test input">
+    </div>
+</div>
 
-````
+```
 <div class="form-group">
     <label class="form-label-header">Form group</label>
     <div class="form-group_item">
@@ -194,22 +194,12 @@
         <input type="text" value="Form group item" title="Test input">
     </div>
 </div>
-````
+```
 
 ## Input with button
 
 ### Default input and button
 
-  <div class="input-with-btn">
-      <div class="input-with-btn_input">
-          <input type="text" title="Test input">
-      </div>
-      <div class="input-with-btn_btn">
-          <button class="btn">Search</button>
-      </div>
-  </div>
-
-````
 <div class="input-with-btn">
     <div class="input-with-btn_input">
         <input type="text" title="Test input">
@@ -218,20 +208,20 @@
         <button class="btn">Search</button>
     </div>
 </div>
-````
+
+```
+<div class="input-with-btn">
+    <div class="input-with-btn_input">
+        <input type="text" title="Test input">
+    </div>
+    <div class="input-with-btn_btn">
+        <button class="btn">Search</button>
+    </div>
+</div>
+```
 
 ### Super input and button
 
-  <div class="input-with-btn">
-      <div class="input-with-btn_input">
-          <input class="input__super" type="text" title="Test input">
-      </div>
-      <div class="input-with-btn_btn">
-          <button class="btn btn__super">Search</button>
-      </div>
-  </div>
-
-````
 <div class="input-with-btn">
     <div class="input-with-btn_input">
         <input class="input__super" type="text" title="Test input">
@@ -240,22 +230,22 @@
         <button class="btn btn__super">Search</button>
     </div>
 </div>
-````
+
+```
+<div class="input-with-btn">
+    <div class="input-with-btn_input">
+        <input class="input__super" type="text" title="Test input">
+    </div>
+    <div class="input-with-btn_btn">
+        <button class="btn btn__super">Search</button>
+    </div>
+</div>
+```
 
 ## Button inside input
 
 ### Default button inside of an default input
 
-  <div class="btn-inside-input">
-      <input type="text"
-             value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable." title="Test input">
-      <button class="btn btn__link btn__secondary">
-          Clear
-          <span class="cf-icon cf-icon-delete"></span>
-      </button>
-  </div>
-
-````
 <div class="btn-inside-input">
     <input type="text"
            value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable." title="Test input">
@@ -264,21 +254,20 @@
         <span class="cf-icon cf-icon-delete"></span>
     </button>
 </div>
-````
+
+```
+<div class="btn-inside-input">
+    <input type="text"
+           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable." title="Test input">
+    <button class="btn btn__link btn__secondary">
+        Clear
+        <span class="cf-icon cf-icon-delete"></span>
+    </button>
+</div>
+```
 
 ### Super button inside of a super input
 
-  <div class="btn-inside-input">
-      <input class="input__super"
-             type="text"
-             value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable." title="Test input">
-      <button class="btn btn__super btn__link btn__secondary">
-          Clear
-          <span class="cf-icon cf-icon-delete"></span>
-      </button>
-  </div>
-
-````
 <div class="btn-inside-input">
     <input class="input__super"
            type="text"
@@ -288,4 +277,15 @@
         <span class="cf-icon cf-icon-delete"></span>
     </button>
 </div>
-````
+
+```
+<div class="btn-inside-input">
+    <input class="input__super"
+           type="text"
+           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable." title="Test input">
+    <button class="btn btn__super btn__link btn__secondary">
+        Clear
+        <span class="cf-icon cf-icon-delete"></span>
+    </button>
+</div>
+```

--- a/src/cf-grid/usage.md
+++ b/src/cf-grid/usage.md
@@ -8,39 +8,39 @@ The following variables are exposed, allowing you to easily override them before
 @grid_box-sizing-polyfill-path: '../../box-sizing-polyfill;
 ```
 
-> The path where boxsizing.htc is located.
+The path where boxsizing.htc is located.
 
-> This path MUST be overridden in your project and set to a root relative url.
+This path MUST be overridden in your project and set to a root relative url.
 
 ```
 @grid_wrapper-width: 1200px;
 ```
 
-> The grid's maximum width in px.
+The grid's maximum width in px.
 
 ```
 @grid_gutter-width: 30px;
 ```
 
-> The fixed width between columns.
+The fixed width between columns.
 
 ```
 @grid_total-columns: 12;
 ```
 
-> The total number of columns used in calculating column widths.
+The total number of columns used in calculating column widths.
 
 ```
 @grid_debug
 ```
 
-> Gives column blocks a background color if set to true.
+Gives column blocks a background color if set to true.
 
 ## Wrapper
 
-> Wrappers are centered containers with a max-width and fixed gutters that match the gutter widths of columns.
+Wrappers are centered containers with a max-width and fixed gutters that match the gutter widths of columns.
 
-> To support IE 6/7, ensure that the path to boxsizing.htc is set using the @grid_box-sizing-polyfill-path Less variable. Read more: https://github.com/Schepp/box-sizing-polyfill.
+To support IE 6/7, ensure that the path to boxsizing.htc is set using the `@grid_box-sizing-polyfill-path` Less variable. Read more: https://github.com/Schepp/box-sizing-polyfill.
 
 ### Less mixin
 
@@ -48,7 +48,7 @@ The following variables are exposed, allowing you to easily override them before
 .grid_wrapper( @grid_wrapper-width: @grid_wrapper-width )
 ```
 
-> You can create wrappers with different max-widths by passing a pixel value into the mixin.
+You can create wrappers with different max-widths by passing a pixel value into the mixin.
 
 ### Usage
 
@@ -78,9 +78,9 @@ The following variables are exposed, allowing you to easily override them before
 .grid_column( @columns: 1; @total: @grid_total-columns; @prefix: 0; @suffix: 0 )
 ```
 
-> Computes column widths and prefix/suffix padding.
+Computes column widths and prefix/suffix padding.
 
-> CSS borders are used for fixed gutters.
+CSS borders are used for fixed gutters.
 
 ### Usage
 
@@ -134,11 +134,11 @@ The following variables are exposed, allowing you to easily override them before
 
 ## Nested columns
 
-> Since all cf-grid columns have left and right gutters you will notice undesireable offsetting when nesting columns. Normally this is removed with complex selectors or by adding classes to the first and last column per 'row'. In cf-grid the way to get around this is by wrapping your columns in a container that utilizes the .grid_nested-col-group() mixin. This mixin uses negative left and right margins to pull the columns back into alignment with parent columns.
+Since all cf-grid columns have left and right gutters you will notice undesirable offsetting when nesting columns. Normally this is removed with complex selectors or by adding classes to the first and last column per 'row'. In cf-grid the way to get around this is by wrapping your columns in a container that utilizes the .grid_nested-col-group() mixin. This mixin uses negative left and right margins to pull the columns back into alignment with parent columns.
 
-> NOTE: Working this way allows you to easily create responsive grids. You are free to control the number of columns per 'row' without having to deal with the first and last columns of each row.
+**NOTE:** Working this way allows you to easily create responsive grids. You are free to control the number of columns per 'row' without having to deal with the first and last columns of each row.
 
-> NOTE: cf-grids does not use 'rows' and there is no row container. To clarify, if you have a 12 column grid and place 24 columns inside of a wrapper cf-grid columns will automaitcally stack into 2 'rows' of 12.
+**NOTE:** cf-grids does not use 'rows' and there is no row container. To clarify, if you have a 12 column grid and place 24 columns inside of a wrapper cf-grid columns will automatically stack into 2 'rows' of 12.
 
 ### Less mixin
 
@@ -182,65 +182,65 @@ The following variables are exposed, allowing you to easily override them before
 
 ### 12 columns w/ 1200px max width
 
-  <div class="cols-12">
+<div class="cols-12">
 
-      <section>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-          <div class="col col-1"><p>one</p></div>
-      </section>
+    <section>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><p>one</p></div>
+    </section>
 
-      <section>
-          <div class="col col-2"><p>two</p></div>
-          <div class="col col-2"><p>two</p></div>
-          <div class="col col-2"><p>two</p></div>
-          <div class="col col-2"><p>two</p></div>
-          <div class="col col-2"><p>two</p></div>
-          <div class="col col-2"><p>two</p></div>
-      </section>
+    <section>
+        <div class="col col-2"><p>two</p></div>
+        <div class="col col-2"><p>two</p></div>
+        <div class="col col-2"><p>two</p></div>
+        <div class="col col-2"><p>two</p></div>
+        <div class="col col-2"><p>two</p></div>
+        <div class="col col-2"><p>two</p></div>
+    </section>
 
-      <section>
-          <div class="col col-2"><p>two</p></div>
-          <div class="col col-3"><p>three</p></div>
-          <div class="col col-2"><p>two</p></div>
-          <div class="col col-3"><p>three</p></div>
-          <div class="col col-2"><p>two</p></div>
-      </section>
+    <section>
+        <div class="col col-2"><p>two</p></div>
+        <div class="col col-3"><p>three</p></div>
+        <div class="col col-2"><p>two</p></div>
+        <div class="col col-3"><p>three</p></div>
+        <div class="col col-2"><p>two</p></div>
+    </section>
 
-      <section>
-          <div class="col col-3"><p>three</p></div>
-          <div class="col col-3"><p>three</p></div>
-          <div class="col col-3"><p>three</p></div>
-          <div class="col col-3"><p>three</p></div>
-      </section>
+    <section>
+        <div class="col col-3"><p>three</p></div>
+        <div class="col col-3"><p>three</p></div>
+        <div class="col col-3"><p>three</p></div>
+        <div class="col col-3"><p>three</p></div>
+    </section>
 
-      <section>
-          <div class="col col-4"><p>four</p></div>
-          <div class="col col-4"><p>four</p></div>
-          <div class="col col-4"><p>four</p></div>
-      </section>
+    <section>
+        <div class="col col-4"><p>four</p></div>
+        <div class="col col-4"><p>four</p></div>
+        <div class="col col-4"><p>four</p></div>
+    </section>
 
-      <section>
-          <div class="col col-6"><p>six</p></div>
-          <div class="col col-6"><p>six</p></div>
-      </section>
+    <section>
+        <div class="col col-6"><p>six</p></div>
+        <div class="col col-6"><p>six</p></div>
+    </section>
 
-      <section>
-          <div class="col col-12"><p>twelve</p></div>
-      </section>
+    <section>
+        <div class="col col-12"><p>twelve</p></div>
+    </section>
 
-  </div>
+</div>
 
-````
+```
 <div class="cols-12">
 
     <section>
@@ -476,4 +476,4 @@ The following variables are exposed, allowing you to easily override them before
     </section>
 
 </div>
-````
+```

--- a/src/cf-icons/usage.md
+++ b/src/cf-icons/usage.md
@@ -2,40 +2,40 @@
 
 ### Large icon size
 
-  <span class="cf-icon cf-icon-money cf-icon__lg"></span>
-
-````
 <span class="cf-icon cf-icon-money cf-icon__lg"></span>
-````
+
+```
+<span class="cf-icon cf-icon-money cf-icon__lg"></span>
+```
 
 ### 2x icon size
 
-  <span class="cf-icon cf-icon-money cf-icon__2x"></span>
-
-````
 <span class="cf-icon cf-icon-money cf-icon__2x"></span>
-````
+
+```
+<span class="cf-icon cf-icon-money cf-icon__2x"></span>
+```
 
 ### 3x icon size
 
-  <span class="cf-icon cf-icon-money cf-icon__3x"></span>
-
-````
 <span class="cf-icon cf-icon-money cf-icon__3x"></span>
-````
+
+```
+<span class="cf-icon cf-icon-money cf-icon__3x"></span>
+```
 
 ### 4x icon size
 
-  <span class="cf-icon cf-icon-money cf-icon__4x"></span>
-
-````
 <span class="cf-icon cf-icon-money cf-icon__4x"></span>
-````
+
+```
+<span class="cf-icon cf-icon-money cf-icon__4x"></span>
+```
 
 ### 5x icon size
 
-  <span class="cf-icon cf-icon-money cf-icon__5x"></span>
-
-````
 <span class="cf-icon cf-icon-money cf-icon__5x"></span>
-````
+
+```
+<span class="cf-icon cf-icon-money cf-icon__5x"></span>
+```

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -2,88 +2,6 @@
 
 ### Standard content columns
 
-  <div class="content-l">
-      <div class="content-l_col content-l_col-1">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Full-width column (spans 12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-1-2">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Half-width column (spans 6/12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-1-2">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Half-width column (spans 6/12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-1-3">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Third-width column (spans 4/12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-1-3">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Third-width column (spans 4/12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-1-3">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Third-width column (spans 4/12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-2-3">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Two thirds-width column (spans 8/12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-1-3">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Third-width column (spans 4/12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-1-4">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;">
-              Quarter width column (spans 3/12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-3-4">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;">
-              Three-quarter width column (spans 9/12 columns)
-          </div>
-      </div>
-  </div>
-
-````
 <div class="content-l">
     <div class="content-l_col content-l_col-1">
         <div style="background: #F1F2F2;
@@ -164,40 +82,92 @@
         </div>
     </div>
 </div>
-````
+
+```
+<div class="content-l">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-2-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Two thirds-width column (spans 8/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Quarter width column (spans 3/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-3-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Three-quarter width column (spans 9/12 columns)
+        </div>
+    </div>
+</div>
+```
 
 ### Large gutters modifier
 
-  <div class="content-l content-l__main  content-l__large-gutters">
-      <div class="content-l_col content-l_col-1">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Full-width column (spans 12 columns)
-          </div>
-      </div>
-  </div>
-  <div class="content-l content-l__main  content-l__large-gutters">
-      <div class="content-l_col content-l_col-1-2">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Half-width column (spans 6/12 columns)
-          </div>
-      </div>
-      <div class="content-l_col content-l_col-1-2">
-          <div style="background: #F1F2F2;
-                      text-align: center;
-                      padding: 8px;
-                      margin-bottom: 4px;">
-              Half-width column (spans 6/12 columns)
-          </div>
-      </div>
-  </div>
-
-````
 <div class="content-l content-l__main  content-l__large-gutters">
     <div class="content-l_col content-l_col-1">
         <div style="background: #F1F2F2;
@@ -226,208 +196,238 @@
         </div>
     </div>
 </div>
-````
+
+```
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+</div>
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+</div>
+```
 
 ### Focused state
 
-  <a href="#" class="btn focus" title="Test button">Anchor Tag</a>
-  <button class="btn focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn focus">
-
-````
 <a href="#" class="btn focus" title="Test button">Anchor Tag</a>
 <button class="btn focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn focus">
-````
+
+```
+<a href="#" class="btn focus" title="Test button">Anchor Tag</a>
+<button class="btn focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn focus">
+```
 
 ### Active state
 
-  <a href="#" class="btn active" title="Test button">Anchor Tag</a>
-  <button class="btn active" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn active">
-
-````
 <a href="#" class="btn active" title="Test button">Anchor Tag</a>
 <button class="btn active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn active">
-````
+
+```
+<a href="#" class="btn active" title="Test button">Anchor Tag</a>
+<button class="btn active" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn active">
+```
 
 ## Secondary button
 
 ### Default state
 
-  <a href="#" class="btn btn__secondary">Anchor Tag</a>
-  <button class="btn btn__secondary" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__secondary">
-
-````
 <a href="#" class="btn btn__secondary">Anchor Tag</a>
 <button class="btn btn__secondary" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary">
-````
+
+```
+<a href="#" class="btn btn__secondary">Anchor Tag</a>
+<button class="btn btn__secondary" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__secondary">
+```
 
 ### Hovered state
 
-  <a href="#" class="btn btn__secondary hover">Anchor Tag</a>
-  <button class="btn btn__secondary hover" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__secondary hover">
-
-````
 <a href="#" class="btn btn__secondary hover">Anchor Tag</a>
 <button class="btn btn__secondary hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary hover">
-````
+
+```
+<a href="#" class="btn btn__secondary hover">Anchor Tag</a>
+<button class="btn btn__secondary hover" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__secondary hover">
+```
 
 ### Focused state
 
-  <a href="#" class="btn btn__secondary focus">Anchor Tag</a>
-  <button class="btn btn__secondary focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__secondary focus">
-
-````
 <a href="#" class="btn btn__secondary focus">Anchor Tag</a>
 <button class="btn btn__secondary focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary focus">
-````
+
+```
+<a href="#" class="btn btn__secondary focus">Anchor Tag</a>
+<button class="btn btn__secondary focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__secondary focus">
+```
 
 ### Active state
 
-  <a href="#" class="btn btn__secondary active">Anchor Tag</a>
-  <button class="btn btn__secondary active" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__secondary active">
-
-````
 <a href="#" class="btn btn__secondary active">Anchor Tag</a>
 <button class="btn btn__secondary active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__secondary active">
-````
+
+```
+<a href="#" class="btn btn__secondary active">Anchor Tag</a>
+<button class="btn btn__secondary active" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__secondary active">
+```
 
 ## Destructive action button
 
 ### Default state
 
-  <a href="#" class="btn btn__warning">Anchor Tag</a>
-  <button class="btn btn__warning" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__warning">
-
-````
 <a href="#" class="btn btn__warning">Anchor Tag</a>
 <button class="btn btn__warning" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning">
-````
+
+```
+<a href="#" class="btn btn__warning">Anchor Tag</a>
+<button class="btn btn__warning" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__warning">
+```
 
 ### Hovered state
 
-  <a href="#" class="btn btn__warning hover">Anchor Tag</a>
-  <button class="btn btn__warning hover" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__warning hover">
-
-````
 <a href="#" class="btn btn__warning hover">Anchor Tag</a>
 <button class="btn btn__warning hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning hover">
-````
+
+```
+<a href="#" class="btn btn__warning hover">Anchor Tag</a>
+<button class="btn btn__warning hover" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__warning hover">
+```
 
 ### Focused state
 
-  <a href="#" class="btn btn__warning focus">Anchor Tag</a>
-  <button class="btn btn__warning focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__warning focus">
-
-````
 <a href="#" class="btn btn__warning focus">Anchor Tag</a>
 <button class="btn btn__warning focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning focus">
-````
+
+```
+<a href="#" class="btn btn__warning focus">Anchor Tag</a>
+<button class="btn btn__warning focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__warning focus">
+```
 
 ### Active state
 
-  <a href="#" class="btn btn__warning active">Anchor Tag</a>
-  <button class="btn btn__warning active" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__warning active">
-
-````
 <a href="#" class="btn btn__warning active">Anchor Tag</a>
 <button class="btn btn__warning active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__warning active">
-````
+
+```
+<a href="#" class="btn btn__warning active">Anchor Tag</a>
+<button class="btn btn__warning active" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__warning active">
+```
 
 ## Disabled button
 
 ### Default/hovered/active state
 
-  <a href="#" class="btn btn__disabled">Anchor Tag</a>
-  <button class="btn btn__disabled" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__disabled">
-  <button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
-
-````
 <a href="#" class="btn btn__disabled">Anchor Tag</a>
 <button class="btn btn__disabled" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__disabled">
 <button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
-````
+
+```
+<a href="#" class="btn btn__disabled">Anchor Tag</a>
+<button class="btn btn__disabled" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__disabled">
+<button class="btn" disabled title="Test button">Button Tag w/ disabled attr</button>
+```
 
 ### Focused state
 
-  <a href="#" class="btn btn__disabled focus">Anchor Tag</a>
-  <button class="btn btn__disabled focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__disabled focus">
-  <button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
-
-````
 <a href="#" class="btn btn__disabled focus">Anchor Tag</a>
 <button class="btn btn__disabled focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__disabled focus">
 <button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
-````
+
+```
+<a href="#" class="btn btn__disabled focus">Anchor Tag</a>
+<button class="btn btn__disabled focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__disabled focus">
+<button class="btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
+```
 
 ## Super button
 
 ### Default state
 
-  <a href="#" class="btn btn__super">Anchor Tag</a>
-  <button class="btn btn__super" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__super">
-
-````
 <a href="#" class="btn btn__super">Anchor Tag</a>
 <button class="btn btn__super" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super">
-````
+
+```
+<a href="#" class="btn btn__super">Anchor Tag</a>
+<button class="btn btn__super" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__super">
+```
 
 ### Hovered state
 
-  <a href="#" class="btn btn__super hover">Anchor Tag</a>
-  <button class="btn btn__super hover" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__super hover">
-
-````
 <a href="#" class="btn btn__super hover">Anchor Tag</a>
 <button class="btn btn__super hover" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super hover">
-````
+
+```
+<a href="#" class="btn btn__super hover">Anchor Tag</a>
+<button class="btn btn__super hover" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__super hover">
+```
 
 ### Focused state
 
-  <a href="#" class="btn btn__super focus">Anchor Tag</a>
-  <button class="btn btn__super focus" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__super focus">
-
-````
 <a href="#" class="btn btn__super focus">Anchor Tag</a>
 <button class="btn btn__super focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super focus">
-````
+
+```
+<a href="#" class="btn btn__super focus">Anchor Tag</a>
+<button class="btn btn__super focus" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__super focus">
+```
 
 ### Active state
 
-  <a href="#" class="btn btn__super active">Anchor Tag</a>
-  <button class="btn btn__super active" title="Test button">Button Tag</button>
-  <input type="submit" value="Input Tag" class="btn btn__super active">
-
-````
 <a href="#" class="btn btn__super active">Anchor Tag</a>
 <button class="btn btn__super active" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="btn btn__super active">
-````
+
+```
+<a href="#" class="btn btn__super active">Anchor Tag</a>
+<button class="btn btn__super active" title="Test button">Button Tag</button>
+<input type="submit" value="Input Tag" class="btn btn__super active">
+```

--- a/src/cf-pagination/usage.md
+++ b/src/cf-pagination/usage.md
@@ -2,47 +2,6 @@
 
 ### Default pagination
 
-  <div id="pagination_content"></div>
-
-  <!-- Paginated content here -->
-
-  <nav class="pagination">
-      <a class="btn btn__super pagination_prev" href="#pagination_content">
-          <span class="btn_icon__left cf-icon cf-icon-left"></span>
-          Previous
-      </a>
-      <a class="btn btn__super pagination_next" href="#pagination_content">
-          Next
-          <span class="btn_icon__right cf-icon cf-icon-right"></span>
-      </a>
-      <form class="pagination_form" action="index.html#pagination_content">
-          <label class="pagination_label"
-                 for="pagination_current-page">
-              Page
-              <span class="u-visually-hidden">
-                  number out of 149 total pages
-              </span>
-          </label>
-          <input
-              class="pagination_current-page"
-              id="pagination_current-page"
-              name="pagination_current-page"
-              type="number" min="1" max="149"
-              value="149">
-          <span class="pagination_label">
-              <span aria-hidden="true">
-                  of 149
-              </span>
-          </span>
-          <button class="btn btn__link pagination_submit"
-                  id="pagination_submit"
-                  type="submit">
-              Go
-          </button>
-      </form>
-  </nav>
-
-````
 <div id="pagination_content"></div>
 
 <!-- Paginated content here -->
@@ -82,4 +41,45 @@
         </button>
     </form>
 </nav>
-````
+
+```
+<div id="pagination_content"></div>
+
+<!-- Paginated content here -->
+
+<nav class="pagination">
+    <a class="btn btn__super pagination_prev" href="#pagination_content">
+        <span class="btn_icon__left cf-icon cf-icon-left"></span>
+        Previous
+    </a>
+    <a class="btn btn__super pagination_next" href="#pagination_content">
+        Next
+        <span class="btn_icon__right cf-icon cf-icon-right"></span>
+    </a>
+    <form class="pagination_form" action="index.html#pagination_content">
+        <label class="pagination_label"
+               for="pagination_current-page">
+            Page
+            <span class="u-visually-hidden">
+                number out of 149 total pages
+            </span>
+        </label>
+        <input
+            class="pagination_current-page"
+            id="pagination_current-page"
+            name="pagination_current-page"
+            type="number" min="1" max="149"
+            value="149">
+        <span class="pagination_label">
+            <span aria-hidden="true">
+                of 149
+            </span>
+        </span>
+        <button class="btn btn__link pagination_submit"
+                id="pagination_submit"
+                type="submit">
+            Go
+        </button>
+    </form>
+</nav>
+```

--- a/src/cf-tables/usage.md
+++ b/src/cf-tables/usage.md
@@ -2,47 +2,14 @@
 
 ### Table base style, with small screen base style "stacked"
 
-- Uses '.table__stack-on-small' class to add small screen styles
+- Uses `.table__stack-on-small` class to add small screen styles
 - Note: Tables are not responsive without adding one of the small
   screen classes
-- The use of the '.table__right-align' class on a TD aligns the text
+- The use of the `.table__right-align` class on a TD aligns the text
     right - see the third column above
-- The 'data-label' attribute is used to label each entry. Always
-  include the 'data-label' attribute for each cell!
+- The `data-label` attribute is used to label each entry. Always
+  include the `data-label` attribute for each cell.
 
-    <table class="table__stack-on-small">
-      <thead>
-        <tr>
-          <th>Column 1</th>
-          <th>Column 2</th>
-          <th>Column 3</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td data-label="Column 1">Row A</td>
-          <td data-label="Column 2">Cell A2</td>
-          <td data-label="Column 3">Cell A3</td>
-        </tr>
-        <tr>
-          <td data-label="Column 1">Row B</td>
-          <td data-label="Column 2">Cell B2</td>
-          <td data-label="Column 3">Cell B3</td>
-        </tr>
-        <tr>
-          <td data-label="Column 1">Row C</td>
-          <td data-label="Column 2">Cell C2</td>
-          <td data-label="Column 3">Cell C3</td>
-        </tr>
-        <tr>
-          <td data-label="Column 1">Row D</td>
-          <td data-label="Column 2">Cell D2</td>
-          <td data-label="Column 3">Cell D3</td>
-        </tr>
-      </tbody>
-    </table>
-
-````
 <table class="table__stack-on-small">
   <thead>
     <tr>
@@ -74,51 +41,51 @@
     </tr>
   </tbody>
 </table>
-````
+
+```
+<table class="table__stack-on-small">
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-label="Column 1">Row A</td>
+      <td data-label="Column 2">Cell A2</td>
+      <td data-label="Column 3">Cell A3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row B</td>
+      <td data-label="Column 2">Cell B2</td>
+      <td data-label="Column 3">Cell B3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row C</td>
+      <td data-label="Column 2">Cell C2</td>
+      <td data-label="Column 3">Cell C3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row D</td>
+      <td data-label="Column 2">Cell D2</td>
+      <td data-label="Column 3">Cell D3</td>
+    </tr>
+  </tbody>
+</table>
+```
 
 ### Table with small screen variation - "stacked with entry header"
 
-- "Uses '.table__entry-header-on-small' class in addition to
-  '.table__stack-on-small' class to style the first column as an
+- "Uses `.table__entry-header-on-small` class in addition to
+  `.table__stack-on-small` class to style the first column as an
   entry header. Note that this requires both classes be added."
-- "Note: Tables are not responsive without adding one of the small
-  screen classes"
-- "The 'data-label' attribute is used to label each entry. Always
-  include the 'data-label' attribute for each cell!"
+- Note: Tables are not responsive without adding one of the small
+  screen classes
+- "The `data-label` attribute is used to label each entry. Always
+  include the `data-label` attribute for each cell
 
-    <table class="table__stack-on-small table__entry-header-on-small">
-      <thead>
-        <tr>
-          <th>Column 1</th>
-          <th>Column 2</th>
-          <th>Column 3</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td data-label="Column 1">Row A</td>
-          <td data-label="Column 2">Cell A2</td>
-          <td data-label="Column 3">Cell A3</td>
-        </tr>
-        <tr>
-          <td data-label="Column 1">Row B</td>
-          <td data-label="Column 2">Cell B2</td>
-          <td data-label="Column 3">Cell B3</td>
-        </tr>
-        <tr>
-          <td data-label="Column 1">Row C</td>
-          <td data-label="Column 2">Cell C2</td>
-          <td data-label="Column 3">Cell C3</td>
-        </tr>
-        <tr>
-          <td data-label="Column 1">Row D</td>
-          <td data-label="Column 2">Cell D2</td>
-          <td data-label="Column 3">Cell D3</td>
-        </tr>
-      </tbody>
-  </table>
-
-````
 <table class="table__stack-on-small table__entry-header-on-small">
   <thead>
     <tr>
@@ -150,77 +117,50 @@
     </tr>
   </tbody>
 </table>
-````
+
+```
+<table class="table__stack-on-small table__entry-header-on-small">
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-label="Column 1">Row A</td>
+      <td data-label="Column 2">Cell A2</td>
+      <td data-label="Column 3">Cell A3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row B</td>
+      <td data-label="Column 2">Cell B2</td>
+      <td data-label="Column 3">Cell B3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row C</td>
+      <td data-label="Column 2">Cell C2</td>
+      <td data-label="Column 3">Cell C3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row D</td>
+      <td data-label="Column 2">Cell D2</td>
+      <td data-label="Column 3">Cell D3</td>
+    </tr>
+  </tbody>
+</table>
+```
 
 ### Table with small screen variation - "Comparative with horizontal scroll"
 
-- "Must be wrapped in an element (DIV, in most cases) with the
-  'table-wrapper__scrolling' class"
-- The TABLE element does not need additional markup in this case
-- "'Comparative with horizontal scroll' also adds striped rows to
+- Must be wrapped in an element (`<div>`, in most cases) with the
+  `table-wrapper__scrolling` class
+- The `<table>` element does not need additional markup in this case
+- "Comparative with horizontal scroll" also adds striped rows to
   the table contained within, and remains striped on small screens
-  (unlike the 'table__striped' class, below)."
+  (unlike the `table__striped `class, below).
 
-    <div class="table-wrapper__scrolling">
-      <table>
-        <thead>
-          <tr>
-            <th>Column 1</th>
-            <th>Column 2</th>
-            <th>Column 3</th>
-            <th>Column 4</th>
-            <th>Column 5</th>
-            <th>Column 6</th>
-            <th>Column 7</th>
-            <th>Column 8</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td data-label="Column 1">Row A</td>
-            <td data-label="Column 2">Cell A2</td>
-            <td data-label="Column 3">Cell A3</td>
-            <td data-label="Column 4">Cell A4</td>
-            <td data-label="Column 5">Cell A5</td>
-            <td data-label="Column 6">Cell A6</td>
-            <td data-label="Column 7">Cell A7</td>
-            <td data-label="Column 8">Cell A8</td>
-          </tr>
-          <tr>
-            <td data-label="Column 1">Row B</td>
-            <td data-label="Column 2">Cell B2</td>
-            <td data-label="Column 3">Cell B3</td>
-            <td data-label="Column 4">Cell B4</td>
-            <td data-label="Column 5">Cell B5</td>
-            <td data-label="Column 6">Cell B6</td>
-            <td data-label="Column 7">Cell B7</td>
-            <td data-label="Column 8">Cell B8</td>
-          </tr>
-          <tr>
-            <td data-label="Column 1">Row C</td>
-            <td data-label="Column 2">Cell C2</td>
-            <td data-label="Column 3">Cell C3</td>
-            <td data-label="Column 4">Cell C4</td>
-            <td data-label="Column 5">Cell C5</td>
-            <td data-label="Column 6">Cell C6</td>
-            <td data-label="Column 7">Cell C7</td>
-            <td data-label="Column 8">Cell C8</td>
-          </tr>
-          <tr>
-            <td data-label="Column 1">Row D</td>
-            <td data-label="Column 2">Cell D2</td>
-            <td data-label="Column 3">Cell D3</td>
-            <td data-label="Column 4">Cell D4</td>
-            <td data-label="Column 5">Cell D5</td>
-            <td data-label="Column 6">Cell D6</td>
-            <td data-label="Column 7">Cell D7</td>
-            <td data-label="Column 8">Cell D8</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
-````
 <div class="table-wrapper__scrolling">
   <table>
     <thead>
@@ -279,46 +219,73 @@
     </tbody>
   </table>
 </div>
-````
+
+```
+<div class="table-wrapper__scrolling">
+  <table>
+    <thead>
+      <tr>
+        <th>Column 1</th>
+        <th>Column 2</th>
+        <th>Column 3</th>
+        <th>Column 4</th>
+        <th>Column 5</th>
+        <th>Column 6</th>
+        <th>Column 7</th>
+        <th>Column 8</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td data-label="Column 1">Row A</td>
+        <td data-label="Column 2">Cell A2</td>
+        <td data-label="Column 3">Cell A3</td>
+        <td data-label="Column 4">Cell A4</td>
+        <td data-label="Column 5">Cell A5</td>
+        <td data-label="Column 6">Cell A6</td>
+        <td data-label="Column 7">Cell A7</td>
+        <td data-label="Column 8">Cell A8</td>
+      </tr>
+      <tr>
+        <td data-label="Column 1">Row B</td>
+        <td data-label="Column 2">Cell B2</td>
+        <td data-label="Column 3">Cell B3</td>
+        <td data-label="Column 4">Cell B4</td>
+        <td data-label="Column 5">Cell B5</td>
+        <td data-label="Column 6">Cell B6</td>
+        <td data-label="Column 7">Cell B7</td>
+        <td data-label="Column 8">Cell B8</td>
+      </tr>
+      <tr>
+        <td data-label="Column 1">Row C</td>
+        <td data-label="Column 2">Cell C2</td>
+        <td data-label="Column 3">Cell C3</td>
+        <td data-label="Column 4">Cell C4</td>
+        <td data-label="Column 5">Cell C5</td>
+        <td data-label="Column 6">Cell C6</td>
+        <td data-label="Column 7">Cell C7</td>
+        <td data-label="Column 8">Cell C8</td>
+      </tr>
+      <tr>
+        <td data-label="Column 1">Row D</td>
+        <td data-label="Column 2">Cell D2</td>
+        <td data-label="Column 3">Cell D3</td>
+        <td data-label="Column 4">Cell D4</td>
+        <td data-label="Column 5">Cell D5</td>
+        <td data-label="Column 6">Cell D6</td>
+        <td data-label="Column 7">Cell D7</td>
+        <td data-label="Column 8">Cell D8</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
 
 ### Standard table, with stripes
 
-- Uses '.table__striped' class
+- Uses `.table__striped` class
 - Striping is not visible by default on small screens
 
-    <table class="table__striped">
-      <thead>
-        <tr>
-          <th>Column 1</th>
-          <th>Column 2</th>
-          <th>Column 3</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td data-label="Column 1">Row A</td>
-          <td data-label="Column 2">Cell A2</td>
-          <td data-label="Column 3">Cell A3</td>
-        </tr>
-        <tr>
-          <td data-label="Column 1">Row B</td>
-          <td data-label="Column 2">Cell B2</td>
-          <td data-label="Column 3">Cell B3</td>
-        </tr>
-        <tr>
-          <td data-label="Column 1">Row C</td>
-          <td data-label="Column 2">Cell C2</td>
-          <td data-label="Column 3">Cell C3</td>
-        </tr>
-        <tr>
-          <td data-label="Column 1">Row D</td>
-          <td data-label="Column 2">Cell D2</td>
-          <td data-label="Column 3">Cell D3</td>
-        </tr>
-      </tbody>
-    </table>
-
-````
 <table class="table__striped">
   <thead>
     <tr>
@@ -350,127 +317,60 @@
     </tr>
   </tbody>
 </table>
-````
+
+```
+<table class="table__striped">
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-label="Column 1">Row A</td>
+      <td data-label="Column 2">Cell A2</td>
+      <td data-label="Column 3">Cell A3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row B</td>
+      <td data-label="Column 2">Cell B2</td>
+      <td data-label="Column 3">Cell B3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row C</td>
+      <td data-label="Column 2">Cell C2</td>
+      <td data-label="Column 3">Cell C3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row D</td>
+      <td data-label="Column 2">Cell D2</td>
+      <td data-label="Column 3">Cell D3</td>
+    </tr>
+  </tbody>
+</table>
+```
 
 ### Sortable Table
 
-- Uses '.table__sortable' class to invoke sorting functions on the table
-- "Columns which should be sortable have that column's THEAD TH content wrapped
-  with a BUTTON, and the BUTTON has the .sortable class. (The use of a BUTTON
-  tag here addresses certain accessibility concerns.)""
-- "Note: The class '.sorted-up' refers to a sort from smallest to greatest
-  (first to last), and '.sorted-down' refers to a sort from greatest to smallest
-  (last to first)."
-- "Please note the importance of defining a THEAD and TBODY to preserve
-  the table's header through sorting operations"
-- "Any BUTTON with the '.sortable' class can also be given the 'data-sort_type'
-  attribute"
-- "In the table example above, Distance is sorted by Number value. See below for
-  the 'data-sort_type' modifier."
-- "In the table example above, Distance is sorted low-to-high on page load by using
-  the 'sortable__start-up' class in the BUTTON. See the 'sortable__start-up' and
-  'sortable__start-down' modifiers below."
+- Uses `.table__sortable` class to invoke sorting functions on the table
+- Columns which should be sortable have that column's THEAD TH content wrapped
+  with a BUTTON, and the BUTTON has the `.sortable `class. (The use of a BUTTON
+  tag here addresses certain accessibility concerns.)
+- Note: The class `.sorted-up` refers to a sort from smallest to greatest
+  (first to last), and `.sorted-down` refers to a sort from greatest to smallest
+  (last to first).
+- Please note the importance of defining a THEAD and TBODY to preserve
+  the table's header through sorting operations
+- Any BUTTON with the `.sortable` class can also be given the `data-sort_type`
+  attribute
+- In the table example above, Distance is sorted by Number value. See below for
+  the `data-sort_type` modifier.
+- In the table example above, Distance is sorted low-to-high on page load by using
+  the `sortable__start-up` class in the BUTTON. See the `sortable__start-up` and
+  `sortable__start-down` modifiers below.
 
-    <table class="table__sortable">
-      <thead>
-          <tr>
-              <th>
-                  Agency
-              </th>
-              <th>
-                <button class="sortable">
-                  Languages
-                </button>
-              </th>
-              <th>
-                <button class="sortable sortable__start-up" data-sort_type="number">
-                  Distance
-                </button>
-              </th>
-          </tr>
-      </thead>
-      <tbody>
-          <tr>
-              <td>
-                  Alpha
-              </td>
-              <td data-label="Languages">
-                  English
-              </td>
-              <td data-label="Distance">
-                  2.6 mi
-              </td>
-          </tr>
-          <tr>
-              <td>
-                  Beta
-              </td>
-              <td data-label="Languages">
-                  English, Spanish
-              </td>
-              <td data-label="Distance">
-                  1.4 mi
-              </td>
-          </tr>
-          <tr>
-              <td>
-                  Gamma
-              </td>
-              <td data-label="Languages">
-                  English, French, Spanish
-              </td>
-              <td data-label="Distance">
-                  1.4 mi
-              </td>
-          </tr>
-          <tr>
-              <td>
-                  Delta
-              </td>
-              <td data-label="Languages">
-                  English, Spanish
-              </td>
-              <td data-label="Distance">
-                  3.2 mi
-              </td>
-          </tr>
-          <tr>
-              <td>
-                  Epsilon
-              </td>
-              <td data-label="Languages">
-                  English
-              </td>
-              <td data-label="Distance">
-                  1.6 mi
-              </td>
-          </tr>
-          <tr>
-              <td>
-                Zeta
-              </td>
-              <td data-label="Languages">
-                English, Spanish
-              </td>
-              <td data-label="Distance">
-                1.2 mi
-              </td>
-          </tr>
-          <tr>
-              <td>
-                  Eta
-              </td>
-              <td data-label="Languages">
-                  English
-              </td>
-              <td data-label="Distance">
-                  11.1 mi
-              </td>
-          </tr>
-      </tbody>
-    </table>
-
-````
 <table class="table__sortable">
   <thead>
       <tr>
@@ -569,22 +469,121 @@
       </tr>
   </tbody>
 </table>
-````
+
+```
+<table class="table__sortable">
+  <thead>
+      <tr>
+          <th>
+              Agency
+          </th>
+          <th>
+            <button class="sortable">
+              Languages
+            </button>
+          </th>
+          <th>
+            <button class="sortable sortable__start-up" data-sort_type="number">
+              Distance
+            </button>
+          </th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <td>
+              Alpha
+          </td>
+          <td data-label="Languages">
+              English
+          </td>
+          <td data-label="Distance">
+              2.6 mi
+          </td>
+      </tr>
+      <tr>
+          <td>
+              Beta
+          </td>
+          <td data-label="Languages">
+              English, Spanish
+          </td>
+          <td data-label="Distance">
+              1.4 mi
+          </td>
+      </tr>
+      <tr>
+          <td>
+              Gamma
+          </td>
+          <td data-label="Languages">
+              English, French, Spanish
+          </td>
+          <td data-label="Distance">
+              1.4 mi
+          </td>
+      </tr>
+      <tr>
+          <td>
+              Delta
+          </td>
+          <td data-label="Languages">
+              English, Spanish
+          </td>
+          <td data-label="Distance">
+              3.2 mi
+          </td>
+      </tr>
+      <tr>
+          <td>
+              Epsilon
+          </td>
+          <td data-label="Languages">
+              English
+          </td>
+          <td data-label="Distance">
+              1.6 mi
+          </td>
+      </tr>
+      <tr>
+          <td>
+            Zeta
+          </td>
+          <td data-label="Languages">
+            English, Spanish
+          </td>
+          <td data-label="Distance">
+            1.2 mi
+          </td>
+      </tr>
+      <tr>
+          <td>
+              Eta
+          </td>
+          <td data-label="Languages">
+              English
+          </td>
+          <td data-label="Distance">
+              11.1 mi
+          </td>
+      </tr>
+  </tbody>
+</table>
+```
 
 ### data-sort_type (modifier)
 
-- "By setting the 'data-sort_type' attribute to 'number', the column is sorted by
-  Number value"
-- "By default, columns will be sorted as strings."
+- By setting the `data-sort_type` attribute to 'number', the column is sorted by
+  Number value
+- By default, columns will be sorted as strings.
 
-    <table class="table__sortable">
-      ...
-        <th>
-          <button class="sortable" data-sort_type="number">Column Name</button>
-        </th>
-      ...
-    </table>
+<table class="table__sortable">
+    <th>
+      <button class="sortable" data-sort_type="number">Column Name</button>
+    </th>
+</table>
 
+```
 <table class="table__sortable">
   ...
     <th>
@@ -592,20 +591,19 @@
     </th>
   ...
 </table>
+```
 
 ### .sortable__start-up, .sortable__start-down (modifiers)
 
-"To sort the table on page load, use the '.sortable__start-up' and '.sortable__start-down'
-          classes."
+To sort the table on page load, use the `.sortable__start-u`p and `.sortable__start-down` classes.
 
-    <table class="table__sortable">
-      ...
-        <th>
-          <button class="sortable sortable__start-up">Column Name</button>
-        </th>
-      ...
-    </table>
+<table class="table__sortable">
+    <th>
+      <button class="sortable sortable__start-up">Column Name</button>
+    </th>
+</table>
 
+```
 <table class="table__sortable">
   ...
     <th>
@@ -613,3 +611,4 @@
     </th>
   ...
 </table>
+```

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -2,7 +2,7 @@
 
 ### Colors
 
-````
+```
 @pull-quote_body
 @pull-quote_citation
 @micro-copy-text
@@ -21,26 +21,12 @@
 @jump-link__bg
 @jump-link__bg-border
 @list__branded-bullet
-````
+```
 
 ## Pull quote
 
 ### Default pull quote
 
-  <aside class="pull-quote">
-      <div class="pull-quote_body">
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Cum corrupti tempora nam nihil qui mollitia consectetur
-          corporis nemo culpa dolorum!
-      </div>
-      <footer>
-          <cite class="pull-quote_citation">
-              - Author Name
-          </cite>
-      <footer>
-  </aside>
-
-````
 <aside class="pull-quote">
     <div class="pull-quote_body">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -53,24 +39,24 @@
         </cite>
     <footer>
 </aside>
-````
+
+```
+<aside class="pull-quote">
+    <div class="pull-quote_body">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Cum corrupti tempora nam nihil qui mollitia consectetur
+        corporis nemo culpa dolorum!
+    </div>
+    <footer>
+        <cite class="pull-quote_citation">
+            - Author Name
+        </cite>
+    <footer>
+</aside>
+```
 
 ### Large pull quote
 
-  <aside class="pull-quote pull-quote__large">
-      <div class="pull-quote_body">
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-          Cum corrupti tempora nam nihil qui mollitia consectetur
-          corporis nemo culpa dolorum!
-      </div>
-      <footer>
-          <cite class="pull-quote_citation">
-              - Author Name
-          </cite>
-      <footer>
-  </aside>
-
-````
 <aside class="pull-quote pull-quote__large">
     <div class="pull-quote_body">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.
@@ -83,4 +69,18 @@
         </cite>
     <footer>
 </aside>
-````
+
+```
+<aside class="pull-quote pull-quote__large">
+    <div class="pull-quote_body">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+        Cum corrupti tempora nam nihil qui mollitia consectetur
+        corporis nemo culpa dolorum!
+    </div>
+    <footer>
+        <cite class="pull-quote_citation">
+            - Author Name
+        </cite>
+    <footer>
+</aside>
+```


### PR DESCRIPTION
This preps the `usage.md` files for syntax highlighting in the CF docs by:

- Removing indents from HTML that is intended to render
- Correcting the places where four back ticks were used instead of 3
- Fixing a few small markdown errors or weird copy and paste formatting (extra quotation marks, single quotes used instead of inline backticks)

## Review

@Scotchester or @contolini 