### PR TITLE
Removes vendor prefixes handled by autoprefixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
 - Added CSS autoprefixer to build pipeline.
 
 ### Changed
@@ -12,6 +11,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Removed
 - **cf-typography:** [MINOR] Removed remaining Less from branded bullets
+- **cf-buttons:** [MINOR] Removed vendor prefixes handled by autoprefixer.
+- **cf-core:** [MINOR] Removed vendor prefixes handled by autoprefixer.
+- **cf-grid:** [MINOR] Removed vendor prefixes handled by autoprefixer.
+- **cf-icons:** [MINOR] Removed vendor prefixes handled by autoprefixer.
 
 ## 3.5.2 - 2016-07-06
 

--- a/src/cf-buttons/src/cf-buttons.less
+++ b/src/cf-buttons/src/cf-buttons.less
@@ -73,7 +73,7 @@
 
     cursor: pointer;
     transition: background-color .1s;
-    -webkit-appearance: none;
+    appearance: none;
 
     &,
     &:link,

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -556,14 +556,13 @@ select[multiple] {
     border: 1px solid @input-border;
     border-radius: 0;
     vertical-align: top;
-    -webkit-appearance: none;
-    -webkit-user-modify: read-write-plaintext-only;
+    appearance: none;
 }
 
 // Overrides extra left padding.
 // http://stackoverflow.com/questions/11127891/how-can-i-get-rid-of-horizontal-padding-or-indent-in-html5-search-inputs-in-webk
 ::-webkit-search-decoration {
-    -webkit-appearance: none;
+    appearance: none;
 }
 
 // The .focus class is only included for documentation demos and should not

--- a/src/cf-core/src/cf-media-queries.less
+++ b/src/cf-core/src/cf-media-queries.less
@@ -31,7 +31,7 @@
 
 .respond-to-dpi(@ratio, @rules) {
     @dpi: (@ratio * 96dpi);
-    @media (-webkit-min-device-pixel-ratio: @ratio), (min-resolution: @dpi) {
+    @media (min-device-pixel-ratio: @ratio), (min-resolution: @dpi) {
         @rules();
     }
 }

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -139,7 +139,7 @@ such as Apple retina screens
 .example {
     background: url(regular-resolution-image.png);
 }
-@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+@media (min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
     .example {
         background-image: url(retina-image.png);
     }

--- a/src/cf-grid/src/cf-grid.less
+++ b/src/cf-grid/src/cf-grid.less
@@ -37,9 +37,7 @@
 .grid_column( @columns: 1; @total: @grid_total-columns; @prefix: 0; @suffix: 0 ) {
 
   display: inline-block;
-  -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
-          box-sizing: border-box;
+  box-sizing: border-box;
 
   // To calculate the percentage width of the base element, we take the number of
   // columns it'll span and divide by the total number of columns. As columns are

--- a/src/cf-icons/src/cf-icons.less
+++ b/src/cf-icons/src/cf-icons.less
@@ -58,6 +58,9 @@
   font-style: normal;
   font-weight: normal;
   line-height: 1;
+  // TODO: Determine whether this can be safely removed and remove it.
+  //       Font smooth/smoothing is non-standard:
+  //       https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth
   -webkit-font-smoothing: antialiased;
 }
 
@@ -299,17 +302,15 @@
 //
 
 .cf-icon__rotate(@degrees, @rotation) {
+  // TOOD: Check whether `filter` can be replaced
+  //       by `-ms-transform` for CF supported browsers.
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation);
-  -webkit-transform: rotate(@degrees);
-      -ms-transform: rotate(@degrees);
-          transform: rotate(@degrees);
+  transform: rotate(@degrees);
 }
 
 .cf-icon__flip(@horiz, @vert, @rotation) {
   filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=@rotation, mirror=1);
-  -webkit-transform: scale(@horiz, @vert);
-      -ms-transform: scale(@horiz, @vert);
-          transform: scale(@horiz, @vert);
+  transform: scale(@horiz, @vert);
 }
 //
 // Helper classes for modified icons
@@ -341,34 +342,19 @@
 //
 
 .@{cf-icon-prefix}__spin {
-  -webkit-animation: cf-spin 2s infinite linear;
-          animation: cf-spin 2s infinite linear;
+  animation: cf-spin 2s infinite linear;
 }
 
 .@{cf-icon-prefix}__pulse {
-  -webkit-animation: cf-spin 1s infinite steps(8);
-          animation: cf-spin 1s infinite steps(8);
-}
-
-@-webkit-keyframes cf-spin {
-  0% {
-    -webkit-transform: rotate(0deg);
-            transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(359deg);
-            transform: rotate(359deg);
-  }
+  animation: cf-spin 1s infinite steps(8);
 }
 
 @keyframes cf-spin {
   0% {
-    -webkit-transform: rotate(0deg);
-            transform: rotate(0deg);
+    transform: rotate(0deg);
   }
   100% {
-    -webkit-transform: rotate(359deg);
-            transform: rotate(359deg);
+    transform: rotate(359deg);
   }
 }
 


### PR DESCRIPTION
## Changes

- Removes vendor prefixes handled by autoprefixer.

## Testing

- Place `outline: 1px solid green;` after the styles that have vendor prefixes removed.
- Run `gulp styles`
- Check `dist/capital-framework.css` and search for `green` and note that styles have vendor prefixes added.

## Review

- @Scotchester 
- @jimmynotjim 
- @KimberlyMunoz
- @sebworks
- @contolini

## Notes

- `transform` does not add `-ms-transform`, indicating this is for IE older than 8, which should be covered by `filter` anyway, so I do not think this is needed.
