### PR TITLE
Update contributing documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **capital-framework:** [PATCH] Update contributing documentation.
 
 ### Removed
-- 
+-
 
 ## 3.4.0 - 2016-05-09
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,24 @@
 # Guidance on how to contribute
 
 > All contributions to this project will be released under the CC0 public domain
-> dedication. By submitting a pull request or filing a bug, issue, or 
+> dedication. By submitting a pull request or filing a bug, issue, or
 > feature request, you are agreeing to comply with this waiver of copyright interest.
 > Details can be found in our [TERMS](TERMS.md) and [LICENCE](LICENSE).
 
 
-There are two primary ways to help: 
- - Using the issue tracker, and 
+There are two primary ways to help:
+ - Using the issue tracker, and
  - Changing the code-base.
 
 
 ## Using the issue tracker
 
-Use the issue tracker to suggest feature requests, report bugs, and ask questions. 
+Use the issue tracker to suggest feature requests, report bugs, and ask questions.
 This is also a great way to connect with the developers of the project as well
 as others who are interested in this solution.  
 
 Use the issue tracker to find ways to contribute. Find a bug or a feature, mention in
-the issue that you will take on that effort, then follow the _Changing the codebase_ 
+the issue that you will take on that effort, then follow the _Changing the codebase_
 guidance below.
 
 
@@ -32,15 +32,18 @@ For example, if you wanted to change `cf-buttons`, here's what you'd do:
 1. `git clone git@github.com:cfpb/capital-framework.git`
 1. `cd capital-framework`
 1. `npm install`
-1. `git checkout -b doing-something-with-buttons canary`
+1. `git checkout -b button-fix canary`
 1. Edit file(s) in `/src/cf-buttons/` however you want.
 1. `npm run build` This will build every component (compiling Less, bundling JS, processing markdown docs) to `tmp/` in the project's root.
 1. Inspect and test your modified `cf-buttons` component in `tmp/`. See _Testing components locally_ below.
-1. Describe the changes in the "Unreleased" section of `/CHANGELOG.md`.
-Prepend the component's name to the described changes.
-1. `git commit -am "Describe your commit"`
-1. `git push upstream doing-something-with-buttons`
-1. Go to https://github.com/cfpb/capital-framework and open a pull request to merge `doing-something-with-buttons` into `canary`.
+1. When you're done hacking, open `/CHANGELOG.md` and add a line item describing your changes in the "Unreleased" section.
+Use the format: `- **cf-component-name:** [MAJOR|MINOR|PATCH] Description of change`.
+[Here's an example](https://github.com/cfpb/capital-framework/pull/291/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR12).
+  - If the change affects *all* components, put `**all components:**` as the name.
+  - If the change affects CF and not any components (e.g. if you're just updating [README.md](README.md)), put `**capital-framework**`.
+1. `git commit -am "Fix button border radius"`
+1. `git push origin button-fix`
+1. Go to https://github.com/cfpb/capital-framework and open a pull request to merge `button-fix` into `canary`.
 
 
 ### Testing components locally
@@ -63,16 +66,7 @@ Now `~/Projects/owning-a-home/node_modules/cf-buttons` will be a symlink pointin
 
 After changes have been made to components, nothing will be published to npm until
 those changes enter the `master` branch.
+Release management is now handled by [CFPB's chat bot](https://github.com/cfpb/CFPBot) via [hubot-capital-framework](https://github.com/cfpb/hubot-capital-framework).
 
-1. Go to wherever cf is cloned locally: `cd capital-framework`
-1. Ensure you're on canary: `git checkout canary`
-1. Ensure you're up-to-date: `git pull upstream canary`
-1. Open `/CHANGELOG.md` and check the "Unreleased" section. For each component
-that's been modified, open its `/src/COMPONENT/package.json` and increment its
-version. Follow [SemVer](http://semver.org/) and increment either its major, minor,
-or patch version dependent upon the changes that were made to the component.
-1. Don't bump CF's primary `/package.json`. Travis will automatically increment its version.
-1. Delete any empty sections ("Added", "Changed", "Removed") from the "Unreleased" section.
-1. `git commit -am "Preparing release"`
-1. `git push upstream canary`
-1. Go to https://github.com/cfpb/capital-framework and open a pull request to merge `canary` into `master`.
+1. In the FEWD channel say "cfpbot capital framework prepare release"
+1. It will do a bunch of stuff and create a release PR. Visit the PR and merge it.


### PR DESCRIPTION
@Scotchester Please review when you return. Release management is now handled via [chat w/ hubot](https://github.com/cfpb/hubot-capital-framework). I also updated the contribution steps a l'il bit.