### PR TITLE
Adds GH issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+Short description explaining the high-level reason for the new issue.
+
+## Current behavior
+
+-
+
+## Expected behavior
+
+-
+
+## Steps to replicate behavior
+
+1.
+
+
+## Screenshots
+
+__Current__
+
+
+__Expected__

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+Short description explaining the high-level reason for the pull request
+
+## Additions
+
+-
+
+## Removals
+
+-
+
+## Changes
+
+-
+
+## Testing
+
+-
+
+## Review
+
+- @user
+
+## Screenshots
+
+
+## Notes
+
+-
+
+## Todos
+
+-
+
+## Checklist
+
+* [ ] Changes are limited to a single goal (no scope creep)
+* [ ] Code can be automatically merged (no conflicts)
+* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
+* [ ] Passes all existing automated tests
+* [ ] New functions include new tests
+* [ ] New functions are documented (with a description, list of inputs, and expected output)
+* [ ] Placeholder code is flagged
+* [ ] Visually tested in supported browsers and devices
+* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)


### PR DESCRIPTION
## Additions

- Adds auto-generation of PR/issue template when creating PRs/issues.

## Testing

- After merging this, it shouldn't be necessary to copy/paste the issue or PR template when opening PRs/issues. I don't think this can be tested till it's merged.

## Review

- @Scotchester 
- @jimmynotjim 

## Screenshots

![screen shot 2016-06-07 at 10 44 25 am](https://cloud.githubusercontent.com/assets/704760/15862174/d36a6b0a-2c9c-11e6-8767-bfbf3a6d5b5f.png)
