### PR TITLE
Convert Select to Atomic Design

### DIFF
--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -783,6 +783,99 @@ textarea {
     }
 }
 
+/* ==========================================================================
+   cfgov-refresh
+   forms
+   ========================================================================== */
+
+/* topdoc
+    name: m-select menu
+    family: cfgov-forms
+    patterns:
+    - name: m-select menu demo
+      markup: |
+        <div class="m-select">
+            <select>
+                <option value="option1">Option 1</option>
+                <option value="option2">Option 2</option>
+                <option value="option3">Option 3</option>
+                <option value="option4">Option 4</option>
+            </select>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .m-select
+            select
+              option
+      notes:
+        - "Wrap the select in .m-select to help target certain elements"
+    tags:
+    - cfgov-forms
+*/
+
+.m-select {
+    position: relative;
+    margin-top: 0.5em;
+    border: 1px solid @gray-40;
+
+    select {
+        height: unit( 30px / @base-font-size-px, em );
+        width: 100%;
+        padding: unit( 4px / @base-font-size-px, em )
+                 unit( 6px / @base-font-size-px, em );
+        border: 0;
+        outline: 2px solid transparent;
+        appearance: none;
+        background-color: @white;
+        color: @black;
+
+        &:hover,
+        &:active,
+        &:focus {
+            outline-color: @pacific;
+            outline-offset: 0;
+        }
+    }
+
+    select[disabled] {
+        color: @gray-80;
+        background-color: @gray-10;
+    }
+
+    select option:disabled {
+        color: @gray-80;
+    }
+
+    &:after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: unit( 30px / @base-font-size-px, em );
+        width: unit( 30px / @base-font-size-px, em );
+        border-left: 1px solid @gray-40;
+        background-color: @gray-10;
+        color: @gray-80;
+        content: @cf-icon-down;
+        font-family: 'CFPB Minicons';
+        line-height: unit( 30px / @base-font-size-px, em );
+        text-align: center;
+        pointer-events: none;
+    }
+}
+
+// @todo: add modernizr to CF so this works:
+
+.no-csspointerevents .m-select {
+    &:after {
+        height: 0;
+        width: 0;
+        border: 0;
+        content: '';
+    }
+}
+
 //
 // EOF
 //

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -219,6 +219,570 @@ textarea {
 
 }
 
