### PR TITLE
Fix <th> padding and styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- [PATCH] **cf-core:** Fix padding in `<th>`s to be 10px
+- [PATCH] **cf-tables:** Match sortable `<th>` styles to non-sortable `<th>` styles
 
 ### Removed
-- 
+-
 
 ## 3.2.1 - 2016-03-10
 

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -483,6 +483,7 @@ td {
     padding: unit(10px / @base-font-size-px, em);
 
     thead & {
+        padding: unit(10px / @font-size, em);
         color: @thead-text;
         background: @thead-bg;
         .h5();

--- a/src/cf-tables/src/cf-tables.less
+++ b/src/cf-tables/src/cf-tables.less
@@ -21,7 +21,7 @@
         & > th,
         & > td {
             background: @table-cell-bg_alt;
-        }   
+        }
     }
 }
 
@@ -44,14 +44,16 @@
     button.sortable {
         width: 100%;
         height: 100%;
-        padding: inherit;
-        margin: inherit;
+        padding: 0;
+        margin: 0;
         border: none;
         background: none;
         font-family: inherit;
         font-weight: inherit;
+        line-height: inherit;
         outline: none;
         text-align: left;
+        text-transform: inherit;
     }
 
     .sortable:after {
@@ -81,7 +83,7 @@
 .respond-to-min( @mobile-max, {
     .table__striped {
         .striped-table();
-    }  
+    }
 });
 
 .respond-to-max( @mobile-max, {


### PR DESCRIPTION
Fixes a few padding and typography issues in table headers

## Changes

- Fix padding in `<th>`s to always be 10px on all sides
- Match sortable `<th>` styles to non-sortable `<th>` styles

## Testing

Tables should now have 10px of padding on all sides of any `<th>`. Also, sortable `<th`>s should match regular `<th>`s. Basically, tables should look like the "tables-fixes" screenshot below instead of the "canary" screenshot as they do now. A good table to test with is the one on `test/cf-tables.html`.

## Review

- @Scotchester 
- @mistergone 

## Screenshots

canary | tables-fixes
-------|-------------
![tables-old](https://cloud.githubusercontent.com/assets/1862695/13956385/ec81ab5e-f01e-11e5-919f-beef612f89ff.png) | ![tables-new](https://cloud.githubusercontent.com/assets/1862695/13956393/f1ec6db8-f01e-11e5-9767-cafd49e3e308.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)