### PR TITLE
Add respond-to-print and respond-to-print mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+- **cf-core:** [MINOR] Add respond-to-dpi mixin and respond-to-print mixin
 
 ### Changed
-- 
+-
 
 ### Removed
-- 
+-
 
 ## 3.4.1 - 2016-05-13
 

--- a/src/cf-core/src/cf-media-queries.less
+++ b/src/cf-core/src/cf-media-queries.less
@@ -28,3 +28,19 @@
         @rules();
     }
 }
+
+.respond-to-dpi(@ratio, @rules) {
+    @dpi: (@ratio * 96dpi);
+    @media (-webkit-min-device-pixel-ratio: @ratio), (min-resolution: @dpi) {
+        @rules();
+    }
+}
+
+.respond-to-print(@rules) {
+    @media print {
+        @rules();
+    }
+    .print & {
+        @rules();
+    }
+}

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -31,3 +31,59 @@
 ```
 <a href="#">Default link style</a>
 ```
+
+## Media queries
+
+### Respond to dpi mixin
+
+This mixin allows us to easily write styles
+that target high-resolution screens,
+such as Apple retina screens
+
+```less
+// The following LESS...
+.example {
+    background: url(regular-resolution-image.png);
+    .respond-to-dpi(2, {
+        background-image: url(retina-image.png);
+    });
+}
+
+// ...Exports to
+.example {
+    background: url(regular-resolution-image.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+    .example {
+        background-image: url(retina-image.png);
+    }
+}
+```
+
+### Respond to print mixin
+
+This mixin allows us to easily write styles that target both
+`@media print` and `.print`.
+
+```less
+// The following LESS...
+.example {
+    color: @gray;
+    .respond-to-print({
+        color: @black;
+    });
+}
+
+// ...Exports to
+.example {
+    color: #75787B;
+}
+@media print {
+    .example {
+        color: #101820;
+    }
+}
+.print .example {
+    color: #101820;
+}
+```


### PR DESCRIPTION
This is a MINOR update to cf-core to add two mixins from the [cfgov-refresh project](https://github.com/cfpb/cfgov-refresh/blob/1951b729275fc0cef668e51e951f8a8777c2cf02/cfgov/unprocessed/css/enhancements/media-queries.less).

Closes #205.