+
+
+
+
+/* ==========================================================================
+   cfgov-refresh
+   forms
+   ========================================================================== */
+
+/* topdoc
+  name: Grouped inputs
+  family: cfgov-forms
+  patterns:
+    - name: Horizontal inputs
+      markup: |
+        <div class="input-group">
+            <input class="input-group_item" type="text">
+            <input class="input-group_item" type="text">
+        </div>
+        <br>
+        <br>
+        <div class="input-group">
+            <select class="input-group_item">
+                <option value="option1">Option 1</option>
+                <option value="option2">Option 2</option>
+                <option value="option3">Option 3</option>
+                <option value="option4">Option 4</option>
+            </select>
+            <select class="input-group_item">
+                <option value="option1">Option 1</option>
+                <option value="option2">Option 2</option>
+                <option value="option3">Option 3</option>
+                <option value="option4">Option 4</option>
+            </select>
+        </div>
+      notes:
+        - "BEFORE moving to Capital Framework please review the work done in
+           the Owning a Home project to make sure this pattern will be useful for
+           both projects."
+  tags:
+    - cfgov-forms
+*/
+
+.input-group {
+
+    &_item,
+    &_item[type="text"] {
+        display: inline-block;
+        box-sizing: border-box;
+        width: 50%;
+        position: relative;
+        // Since an input-group_item can overlap another we need to use z-index
+        // is needed to allow the focused input to pop over unfocused inputs.
+        z-index: 1;
+
+        & + & {
+            margin-left: unit(-5px / @base-font-size-px, em);
+        }
+
+        &:focus {
+            z-index: 2;
+        }
+    }
+
+}
+
+/* topdoc
+  name: Form layouts
+  family: cfgov-forms
+  patterns:
+    - name: Form columns
+      markup: |
+        <div class="form-l">
+            <div class="form-l_col form-l_col-1-3">
+                Form layout column 1
+            </div>
+            <div class="form-l_col form-l_col-1-3">
+                Form layout column 2
+            </div>
+            <div class="form-l_col form-l_col-1-3">
+                Form layout column 3
+            </div>
+        </div>
+      codenotes:
+        - |
+          Structural cheat sheet:
+          -----------------------
+          .form-l
+            .form-l_col.form-l_col-1-3
+    - name: "Form layout modifier: flush"
+      markup: |
+        <div class="form-l form-l__flush">
+            <div class="form-l_col form-l_col-1-3">
+                Form layout column 1
+            </div>
+            <div class="form-l_col form-l_col-1-3">
+                Form layout column 2
+            </div>
+            <div class="form-l_col form-l_col-1-3">
+                Form layout column 3
+            </div>
+        </div>
+      codenotes:
+        - .form-l.form-l__flush
+      notes:
+        - "Form layout columns have left and right gutters. If you want the
+          first and last column in each row to sit flush left/right
+          respectively then use the .form-l__flush modifier."
+    - name: Form layout columns
+      codenotes:
+        - .form-l_col
+        - .form-l_col-1-2
+        - .form-l_col-1-3
+        - .form-l_col-1-4
+      notes:
+        - ".form-l_col-1-3 elements are stacked for small screens. When the
+          viewport reaches 600px they transform into columns with one half the
+          width of the container. When the viewport reaches 768px their width
+          updates to one third of the container."
+  tags:
+    - cfgov-forms
+*/
+
+.form-l {
+    &__flush {
+        .respond-to-min(@bp-lg-min, {
+            .grid_nested-col-group();
+        });
+    }
+    &__float {
+        .respond-to-min(@bp-lg-min, {
+            .u-clearfix();
+            & .form-l_col {
+                display: block;
+                float: left;
+                margin-right: 0;
+            }
+        });
+    }
+
+    .respond-to-min(@bp-sm-min, {
+        .grid_nested-col-group();
+    });
+}
+
+.form-l_col {
+    margin-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
+
+    &__flush-bottom {
+        // Used when a col is wrapping inner cols that
+        // have their own margin
+        margin-bottom: 0;
+    }
+
+    input[type="text"],
+    input[type="search"],
+    input[type="email"],
+    input[type="url"],
+    input[type="tel"],
+    input[type="number"],
+    select,
+    textarea {
+        // TODO: Move border-box value to cf-forms.
+        box-sizing: border-box;
+        width: 100%;
+    }
+}
+
+.respond-to-min(@bp-sm-min, {
+    .form-l_col-1-4 {
+        .grid_column(3);
+    }
+
+    .form-l_col-1-2 {
+        .grid_column(6);
+    }
+
+    .form-l_col-1-3 {
+        .grid_column(4);
+    }
+
+    .form-l_col-2-3 {
+        .grid_column(8);
+    }
+
+    .form-l_col-1 {
+        .grid_column(12);
+    }
+});
+
+
+/* topdoc
+  name: Checkboxes and radio buttons
+    family: cf-forms
+    notes:
+      - "CSS for checkboxes and radio buttons requires following a specific HTML structure for each type of input, otherwise the styles will not be properly applied."
+      - "Labels should follow the input"
+      - "Remember to use 'for' and 'id' attributes so that selected/checked styles function properly."
+      - "Remember to use the same 'name' attribute for each set of radio buttons."
+    patterns:
+      - name: Checkbox
+        markup: |
+            <fieldset class="u-reset">
+                <div class="form-l_col
+                            form-l_col-1">
+                    <legend class="form-label-header">
+                        Pets you own
+                    </legend>
+                </div>
+                <div class="form-l_col
+                            form-l_col-1-2
+                            form-l-col__inset">
+                    <div class="form-l-inset_container">
+                        <input class="cf-input"
+                               type="checkbox"
+                               name="form_id"
+                               id="input_id_cats">
+                        <label class="cf-input_label"
+                               for="input_id_cats">
+                            Cats
+                        </label>
+                    </div>
+                </div>
+                <div class="form-l_col
+                            form-l_col-1-2
+                            form-l-inset">
+                    <div class="form-l-inset_container">
+                        <input class="cf-input"
+                               type="checkbox"
+                               name="form_id"
+                               id="input_id_dogs">
+                        <label class="cf-input_label"
+                               for="input_id_dogs">
+                            Dogs
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+        codenotes:
+          - |
+            Structural cheat sheet:
+            -----------------------
+            fieldset
+                .form-l_col-1
+                    legend
+                .form-l-inset
+                    .form-l-inset_container
+                        input[type="checkbox"].cf-input
+                        label.cf-input_label
+        notes:
+          - "Use the markup structure above to add checkbox .cf-input elements."
+      - name: Radio buttons
+        markup: |
+            <fieldset class="u-reset">
+                <div class="form-l_col
+                            form-l_col-1">
+                    <legend class="form-label-header">
+                        Pick an option
+                    </legend>
+                </div>
+                <div class="form-l_col
+                            form-l_col-1-2
+                            form-l-inset">
+                    <div class="form-l-inset_container">
+                        <input class="cf-input"
+                               type="radio"
+                               name="form_id"
+                               id="input_id_1">
+                        <label class="cf-input_label"
+                               for="input_id_1">
+                            Yes
+                        </label>
+                    </div>
+                </div>
+                <div class="form-l_col
+                            form-l_col-1-2
+                            form-l-inset">
+                    <div class="form-l-inset_container">
+                        <input class="cf-input"
+                               type="radio"
+                               name="form_id"
+                               id="input_id_2">
+                        <label class="cf-input_label"
+                               for="input_id_2">
+                            No
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+        codenotes:
+          - |
+            Structural cheat sheet:
+            -----------------------
+            fieldset
+                .form-l_col-1
+                    legend
+                .form-l-inset
+                    .form-l-inset_container
+                        input[type="radio"].cf-input
+                        label.cf-input_label
+        notes:
+          - "Use the markup structure above to add radio button .cf-input elements."
+    tags:
+      - cf-forms
+*/
+
+@input-active:          #0072ce; // pacific.
+
+@input-bg-disabled:     #5a5d61; // gray;
+@input-border-disabled: #b4b5b6; // gray-40;
+
+// Insets
+@input-inset-bg:        #d2d3d5; // gray-20;
+@input-inset-selected:  #d6e8fa; // pacific-20;
+
+@checkbox-width: unit( 18px / @base-font-size-px, em);
+@radio-width: unit( 14px / @base-font-size-px, em);
+
+.cf-input {
+
+
+    &[type="checkbox"],
+    &[type="radio"]{
+        .u-visually-hidden();
+
+        .lt-ie9 & {
+            height: 20px;
+            width: 20px;
+            border: 0;
+            float: left;
+            margin: 1em;
+            position: static;
+            width: auto;
+        }
+    }
+
+    &[type="checkbox"] + label,
+    &[type="radio"] + label {
+        cursor: pointer;
+        margin-bottom: 0.5em;
+    }
+
+    &[type="checkbox"] + label::before,
+    &[type="radio"] + label::before {
+        background: white;
+        content: '\a0';
+        display: inline-block;
+        // margin-top: unit( 2px / @base-font-size-px, em);
+        margin-right: .6em;
+        vertical-align: middle;
+    }
+
+    &[type="radio"] + label::before {
+        height: @radio-width;
+        width: @radio-width;
+        border-radius: 100%;
+        box-shadow: 0 0 0 3px #fff, 0 0 0 4px @input-border;
+    }
+
+    &[type="radio"]:checked + label::before {
+        background-color: @input-active;
+        box-shadow: 0 0 0 3px @input-bg, 0 0 0 4px @input-active;
+    }
+
+    &[type="radio"]:hover + label::before {
+        box-shadow: 0 0 0 3px @input-bg, 0 0 0 4px @input-active;
+    }
+
+    &[type="radio"]:focus + label::before {
+        box-shadow: 0 0 0 2px @input-bg, 0 0 0 4px @input-active;
+    }
+
+    &[type="checkbox"] + label::before {
+        height: @checkbox-width;
+        width: @checkbox-width;
+        box-shadow: 0 0 0 1px @input-bg, 0 0 0 2px @input-border;
+    }
+
+    &[type="checkbox"]:checked + label::before {
+        content: @cf-icon-approved;
+        font-family: 'CFPB Minicons';
+        font-size: unit( 16px / @base-font-size-px, em);
+        box-shadow: 0 0 0 1px @input-bg, 0 0 0 2px @input-active;
+        text-align: center;
+    }
+
+    &[type="checkbox"]:hover + label::before {
+        box-shadow: 0 0 0 1px @input-bg, 0 0 0 2px @input-active;
+    }
+
+    &[type="checkbox"]:focus + label::before {
+        box-shadow: 0 0 0 2px @input-active;
+    }
+
+    &[type="checkbox"]:disabled + label {
+        color: @input-border-disabled;
+    }
+
+    &[type="checkbox"]:disabled + label::before,
+    &[type="radio"]:disabled + label::before {
+      background: @input-bg-disabled;
+      box-shadow: 0 0 0 1px @input-bg, 0 0 0 2px @input-border-disabled;
+      cursor: not-allowed;
+    }
+
+}
+
+
+
+/* topdoc
+    name: Form layouts
+    family: cf-forms
+    patterns:
+      - name: Form one-half columns
+        markup: |
+          <div class="form-l">
+              <div class="form-l_col form-l_col-1-3">
+                  Form layout column 1
+              </div>
+              <div class="form-l_col form-l_col-1-2">
+                  Form layout column 2
+              </div>
+          </div>
+        codenotes:
+          - |
+            Structural cheat sheet:
+            -----------------------
+            .form-l
+              .form-l_col.form-l_col-1-2
+      - name: Form one-third columns
+        markup: |
+          <div class="form-l">
+              <div class="form-l_col form-l_col-1-3">
+                  Form layout column 1
+              </div>
+              <div class="form-l_col form-l_col-1-3">
+                  Form layout column 2
+              </div>
+              <div class="form-l_col form-l_col-1-3">
+                  Form layout column 3
+              </div>
+          </div>
+        codenotes:
+          - |
+            Structural cheat sheet:
+            -----------------------
+            .form-l
+              .form-l_col.form-l_col-1-3
+        notes:
+          - ".form-l_col-1-3 elements are stacked for small screens. When the
+            viewport reaches 600px they transform into columns with one half the
+            width of the container. When the viewport reaches 768px their width
+            updates to one third of the container."
+      - name: "Form layout modifier: flush"
+        markup: |
+          <div class="form-l form-l__flush">
+              <div class="form-l_col form-l_col-1-3">
+                  Form layout column 1
+              </div>
+              <div class="form-l_col form-l_col-1-3">
+                  Form layout column 2
+              </div>
+              <div class="form-l_col form-l_col-1-3">
+                  Form layout column 3
+              </div>
+          </div>
+        codenotes:
+          - .form-l.form-l__flush
+        notes:
+          - "Form layout columns have left and right gutters. If you want the
+            first and last column in each row to sit flush left/right
+            respectively then use the .form-l__flush modifier."
+      - name: Form layout inset
+        markup: |
+          <div class="form-l form-l__flush">
+              <div class="form-l_col form-l_col-1-2 form-l-inset">
+                  <div class="form-l-inset_container">
+                      <input class="cf-input cf-input_hidden" type="radio" name="cf-input-example_default-inset" id="cf-input-example_default-inset">
+                      <label class="cf-input_label" for="cf-input-example_default-inset">
+                          <span class="cf-input_text">Yes</span>
+                      </label>
+                      <span class="cf-input_radio"></span>
+                  </div>
+              </div>
+              <div class="form-l_col form-l_col-1-2 form-l-inset">
+                  <div class="form-l-inset_container">
+                      <input class="cf-input cf-input_hidden" type="radio" name="cf-input-example_default-inset" id="cf-input-example_default-inset2">
+                      <label class="cf-input_label" for="cf-input-example_default-inset2">
+                          <span class="cf-input_text">No</span>
+                      </label>
+                      <span class="cf-input_radio"></span>
+                  </div>
+              </div>
+          </div>
+        codenotes:
+          - |
+            Structural cheat sheet:
+            -----------------------
+            .form-l-inset
+              .form-l-inset_container
+        notes:
+          - ".form-l-inset_container elements have larger target areas for easier user interaction."
+    tags:
+      - cf-forms
+*/
+
+.form-l-inset {
+    border-right-width: 2.5px;
+    + .form-l_col-1-2.form-l-inset:nth-child(odd) { border-left-width: 2.5px; }
+    &.form-l_col-1-2:nth-child(odd),
+    &.form-l_col-1-2:last-child { border-right-width: 15px; }
+
+      .form-l-inset_container {
+          background: @input-inset-bg;
+
+          .cf-input_label {
+              margin: 0;
+              padding: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em )
+                   unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em )
+                   unit( ( @grid_gutter-width / 1.75 ) / @base-font-size-px, em );
+          }
+
+          .cf-input_text {
+              margin-left: unit( @grid_gutter-width / @base-font-size-px, em );
+          }
+
+          .cf-input_radio,
+          .cf-input_checkbox {
+              position: absolute;
+              top: unit( ( @grid_gutter-width / 1.75 ) / @base-font-size-px, em );
+              left: 15px;
+              z-index: 3;
+          }
+
+          &:hover,
+          &:focus,
+          &.focus {
+              .cf-input_checkbox,
+              .cf-input_radio {
+                  box-shadow: 0px 0px 0px 2px @input-border-focus;
+                  // Older IE does not support border-radius or box-shadow it's ok to
+                  // use outline here.
+                  .lt-ie9 & {
+                      outline: 1px solid @input-border-focus;
+                  }
+              }
+          }
+
+        &.selected .cf-input_label,
+        &.focus .cf-input_label,
+        &:focus .cf-input_label,
+        &:hover .cf-input_label,
+        input:focus + .cf-input_label,
+        input:checked + .cf-input_label     {
+            outline: 2px solid @input-border-focus;
+        }
+
+        &.selected .cf-input_label,
+        input:checked + .cf-input_label {
+            background-color: @input-inset-selected;
+        }
+    }
+}
+
 //
 // EOF
 //

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -83,10 +83,20 @@ See the 'Form icons' section below for guidance on adding icons to states.
 
 ### Disabled state
 
