### PR TITLE
Added Overlay Hero styles and a bit of cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 
+- Added `overlay` and `white-text` modifiers to the hero
+
+### Changed
+- Updated the Hero styles to properly match the content layout and
+  simplified the rules
+
+### Removed
+-
+
 ## 3.2.1 - 2016-03-10
 
 ### Changed

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -650,48 +650,47 @@
     });
   }
 }
+
+
 //
 // Hero
 //
 
 @hero-desktop-height: 285px;
 @hero-image-height: 195px;
-@desktop-min: 801px;
+@hero-bg: #f7f8f9;
+@hero-overlay-bg: #5a5d61;
+@hero-overlay-text: white;
 
 .hero {
-    background-color: @block__bg;
+    background-color: @hero-bg;
+
+    .respond-to-min( @bp-sm-min, {
+        display: table;
+        width: 100%;
+    } );
 
     &_wrapper {
-        box-sizing: border-box;
-        padding: unit(@grid_gutter-width / @base-font-size-px, em)
-                 unit(15px / @base-font-size-px, em);
-        width: 100%;
+        padding-top: unit( @grid_gutter-width / @base-font-size-px, em );
+        padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
 
-        .respond-to-min(@bp-sm-min, {
-            display: table;
+        .respond-to-min( @bp-sm-min, {
+            padding-right: unit( 15px / @base-font-size-px, em );
+            padding-left: unit( 15px / @base-font-size-px, em );
+        } );
+
+        .respond-to-min( @bp-med-min, {
+            padding-top: unit( 45px / @base-font-size-px, em );
+            padding-bottom: unit( 45px / @base-font-size-px, em );
         });
-
-        .respond-to-min(@bp-med-min, {
-            padding-top: unit(45px / @base-font-size-px, em);
-            padding-bottom: unit(45px / @base-font-size-px, em);
-            min-height: unit(@hero-desktop-height / @base-font-size-px, em);
-        });
-
-        .respond-to-min(@bp-xl-min, {
-            padding-right: 0;
-            padding-left: 0;
-        });
-
-        .lt-ie9 & {
-            // Reduce min-height because IE8 apparently isn't honoring the border-box property,
-            // perhaps due to bug seen here: http://grab.by/JutE
-            min-height: initial;
-        }
     }
 
     &_text {
-        .respond-to-min(@bp-sm-min, {
-            .grid_column(7,12);
+        .grid_column( 1, 1 );
+
+        .respond-to-min( @bp-sm-min, {
+            .grid_column( 7, 12 );
+
             display: table-cell;
             vertical-align: middle;
         });
@@ -700,47 +699,88 @@
     &_heading {
         .heading-1();
 
-        .respond-to-max(@bp-sm-max, {
+        .respond-to-max( @bp-sm-max, {
             .heading-2();
-        });
+        } );
     }
 
     &_subhead,
-    &_cta:not(.btn) {
-        .heading-3();
+    &_cta:not( .btn ) {
+        .webfont-regular();
 
-        margin-bottom: unit(@grid_gutter-width / @font-size, em);
+        font-size: @size-iv;
+        line-height: 1.25;
 
-        .respond-to-max(@bp-sm-max, {
-            // Use the same regular weight but reduce the sizes to h4 size
-            // Can't use .into-paragraph because it has a different breakpoint
-            font-size: unit(18px / @base-font-size-px, em);
-            margin-bottom: unit(@grid_gutter-width / 18px, em);
-        });
+        .respond-to-min( @bp-med-min, {
+            font-size: @size-iii;
+        } );
+    }
 
-        &:last-child {
-            margin-bottom: initial;
-        }
+    &_subhead:not( :last-child ) {
+        margin-bottom: unit( @grid_gutter-width / @size-iv, em );
+
+        .respond-to-min( @bp-med-min, {
+            margin-bottom: unit( @grid_gutter-width / @size-iii, em );
+        } );
     }
 
     &_cta {
-        margin-bottom: initial;
+        display: block;
     }
 
     &_image {
-        min-height: unit(@hero-image-height / @base-font-size-px, em);
+        .grid_column( 1, 1 );
+
+        // height is the same as min-height in a table
+        height: unit( @hero-image-height / @base-font-size-px, em );
+
         background-position: center;
         background-repeat: no-repeat;
-        background-size: contain;
+        background-size: cover;
 
-        .respond-to-min(@bp-sm-min, {
-            .grid_column(5,12);
+        .respond-to-min( @bp-sm-min, {
+            .grid_column( 5, 12 );
+
+            // Keep the text and image vertically centered
             display: table-cell;
             vertical-align: middle;
-        });
 
-        .respond-to-max(@bp-xs-max, {
-            margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
-        });
+            background-size: contain;
+        } );
+
+        .respond-to-max( @bp-xs-max, {
+            margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+        } );
+    }
+
+    &__overlay {
+        .hero_wrapper {
+            background-repeat: no-repeat;
+        }
+
+        .respond-to-max( @bp-xs-max, {
+            .hero_wrapper {
+                // Overwrite the image that is set in the markup because
+                // we're showing the image container below instead
+                background: transparent !important;
+            }
+        } );
+
+        .respond-to-min( @bp-sm-min, {
+            .hero_image {
+                // Overwrite the image but don't remove the container from
+                // the grid flow. Necessary due to table-cell.
+                background: transparent !important;
+            }
+        } );
+    }
+
+    &__white-text {
+        .respond-to-min( @bp-sm-min, {
+            .hero_wrapper {
+                background-color: @hero-overlay-bg;
+                color: @hero-overlay-text;
+            }
+        } );
     }
 }


### PR DESCRIPTION
Update for pages that need an overlay hero that uses a BG image instead of the inset right image.

## Additions

- Added `overlay` and `white-text` modifiers to the hero

## Changes

- Updated the Hero styles to properly match the content layout and
  simplified the rules

## Testing

_See [ CF Testing Components Locally for more info](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally)_

- run `npm run build` in the `[ cf repo ]`
- cd to `[ cf repo ]/tmp/cf-layout` and run `npm link`
- Used the linked module in your project by cd-ing to your project root and running `npm link cf-layout`
- Build your project
- Add `hero__overlay` to your hero's classlist
- Add an inline bg image style to the `hero_wrapper` Ex. `style="background-image: url(http://beta.consumerfinance.gov/static/img/home-hero_lg.jpg);`

## Review

- @schaferjh
- @ajbush 
- @KimberlyMunoz 
- @sebworks 
- @anselmbradford 

## Screenshots

![screen shot 2016-03-24 at 3 26 30 pm](https://cloud.githubusercontent.com/assets/1280430/14030281/d9315182-f1d4-11e5-9ff4-2e91bd5399e0.png)

![screen shot 2016-03-24 at 3 24 23 pm](https://cloud.githubusercontent.com/assets/1280430/14030286/df3797a8-f1d4-11e5-957d-7daea92267e0.png)

## Notes

- This is using the Homepage image even though it's not the homepage. It's what we have on beta currently that makes testing across machines simple. The flag/building image will need to be set in the CMS when the new page is published.
- After discussion with @ajbush, we decided it was better to keep the image the same as the default hero at smaller screen sizes, rather than span edge-to-edge and remove the bottom padding. It's more consistent and leads to a simpler code base.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)