### PR TITLE
Updated main content spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- [MINOR] **cf-layout** Updated main content spacing
 
 ### Removed
-- 
+-
 
 ## 3.3.0 - 2016-04-06
 

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -234,12 +234,12 @@
 
     .respond-to-min(@bp-sm-min, {
         .grid_column(12);
-        padding: unit((@grid_gutter-width * 2) / @base-font-size-px, em)
+        padding: unit((@grid_gutter-width * 1.5) / @base-font-size-px, em)
                  unit((@grid_gutter-width / 2) / @base-font-size-px, em);
     });
 
     .respond-to-min(@bp-med-min, {
-        padding: unit((@grid_gutter-width * 2) / @base-font-size-px, em)
+        padding: unit((@grid_gutter-width * 1.5) / @base-font-size-px, em)
                  0;
     });
 }
@@ -268,7 +268,7 @@
                     content: '';
                     border-left: 1px solid @content_main-border;
                     position: absolute;
-                    top: unit((@grid_gutter-width * 2) / @base-font-size-px, em);
+                    top: unit((@grid_gutter-width * 1.5) / @base-font-size-px, em);
                     bottom: 0;
                     left: unit(-1 * @grid_gutter-width / @base-font-size-px, em);
                 }
@@ -466,7 +466,7 @@
         overflow: hidden;
 
         .content_sidebar {
-            padding: unit((@grid_gutter-width * 2) / @base-font-size-px, em)
+            padding: unit((@grid_gutter-width * 1.5) / @base-font-size-px, em)
                      0
                      unit((@grid_gutter-width / 2) / @base-font-size-px, em)
                      unit(@grid_gutter-width / @base-font-size-px, em);


### PR DESCRIPTION
AJ updated the spacing requirements for main content in [GHE]/flapjack/Modules-V1/issues/116. Hero spacing is documented in the Design Manual, other uses will be documented in the future.

## Changes

- Updated the `unit` function to convert 45px to ems

## Testing

- [follow these directions](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally)
- New spacing should match examples below.

## Review

- @ajbush
- @anselmbradford 
- @sebworks 
- @cfarm 
- @Scotchester 

## Screenshots

<img width="1204" alt="screen shot 2016-05-03 at 5 39 34 pm" src="https://cloud.githubusercontent.com/assets/1280430/15020269/ee0e3886-11e6-11e6-8291-461e15ade6f2.png">

<img width="1202" alt="screen shot 2016-05-03 at 5 39 46 pm" src="https://cloud.githubusercontent.com/assets/1280430/15020275/f136eb7a-11e6-11e6-8ac9-fd036abd7e32.png">

<img width="1183" alt="screen shot 2016-05-03 at 5 39 55 pm" src="https://cloud.githubusercontent.com/assets/1280430/15020278/f4ea392a-11e6-11e6-868a-87b287760b84.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices 
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