-<input class="disabled" disabled="true" autocomplete="off" type="text" value="Validated input" title="Test input">
+<input class="disabled"
+       disabled="true"
+       autocomplete="off"
+       type="text"
+       value="Validated input"
+       title="Test input">
 
 ```
-<input class="disabled" disabled="true" autocomplete="off" type="text" value="Validated input" title="Test input">
+<input class="disabled"
+       disabled="true"
+       autocomplete="off"
+       type="text"
+       value="Validated input"
+       title="Test input">
 ```
 
 ## Form icons
@@ -290,7 +300,8 @@ Provides sizeable margins between groups of form elements.
 
 <div class="btn-inside-input">
     <input type="text"
-           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable." title="Test input">
+           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable."
+           title="Test input">
     <button class="btn btn__link">
         Clear
         <span class="cf-icon cf-icon-delete"></span>
@@ -300,7 +311,8 @@ Provides sizeable margins between groups of form elements.
 ```
 <div class="btn-inside-input">
     <input type="text"
-           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable." title="Test input">
+           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable."
+           title="Test input">
     <button class="btn btn__link">
         Clear
         <span class="cf-icon cf-icon-delete"></span>
@@ -313,7 +325,8 @@ Provides sizeable margins between groups of form elements.
 <div class="btn-inside-input">
     <input class="input__super"
            type="text"
-           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable." title="Test input">
+           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable."
+           title="Test input">
     <button class="btn btn__super btn__link btn__secondary">
         Clear
         <span class="cf-icon cf-icon-delete"></span>
@@ -324,10 +337,93 @@ Provides sizeable margins between groups of form elements.
 <div class="btn-inside-input">
     <input class="input__super"
            type="text"
-           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable." title="Test input">
+           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable."
+           title="Test input">
     <button class="btn btn__super btn__link btn__secondary">
         Clear
         <span class="cf-icon cf-icon-delete"></span>
     </button>
 </div>
 ```
