### PR TITLE
Fix FCM side borders, slug spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-layout:** [PATCH] Add negative side margin to FCMs so they don't double
+  up the border when against a sidebar.
+- **cf-layout:** [PATCH] Update recommended FCM markup to use `category-slug`.
 
 ### Removed
-- 
+-
 
 ## 3.5.0 - 2016-05-26
 

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -589,6 +589,8 @@
   position: relative;
 
   min-height: 320px;
+  margin-right: -1px;
+  margin-left: -1px;
 
   background-color: @block__bg;
 

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -1229,9 +1229,9 @@ The visual should be 640x360 (16x9 ratio) and resize to fit the height of the FC
 
 <section class="block block__border block__flush featured-content-module">
     <div class="featured-content-module_text">
-        <p class=h4>
+        <div class="category-slug">
             <span class="featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured </p>
+</span> Featured </div>
         <h2>Feature title</h2>
         <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
         <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>
@@ -1242,9 +1242,9 @@ The visual should be 640x360 (16x9 ratio) and resize to fit the height of the FC
 ```
 <section class="block block__border block__flush featured-content-module">
     <div class="featured-content-module_text">
-        <p class=h4>
+        <div class="category-slug">
             <span class="featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured </p>
+</span> Featured </div>
         <h2>Feature title</h2>
         <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
         <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>


### PR DESCRIPTION
- Add negative side margin to FCMs so they don't double up the border when against a sidebar.
- Updates recommended FCM markup to use `category-slug`, to prevent extra margin between the category and the main FCM heading.

## Before

![screen shot 2016-05-27 at 15 27 18](https://cloud.githubusercontent.com/assets/1044670/15619811/9f09ff36-2424-11e6-853d-8a48b0f4aace.png)

## After

![screen shot 2016-05-27 at 15 58 06](https://cloud.githubusercontent.com/assets/1044670/15619820/ab39f13a-2424-11e6-9b21-f28dcd39abbc.png)

**Please review:**
- @jimmynotjim 
- @cfpb/front-end-team-admin 