### PR TITLE
CF Release

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+Short description explaining the high-level reason for the new issue.
+
+## Current behavior
+
+-
+
+## Expected behavior
+
+-
+
+## Steps to replicate behavior
+
+1.
+
+
+## Screenshots
+
+__Current__
+
+
+__Expected__

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+Short description explaining the high-level reason for the pull request
+
+## Additions
+
+-
+
+## Removals
+
+-
+
+## Changes
+
+-
+
+## Testing
+
+-
+
+## Review
+
+- @user
+
+## Screenshots
+
+
+## Notes
+
+-
+
+## Todos
+
+-
+
+## Checklist
+
+* [ ] Changes are limited to a single goal (no scope creep)
+* [ ] Code can be automatically merged (no conflicts)
+* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
+* [ ] Passes all existing automated tests
+* [ ] New functions include new tests
+* [ ] New functions are documented (with a description, list of inputs, and expected output)
+* [ ] Placeholder code is flagged
+* [ ] Visually tested in supported browsers and devices
+* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,11 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 
-### Added
--
-
 ### Changed
-- **cf-layout:** [PATCH] Add negative side margin to FCMs so they don't double
+- **cf-layout:** Add negative side margin to FCMs so they don't double
   up the border when against a sidebar.
-- **cf-layout:** [PATCH] Update recommended FCM markup to use `category-slug`.
+- **cf-layout:** Update recommended FCM markup to use `category-slug`.
 
-### Removed
--
 
 ## 3.5.0 - 2016-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-layout:** [PATCH] Add negative side margin to FCMs so they don't double
+  up the border when against a sidebar.
+- **cf-layout:** [PATCH] Update recommended FCM markup to use `category-slug`.
 
 ### Removed
-- 
+-
 
 ## 3.5.0 - 2016-05-26
 

--- a/src/cf-layout/package.json
+++ b/src/cf-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-layout",
-  "version": "3.2.0",
+  "version": "null",
   "description": "Capital Framework layouts",
   "less": "src/cf-layout.less",
   "style": "cf-layout.css",

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -589,6 +589,8 @@
   position: relative;
 
   min-height: 320px;
+  margin-right: -1px;
+  margin-left: -1px;
 
   background-color: @block__bg;
 

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -1229,9 +1229,9 @@ The visual should be 640x360 (16x9 ratio) and resize to fit the height of the FC
 
 <section class="block block__border block__flush featured-content-module">
     <div class="featured-content-module_text">
-        <p class=h4>
+        <div class="category-slug">
             <span class="featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured </p>
+</span> Featured </div>
         <h2>Feature title</h2>
         <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
         <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>
@@ -1242,9 +1242,9 @@ The visual should be 640x360 (16x9 ratio) and resize to fit the height of the FC
 ```
 <section class="block block__border block__flush featured-content-module">
     <div class="featured-content-module_text">
-        <p class=h4>
+        <div class="category-slug">
             <span class="featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured </p>
+</span> Featured </div>
         <h2>Feature title</h2>
         <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
         <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>


### PR DESCRIPTION
### Changed
- **cf-layout:** Add negative side margin to FCMs so they don't double
  up the border when against a sidebar.
- **cf-layout:** Update recommended FCM markup to use `category-slug`.


## Review

- @cfpb/front-end-team-admin

I am a [bot](https://github.com/cfpb/cfpbot). If I did something wrong, blame a human.

![kitten gif](http://thecatapi.com/api/images/get?format=src&type=gif)