+
+### Checkboxes with large target areas
+
+<fieldset class="u-reset">
+    <div class="form-l_col
+                form-l_col-1">
+        <legend class="form-label-header">
+            Pets you own
+        </legend>
+    </div>
+    <div class="form-l_col
+                form-l_col-1-2
+                form-l-col__inset">
+        <div class="form-l-inset_container">
+            <input class="cf-input"
+                   type="checkbox"
+                   name="form_id"
+                   id="input_id_cats">
+            <label class="cf-input_label"
+                   for="input_id_cats">
+                Cats
+            </label>
+        </div>
+    </div>
+    <div class="form-l_col
+                form-l_col-1-2
+                form-l-inset">
+        <div class="form-l-inset_container">
+            <input class="cf-input"
+                   type="checkbox"
+                   name="form_id"
+                   id="input_id_dogs">
+            <label class="cf-input_label"
+                   for="input_id_dogs">
+                Dogs
+            </label>
+        </div>
+    </div>
+</fieldset>
+
+```
+
+```
+
+### Radio buttons with large target areas
+
+<fieldset class="u-reset">
+    <div class="form-l_col
+                form-l_col-1">
+        <legend class="form-label-header">
+            Pick an option
+        </legend>
+    </div>
+    <div class="form-l_col
+                form-l_col-1-2
+                form-l-inset">
+        <div class="form-l-inset_container">
+            <input class="cf-input"
+                   type="radio"
+                   name="form_id"
+                   id="input_id_1">
+            <label class="cf-input_label"
+                   for="input_id_1">
+                Yes
+            </label>
+        </div>
+    </div>
+    <div class="form-l_col
+                form-l_col-1-2
+                form-l-inset">
+        <div class="form-l-inset_container">
+            <input class="cf-input"
+                   type="radio"
+                   name="form_id"
+                   id="input_id_2">
+            <label class="cf-input_label"
+                   for="input_id_2">
+                No
+            </label>
+        </div>
+    </div>
+</fieldset>

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -427,3 +427,61 @@ Provides sizeable margins between groups of form elements.
         </div>
     </div>
 </fieldset>
