### PR TITLE
Fixes 348 - adds autoprefixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Added
 -
+- Added CSS autoprefixer to build pipeline.
 
 ### Changed
 - **cf-typography:** [MINOR] Many documentation fixes and standardization

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 The Consumer Financial Protection Bureau's user interface framework.
 
+| buttons | core | expandables | forms | grid | icons | layout | pagination | typography |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| [![npm](https://img.shields.io/npm/v/cf-buttons.svg?style=flat-square)](https://www.npmjs.com/package/cf-buttons)  | [![npm](https://img.shields.io/npm/v/cf-core.svg?style=flat-square)](https://www.npmjs.com/package/cf-core)  | [![npm](https://img.shields.io/npm/v/cf-expandables.svg?style=flat-square)](https://www.npmjs.com/package/cf-expandables)  | [![npm](https://img.shields.io/npm/v/cf-forms.svg?style=flat-square)](https://www.npmjs.com/package/cf-forms)  | [![npm](https://img.shields.io/npm/v/cf-grid.svg?style=flat-square)](https://www.npmjs.com/package/cf-grid)  | [![npm](https://img.shields.io/npm/v/cf-icons.svg?style=flat-square)](https://www.npmjs.com/package/cf-icons)  | [![npm](https://img.shields.io/npm/v/cf-layout.svg?style=flat-square)](https://www.npmjs.com/package/cf-layout)  | [![npm](https://img.shields.io/npm/v/cf-pagination.svg?style=flat-square)](https://www.npmjs.com/package/cf-pagination)  | [![npm](https://img.shields.io/npm/v/cf-typography.svg?style=flat-square)](https://www.npmjs.com/package/cf-typography)  |
+
+## Installation
+
 ```sh
 npm install capital-framework
 ```
@@ -13,7 +19,11 @@ npm install cf-buttons
 npm install cf-expandables
 ```
 
+### Project scaffolding
+
 Want some boilerplate?
+There is a Yeoman generator through the
+[generator-cf](https://github.com/cfpb/generator-cf) project:
 
 ```sh
 npm install -g yo generator-cf
@@ -21,10 +31,29 @@ mkdir my-new-project && cd $_
 yo cf
 ```
 
-| buttons | core | expandables | forms | grid | icons | layout | pagination | typography |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| [![npm](https://img.shields.io/npm/v/cf-buttons.svg?style=flat-square)](https://www.npmjs.com/package/cf-buttons)  | [![npm](https://img.shields.io/npm/v/cf-core.svg?style=flat-square)](https://www.npmjs.com/package/cf-core)  | [![npm](https://img.shields.io/npm/v/cf-expandables.svg?style=flat-square)](https://www.npmjs.com/package/cf-expandables)  | [![npm](https://img.shields.io/npm/v/cf-forms.svg?style=flat-square)](https://www.npmjs.com/package/cf-forms)  | [![npm](https://img.shields.io/npm/v/cf-grid.svg?style=flat-square)](https://www.npmjs.com/package/cf-grid)  | [![npm](https://img.shields.io/npm/v/cf-icons.svg?style=flat-square)](https://www.npmjs.com/package/cf-icons)  | [![npm](https://img.shields.io/npm/v/cf-layout.svg?style=flat-square)](https://www.npmjs.com/package/cf-layout)  | [![npm](https://img.shields.io/npm/v/cf-pagination.svg?style=flat-square)](https://www.npmjs.com/package/cf-pagination)  | [![npm](https://img.shields.io/npm/v/cf-typography.svg?style=flat-square)](https://www.npmjs.com/package/cf-typography)  |
+### Using Less files directly
 
+If you don't want to use the
+[generator-cf](https://github.com/cfpb/generator-cf) Yeoman generator,
+you can download the Capital Framework source files and
+import them into your project.
+
+Run `npm install capital-framework`.
+This will download Capital Framework to your project's `node_modules` folder.
+You can then import the framework into your application's primary Less file:
+
+```less
+@import (less) "node_modules/capital-framework/src/capital-framework.less";
+
+// the rest of your stylesheet...
+```
+
+You may want to install individual [Capital Framework Components](https://cfpb.github.io/capital-framework/components/), so that you can leave out things you don't need, or to make it possible to update the components one-at-a-time in the future.
+
+> NOTE: Be sure to run the Less files through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will not work
+  perfectly in older browsers.
 
 ## Contributing
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@
 /*
   gulpfile.js
   ===========
-  
+
   Rather than manage one giant configuration file responsible
   for creating multiple tasks, each task has been broken out into
   its own file in gulp/tasks. Any files in that directory get

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fs-readdir-promise": "^1.0.1",
     "gulp": "^3.9.0",
     "gulp-apply-template": "0.0.2",
+    "gulp-autoprefixer": "3.1.0",
     "gulp-cssmin": "^0.1.7",
     "gulp-data": "^1.2.0",
     "gulp-debug": "^2.1.2",

--- a/scripts/gulp/clean.js
+++ b/scripts/gulp/clean.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var gulp = require( 'gulp' );
-var $ = require( 'gulp-load-plugins' )();
+var plugins = require( 'gulp-load-plugins' )();
 var component = require('./parseComponentName');
 
 gulp.task('clean:tmp', function() {
   return gulp.src('./tmp/' + (component || ''), { read: false })
-    .pipe($.rimraf());
+    .pipe(plugins.rimraf());
 });

--- a/scripts/gulp/copy.js
+++ b/scripts/gulp/copy.js
@@ -2,14 +2,14 @@
 
 var gulp = require( 'gulp' );
 var fs = require('fs');
-var $ = require( 'gulp-load-plugins' )();
+var plugins = require('gulp-load-plugins')();
 var component = require('./parseComponentName');
 var merge = require('deepmerge');
 var baseManifest = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 
 gulp.task( 'copy:components:boilerplate', function() {
   return gulp.src(['./src/' + (component || '*'), '!./src/*.js', '!./src/*.less'])
-    .pipe($.foreach(function(stream, file) {
+    .pipe(plugins.foreach(function(stream, file) {
       var component = file.path.split('/').pop();
       gulp.src( './scripts/templates/component-boilerplate/*' )
           .pipe( gulp.dest('./tmp/' + component) );
@@ -19,7 +19,7 @@ gulp.task( 'copy:components:boilerplate', function() {
 
 gulp.task( 'copy:components:source', function() {
   return gulp.src(['./src/' + (component || '*'), '!./src/*.js', '!./src/*.less'])
-    .pipe($.foreach(function(stream, file) {
+    .pipe(plugins.foreach(function(stream, file) {
       var component = file.path.split('/').pop(),
           src = [
                   file.path + '/**',
@@ -36,7 +36,7 @@ gulp.task( 'copy:components:source', function() {
 
 gulp.task( 'copy:components:manifest', function() {
   return gulp.src('./src/' + (component || '*') + '/package.json')
-    .pipe($.data(function(file) {
+    .pipe(plugins.data(function(file) {
       // Remove any dependencies from CF's package.json, we don't want components
       // to have them.
       delete baseManifest.dependencies;
@@ -46,9 +46,9 @@ gulp.task( 'copy:components:manifest', function() {
       delete manifest.devDependencies;
       file.contents = new Buffer(JSON.stringify(manifest));
     }))
-    .pipe($.rename(function(path) {
+    .pipe(plugins.rename(function(path) {
       path.dirname = component || path.dirname;
     }))
-    .pipe($.jsonFormat(2))
+    .pipe(plugins.jsonFormat(2))
     .pipe(gulp.dest('./tmp'));
 } );

--- a/scripts/gulp/parseComponentName.js
+++ b/scripts/gulp/parseComponentName.js
@@ -1,4 +1,7 @@
-var argv = require('minimist')(process.argv.slice(2)),
-    component = argv.component || argv.c;
+'use strict';
+
+var minimalist = require('minimist');
+var argv = minimalist(process.argv.slice(2));
+var component = argv.component || argv.c;
 
 module.exports = component;

--- a/scripts/gulp/scripts.js
+++ b/scripts/gulp/scripts.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var gulp = require('gulp'),
-    named = require('vinyl-named'),
-    $ = require('gulp-load-plugins')(),
-    component = require('./parseComponentName');
+var gulp = require('gulp');
+var named = require('vinyl-named');
+var plugins = require('gulp-load-plugins')();
+var component = require('./parseComponentName');
 
 // Compile the master capital-framework.less file.
 gulp.task( 'scripts:cf', function() {
   return gulp.src('./src/capital-framework.js')
-    .pipe($.webpack())
-    .pipe($.rename({
+    .pipe(plugins.webpack())
+    .pipe(plugins.rename({
       basename: 'capital-framework'
     }))
     .pipe(gulp.dest('./dist'))
-    .pipe($.uglify())
-    .pipe($.rename({
+    .pipe(plugins.uglify())
+    .pipe(plugins.rename({
       suffix: '.min'
     }))
     .pipe(gulp.dest('./dist'));
@@ -25,27 +25,27 @@ gulp.task( 'scripts:cf', function() {
 gulp.task( 'scripts:components', function() {
   var tmp = {};
   return gulp.src('./src/' + (component || '*') + '/src/*.js')
-    .pipe($.ignore.exclude(function(vf) {
+    .pipe(plugins.ignore.exclude(function(vf) {
       // Exclude JS files that don't share the same name as the directory
       // they're in. This filters out utility files.
       var matches = vf.path.match(/\/([\w-]*)\/src\/([\w-]*)\.js/);
       return matches[1] !== matches[2];
     }))
     .pipe(named())
-    .pipe($.rename(function (path) {
+    .pipe(plugins.rename(function (path) {
       tmp[path.basename] = path;
     }))
-    .pipe($.webpack({
+    .pipe(plugins.webpack({
       output: {
-        filename : '[name].js'    
+        filename : '[name].js'
       }
     }))
-    .pipe($.rename(function (path) {
+    .pipe(plugins.rename(function (path) {
       path.dirname = tmp[path.basename].dirname.replace('/src', '');
     }))
     .pipe(gulp.dest('./tmp'))
-    .pipe($.uglify())
-    .pipe($.rename({
+    .pipe(plugins.uglify())
+    .pipe(plugins.rename({
       suffix: '.min'
     }))
     .pipe(gulp.dest('./tmp'));

--- a/scripts/gulp/styles.js
+++ b/scripts/gulp/styles.js
@@ -1,31 +1,44 @@
 'use strict';
 
-var gulp = require('gulp'),
-    $ = require('gulp-load-plugins')(),
-    component = require('./parseComponentName');
+var gulp = require('gulp');
+var plugins = require('gulp-load-plugins')();
+var component = require('./parseComponentName');
 
-// Compile the master capital-framework.less file.
-gulp.task( 'styles:cf', function() {
+/**
+ * Compile the master capital-framework.less file.
+ * @returns {PassThrough} A source stream.
+ */
+function stylesCf() {
   return gulp.src('./src/capital-framework-with-grid.less')
-    .pipe($.less({
+    .pipe(plugins.less({
       paths: ['node_modules/cf-*/src/']
     }))
-    .pipe($.rename({
+    .pipe( plugins.autoprefixer( {
+      browsers: [ 'last 2 version',
+                  'not ie < 7',
+                  'android 4',
+                  'BlackBerry 7',
+                  'BlackBerry 10' ]
+    } ) )
+    .pipe(plugins.rename({
       basename: 'capital-framework'
     }))
     .pipe(gulp.dest('./dist'))
-    .pipe($.cssmin())
-    .pipe($.rename({
+    .pipe(plugins.cssmin())
+    .pipe(plugins.rename({
       suffix: '.min'
     }))
     .pipe(gulp.dest('./dist'));
-} );
+}
 
-// Compile all the individual component files so that users can `npm install`
-// a single component if they desire.
-gulp.task( 'styles:components', function() {
+/**
+ * Compile all the individual component files so that users can `npm install`
+ * a single component if they desire.
+ * @returns {PassThrough} A source stream.
+ */
+function stylesComponents() {
   return gulp.src('./src/' + (component || '*') + '/src/*.less')
-    .pipe($.ignore.exclude(function(vf) {
+    .pipe(plugins.ignore.exclude(function(vf) {
       // Exclude Less files that don't share the same name as the directory
       // they're in. This filters out things like cf-vars.less but still
       // includes cf-core.less.
@@ -33,34 +46,59 @@ gulp.task( 'styles:components', function() {
       // We also exclude cf-grid. It needs its own special task. See below.
       return matches[2] === 'cf-grid' || matches[1] !== matches[2];
     }))
-    .pipe($.less({
+    .pipe(plugins.less({
       paths: ['node_modules/cf-*/src/']
     }))
-    .pipe($.rename(function (path) {
+    .pipe( plugins.autoprefixer( {
+      browsers: [ 'last 2 version',
+                  'not ie < 7',
+                  'android 4',
+                  'BlackBerry 7',
+                  'BlackBerry 10' ]
+    } ) )
+    .pipe(plugins.rename(function (path) {
       path.dirname = component || path.dirname;
       path.dirname = path.dirname.replace('/src','');
     }))
     .pipe(gulp.dest('./tmp'))
-    .pipe($.cssmin())
-    .pipe($.rename({
+    .pipe(plugins.cssmin())
+    .pipe(plugins.rename({
       suffix: '.min'
     }))
     .pipe(gulp.dest('./tmp'));
-} );
+}
 
-// cf-grid needs to compile cf-grid-generated.less
-gulp.task( 'styles:grid', function() {
+/**
+ * cf-grid needs to compile cf-grid-generated.less.
+ * @returns {PassThrough} A source stream.
+ */
+function stylesGrid() {
   return gulp.src('./src/cf-grid/src-generated/*.less')
-    .pipe($.less({
+    .pipe(plugins.less({
       paths: ['node_modules/cf-*/src/']
     }))
-    .pipe($.rename({
+    .pipe( plugins.autoprefixer( {
+      browsers: [ 'last 2 version',
+                  'not ie < 7',
+                  'android 4',
+                  'BlackBerry 7',
+                  'BlackBerry 10' ]
+    } ) )
+    .pipe(plugins.rename({
       basename: 'cf-grid'
     }))
     .pipe(gulp.dest('./tmp/cf-grid'))
-    .pipe($.cssmin())
-    .pipe($.rename({
+    .pipe(plugins.cssmin())
+    .pipe(plugins.rename({
       suffix: '.min'
     }))
     .pipe(gulp.dest('./tmp/cf-grid'));
-} );
+}
+
+gulp.task( 'styles:cf', stylesCf );
+gulp.task( 'styles:components', stylesComponents );
+gulp.task( 'styles:grid', stylesGrid );
+
+gulp.task( 'styles', [
+  'styles:cf'
+] );

--- a/scripts/gulp/template.js
+++ b/scripts/gulp/template.js
@@ -1,18 +1,18 @@
 'use strict';
 
 var gulp = require( 'gulp' );
-var $ = require( 'gulp-load-plugins' )();
+var plugins = require( 'gulp-load-plugins' )();
 var component = require('./parseComponentName');
 var fs = require('fs');
 
 gulp.task('template:readmes', function() {
   var pkgs = './src/' + (component || '*') + '/package.json';
   return gulp.src(pkgs)
-    .pipe($.data(function(file) {
+    .pipe(plugins.data(function(file) {
       var content = String(file.contents);
       return JSON.parse(content);
     }))
-    .pipe($.applyTemplate({
+    .pipe(plugins.applyTemplate({
       engine: 'lodash',
       template: './scripts/templates/README.md.tmpl',
       props: ['contents', 'data'],
@@ -20,7 +20,7 @@ gulp.task('template:readmes', function() {
         return file.data;
       }
     }))
-    .pipe($.rename(function(path) {
+    .pipe(plugins.rename(function(path) {
       path.dirname = component || path.dirname;
       path.basename = 'README';
       path.extname = '.md';
@@ -30,8 +30,8 @@ gulp.task('template:readmes', function() {
 
 gulp.task('template:usage', function () {
   return gulp.src('./src/' + (component || '*') + '/usage.md')
-    .pipe($.markdown())
-    .pipe($.data(function(file) {
+    .pipe(plugins.markdown())
+    .pipe(plugins.data(function(file) {
       var content = String(file.contents),
           component = file.path.split('/'),
           component = component[component.length - 2];
@@ -41,7 +41,7 @@ gulp.task('template:usage', function () {
         hasJS: fs.existsSync('./src/' + component + '/src/' + component + '.js')
       };
     }))
-    .pipe($.applyTemplate({
+    .pipe(plugins.applyTemplate({
       engine: 'lodash',
       template: './scripts/templates/preview.html.tmpl',
       props: ['contents', 'data'],
@@ -49,7 +49,7 @@ gulp.task('template:usage', function () {
         return file.data;
       }
     }))
-    .pipe($.rename(function (path) {
+    .pipe(plugins.rename(function (path) {
       path.dirname = component || path.dirname;
     }))
     .pipe(gulp.dest('tmp'));

--- a/scripts/gulp/test.js
+++ b/scripts/gulp/test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var gulp = require('gulp'),
-    $ = require('gulp-load-plugins')(),
-    component = require('./parseComponentName');
+var gulp = require('gulp');
+var plugins = require('gulp-load-plugins')();
+var component = require('./parseComponentName');
 
 gulp.task( 'test', function() {
-    return gulp.src('./test/' + (component || '*') + '.html')
-        .pipe($.qunit({timeout: 20}));
+  return gulp.src('./test/' + (component || '*') + '.html')
+  	.pipe(plugins.qunit({timeout: 20}));
 } );

--- a/scripts/templates/README.md.tmpl
+++ b/scripts/templates/README.md.tmpl
@@ -16,6 +16,11 @@ a front end framework developed at the
 Detailed instructions can be found at the Capital Framework
 [documentation site](https://cfpb.github.io/capital-framework/).
 
+> NOTE: Be sure to run the Less files through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will not work
+  perfectly in older browsers.
+
 
 ## Getting involved
 

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -4,6 +4,12 @@
 - [Disabled button](#disabled)
 - [Super button](#super)
 
+> NOTE: If you use `cf-buttons.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
+
 ## Variables
 
 ### Color variables

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -1,5 +1,10 @@
 The cf-core component acts as the backbone for Capital Framework. It's made up of four child components `cf-vars`, `cf-media-queries`, `cf-utilities`, and `cf-base`.
 
+> NOTE: If you use any cf-core Less file directly,
+  be sure to run the files through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
 
 ## Vars
 

--- a/src/cf-expandables/usage.md
+++ b/src/cf-expandables/usage.md
@@ -2,6 +2,11 @@ Expandables are components that have additional content that can be
 opened (expanded) and closed (collapsed). They can appear on their own
 or can appear in groups.
 
+> NOTE: If you use `cf-expandables.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
 
 ## Dependencies
 

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -1,5 +1,11 @@
 # Forms
 
+> NOTE: If you use `cf-forms.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
+
 ## Vars
 
 Theme variables for setting the color and sizes throughout the project. Overwrite them in your own project by duplicating the variable `@key: value`.

--- a/src/cf-grid/usage.md
+++ b/src/cf-grid/usage.md
@@ -30,6 +30,11 @@ and apply the mixins to those semantic classes, like this:
 
 Read on for more details on the variables and mixins this component provides.
 
+> NOTE: If you use `cf-grid.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
 
 ## Variables
 

--- a/src/cf-icons/usage.md
+++ b/src/cf-icons/usage.md
@@ -1,6 +1,11 @@
 The cf-icon component provides the custom icon font for Capital Framework.
 This component can be used by itself, but is designed to work with Capital Framework.
 
+> NOTE: If you use `cf-icons.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
 
 ## Variables
 

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -1,5 +1,10 @@
 A set of HTML and CSS layout helpers.
 
+> NOTE: If you use `cf-layout.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
 
 ## Dependencies
 

--- a/src/cf-pagination/usage.md
+++ b/src/cf-pagination/usage.md
@@ -1,5 +1,10 @@
 The cf-pagination component provides a responsive approach to multipage page navigation.
 
+> NOTE: If you use `cf-pagination.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
 
 ## Dependencies
 - cf-core

--- a/src/cf-tables/usage.md
+++ b/src/cf-tables/usage.md
@@ -1,5 +1,11 @@
 The cf-tables component formats tables, and provides an easy way to make tables sortable.
 
+> NOTE: If you use `cf-tables.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
+
 ## Vars
 
 Theme variables for setting the color and sizes throughout the project. Overwrite them in your own project by duplicating the variable `@key:` value.

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -32,6 +32,11 @@ and has more basic typography patterns.
     - [Link list with icons](#link-list-with-icons)
     - [Custom bullet mixin](#custom-bullet-mixin)
 
+> NOTE: If you use `cf-typography.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
 
 ## Variables
 


### PR DESCRIPTION
Fixes #348 

## Additions

- Added CSS autoprefixer to build pipeline.

## Changes

- General gulp build script cleanup.

## Testing

- Run `npm install`
- Run `gulp styles`
- Open `dist/capital-framework.css`
- Scroll to L:2352
- Note style `-webkit-appearance: none;`
- Edit [this line](https://github.com/cfpb/capital-framework/blob/canary/src/cf-buttons/src/cf-buttons.less#L76) from `-webkit-appearance: none` to `appearance: none`.
- Re-run `gulp styles`
- Re-open `dist/capital-framework.css`
- Note L:2352-L:2354 should now be:

```
-webkit-appearance: none;
     -moz-appearance: none;
          appearance: none;
```

## Review

- @Scotchester 
- @KimberlyMunoz 
- @jimmynotjim 
- @sebworks 
- @contolini 

## Notes

- After merging this another PR should be opened that removes existing browser prefixes in the codebase.
- This runs autoprefixer for IE7+. We should consider breaking out a separate legacy IE styles build, like what cfgov-refresh does.