### PR TITLE
Adds external URL support to sidenav

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -36,9 +36,9 @@
   href: "/contributing/"
   subcategories:
   - subtitle: "Testing checklist"
-    subhref: "testing-snippet.html"
+    subhref: "/contributing/testing-snippet.html"
   - subtitle: "Anatomy of a Component"
-    subhref: "anatomy.html"
+    subhref: "/contributing/anatomy.html"
 
 - title: "About"
   href: "/about/"

--- a/_includes/section-nav.html
+++ b/_includes/section-nav.html
@@ -9,9 +9,10 @@
               <li class="nav-secondary_item"><a class="nav-secondary_link" href="{{ site.baseurl }}{{ link.href }}">{{ link.title }}</a></li>
             {% endif %}
             {% for subpage in link.subcategories %}
+              {% assign prefix = subpage.subhref | slice: 0,4 %}
               {% if subpage.subtitle == page.title %}
                 <li><a class="nav-secondary_link nav-secondary_link__current" href="{{ site.baseurl }}{{ subpage.subhref }}">{{ subpage.subtitle }}</a></li>
-              {% else if subpage.subhref | slice: 0,4 == "http" %}
+              {% elsif prefix == "http" %}
                 <li><a class="nav-secondary_link{% if subpage.class %} {{ subpage.class }}{% endif %}" href="{{ subpage.subhref }}">{{ subpage.subtitle }}</a></li>
               {% else %}
                 <li><a class="nav-secondary_link{% if subpage.class %} {{ subpage.class }}{% endif %}" href="{{ site.baseurl }}{{ subpage.subhref }}">{{ subpage.subtitle }}</a></li>

--- a/_includes/section-nav.html
+++ b/_includes/section-nav.html
@@ -11,6 +11,8 @@
             {% for subpage in link.subcategories %}
               {% if subpage.subtitle == page.title %}
                 <li><a class="nav-secondary_link nav-secondary_link__current" href="{{ site.baseurl }}{{ subpage.subhref }}">{{ subpage.subtitle }}</a></li>
+              {% else if subpage.subhref | slice: 0,4 == "http" %}
+                <li><a class="nav-secondary_link{% if subpage.class %} {{ subpage.class }}{% endif %}" href="{{ subpage.subhref }}">{{ subpage.subtitle }}</a></li>
               {% else %}
                 <li><a class="nav-secondary_link{% if subpage.class %} {{ subpage.class }}{% endif %}" href="{{ site.baseurl }}{{ subpage.subhref }}">{{ subpage.subtitle }}</a></li>
               {% endif %}


### PR DESCRIPTION
Fixes https://github.com/cfpb/capital-framework/issues/322

## Changes

- Adds external URL support to sidenav

## Testing

- Locally run `bundle install && bundle exec jekyll serve`
- Visit http://127.0.0.1:4000/capital-framework/contributing/ and http://127.0.0.1:4000/capital-framework/getting-started/ and see that sidenav links work.

## Review

- @Scotchester 
- @contolini 
- @ascott1 