+
+
+## Select dropdown
+
+### Required select
+
+<div class="form-l_col form-l_col-1">
+    <label class="form-label-header"
+           for="select_example">
+            Required select example
+    </label>
+    <div class="m-select">
+        <select id="select_example" required>
+            <option value="option1">Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+            <option value="option4">Option 4</option>
+        </select>
+    </div>
+</div>
+
+
+### Disabled select
+
+<div class="form-l_col form-l_col-1">
+    <label class="form-label-header"
+           for="select_example">
+            Disabled select example
+    </label>
+    <div class="m-select">
+        <select id="select_example" disabled>
+            <option value="option1">Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+            <option value="option4">Option 4</option>
+        </select>
+    </div>
+</div>
+
+
+### Optional select
+
+<div class="form-l_col form-l_col-1">
+    <label class="form-label-header"
+           for="select_example">
+            Optional select example
+            <span class="micro-copy">&nbsp;(Optional)</span>
+    </label>
+    <div class="m-select">
+        <select id="select_example">
+            <option value="" disabled selected>Please select</option>
+            <option value="option1">Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+            <option value="option4">Option 4</option>
+        </select>
+    </div>
+</div>


### PR DESCRIPTION
Part of Atomic design issue https://github.com/cfpb/capital-framework/issues/345

Adds cf-forms from cfgov-refresh (based on @anselmbradford's update_form_elems branch) + makes select element a molecule

## Additions

- cf-forms.less from cfgov-refresh
- select element CSS from cfpb/cfgov-refresh#1273: New inputs and textareas
- markup for select elements in `usage.md`

## Testing

- npm link this and check out the following branch on capital-framework-sandbox to test: https://github.com/cfarm/capital-framework-sandbox/tree/atomic/cf-forms

## Review

- @jimmynotjim or @KimberlyMunoz 

## Screenshots
![screen shot 2016-07-20 at 11 32 01 am](https://cloud.githubusercontent.com/assets/702526/16992565/c1f43dea-4e6d-11e6-8478-6599f91e226b.png)
![screen shot 2016-07-20 at 11 31 52 am](https://cloud.githubusercontent.com/assets/702526/16992566/c1f459ce-4e6d-11e6-8512-b036f51652fb.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
