### PR TITLE
Convert cf-core to Atomic Design conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - `.subheader`
   - `.superheader`
   - `.figure__bordered`
+  - `.u-link-child__hover`
+  - Ability to use radio buttons and checkboxes within a `label`
 
 ## 3.5.0 - 2016-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-core:** [MAJOR] Update to atomic naming conventions:
+  - `.webfont-<style>()` mixins renamed to `.u-webfont-<style>()`
+  - `body` font is now `@webfont-regular` (Arial, by default).
+
 
 ### Removed
-- 
+- **cf-core:** [MAJOR] Removed deprecated items:
+  - `@mobile-max`
+  - `@tablet-min`
+  - `.subheader`
+  - `.superheader`
+  - `.figure__bordered`
 
 ## 3.5.0 - 2016-05-26
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "postinstall": "node scripts/npm/postinstall",
     "release": "./scripts/travis/release.sh",
     "build": "gulp build",
-    "test": "gulp test && node test/accessibility/wcag.js"
+    "test": "gulp test && node test/accessibility/wcag.js",
+    "cf-link": "cd ./src/cf-core && npm link && cd ../cf-buttons/ && npm link"
   },
   "devDependencies": {
     "bluebird": "^3.0.5",

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -539,7 +539,7 @@ select[multiple] {
     @font-size: 16px;
 
     display: inline-block;
-    padding: unit( 6 / @base-font-size-px, em );
+    padding: unit( 6px / @base-font-size-px, em );
     border: 1px solid @input-border;
     border-radius: 0;
     margin: 0;

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -8,48 +8,51 @@
 //
 
 @webfont-regular: Arial;
-@webfont-italic: Arial;
-@webfont-medium: Arial;
-@webfont-demi: Arial;
+@webfont-italic:  Arial;
+@webfont-medium:  Arial;
+@webfont-demi:    Arial;
 
-.webfont-regular() {
+.u-webfont-regular() {
     font-family: @webfont-regular, Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
 
     & em,
     & i {
-        .webfont-italic();
+        .u-webfont-italic();
     }
 
     & strong,
     & b {
-        .webfont-demi();
+        .u-webfont-demi();
     }
 }
 
-.webfont-italic() {
+.u-webfont-italic() {
     font-family: @webfont-italic, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+
     .lt-ie9 & {
         font-style: normal !important;
     }
 }
 
-.webfont-medium() {
+.u-webfont-medium() {
     font-family: @webfont-medium, Arial, sans-serif;
     font-style: normal;
     font-weight: 500;
+
     .lt-ie9 & {
         font-weight: normal !important;
     }
 }
 
-.webfont-demi() {
+.u-webfont-demi() {
     font-family: @webfont-demi, Arial, sans-serif;
     font-style: normal;
     font-weight: bold;
+
     .lt-ie9 & {
         font-weight: normal !important;
     }
@@ -60,15 +63,16 @@
 //
 
 body {
+    .u-webfont-regular();
+
     color: @text;
-    font-family: Georgia, "Times New Roman", serif;
-    font-size: unit(@base-font-size-px / 16 * 100, %);
+    font-size: unit( @base-font-size-px / 16 * 100, % );
     line-height: @base-line-height;
 }
 
 .heading-1( @fs: @size-i ) {
     @font-size: @fs;
-    .webfont-regular();
+    .u-webfont-regular();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
@@ -77,7 +81,7 @@ body {
 
 .heading-2( @fs: @size-ii ) {
     @font-size: @fs;
-    .webfont-regular();
+    .u-webfont-regular();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
@@ -86,7 +90,7 @@ body {
 
 .heading-3( @fs: @size-iii )  {
     @font-size: @fs;
-    .webfont-regular();
+    .u-webfont-regular();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
@@ -95,7 +99,7 @@ body {
 
 .heading-4( @fs: @size-iv )  {
     @font-size: @fs;
-    .webfont-medium();
+    .u-webfont-medium();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
@@ -104,7 +108,7 @@ body {
 
 .heading-5( @fs: @size-v )  {
     @font-size: @fs;
-    .webfont-demi();
+    .u-webfont-demi();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
@@ -115,7 +119,7 @@ body {
 
 .heading-6( @fs: @size-vi )  {
     @font-size: @fs;
-    .webfont-demi();
+    .u-webfont-demi();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
@@ -149,7 +153,7 @@ h1,
         margin-top: unit( 60px / @font-size, em );
     }
 
-    .respond-to-max(@bp-xs-max, {
+    .respond-to-max( @bp-xs-max, {
         .heading-2();
 
         p + &,
@@ -175,7 +179,7 @@ h1,
         .h6 + & {
             margin-top: unit( 30px / @font-size, em );
         }
-    });
+    } );
 }
 
 h2,
@@ -206,7 +210,7 @@ h2,
         margin-top: unit( 30px / @font-size, em );
     }
 
-    .respond-to-max(@bp-xs-max, {
+    .respond-to-max( @bp-xs-max, {
         .heading-3();
 
         p + &,
@@ -219,7 +223,7 @@ h2,
         blockquote + & {
             margin-top: unit( 30px / @font-size, em );
         }
-    });
+    } );
 }
 
 h3,
@@ -247,9 +251,9 @@ h3,
         margin-top: unit( 30px / @font-size, em );
     }
 
-    .respond-to-max(@bp-xs-max, {
+    .respond-to-max( @bp-xs-max, {
         .heading-4();
-    });
+    } );
 }
 
 h4,
@@ -343,25 +347,14 @@ h6,
     });
 }
 
-// To be deprecated at the 2.0 release:
-.subheader {
-    &:extend(.lead-paragraph);
-}
-
 .superheading {
     // For when you want a heading that's bigger than a normal H1
     @font-size: @size-xl;
-
-    .webfont-regular();
+    .u-webfont-regular();
 
     margin-bottom: unit( 20px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
     line-height: 1.25;
-}
-
-// To be deprecated at the 2.0 release:
-.superheader {
-    &:extend(.superheading);
 }
 
 //
@@ -376,16 +369,16 @@ figure,
 table,
 blockquote {
     margin-top: 0;
-    margin-bottom: unit(15px / @base-font-size-px, em);
+    margin-bottom: unit( 15px / @base-font-size-px, em );
 }
 
 p + ul,
 p + ol {
-    margin-top: unit(-5px / @base-font-size-px, em);
+    margin-top: unit( -5px / @base-font-size-px, em );
 }
 
 li {
-    margin-bottom: unit(8px / @base-font-size-px, em);
+    margin-bottom: unit( 8px / @base-font-size-px, em );
 
     &:last-child,
     nav & {
@@ -403,6 +396,9 @@ a {
     border-color: @link-underline;
     color: @link-text;
     text-decoration: none;
+
+    // Note: The class definitions below are only for use in
+    // demonstrating link states. Do not use in production.
 
     &:visited,
     &.visited {
@@ -457,16 +453,16 @@ nav a {
 ul {
     // 32px provides exactly 15px between left margin
     // and bullet character in most browsers
-    padding-left: unit(32px / @base-font-size-px, em);
+    padding-left: unit( 32px / @base-font-size-px, em );
     list-style: square;
 }
 
 // Use the same overall number as ULs, but pull the number 1px to the left
 ol {
-    padding-left: unit(31px / @base-font-size-px, em);
+    padding-left: unit( 31px / @base-font-size-px, em );
 
     > li {
-        padding-left: unit(1px / @base-font-size-px, em);
+        padding-left: unit( 1px / @base-font-size-px, em );
     }
 }
 
@@ -474,19 +470,16 @@ ol {
 // Tables
 //
 
-table {
-    .webfont-regular();
-}
-
 th,
 td {
-    padding: unit(10px / @base-font-size-px, em);
+    padding: unit( 10px / @base-font-size-px, em );
 
     thead & {
-        padding: unit(10px / @font-size, em);
-        color: @thead-text;
-        background: @thead-bg;
         .h5();
+
+        padding: unit( 10px / @font-size, em );
+        background: @thead-bg;
+        color: @thead-text;
     }
 }
 
@@ -496,25 +489,23 @@ tbody tr {
 }
 
 th {
-    .webfont-demi();
+    .u-webfont-demi();
+
     text-align: left;
 }
 
-tbody th {
-    .webfont-regular();
-}
 //
 // Block quote
 //
 
 blockquote {
-    margin-right: unit(15px / @base-font-size-px, em);
-    margin-left: unit(15px / @base-font-size-px, em);
+    margin-right: unit( 15px / @base-font-size-px, em );
+    margin-left: unit( 15px / @base-font-size-px, em );
 
-    .respond-to-min(@bp-sm-min, {
-        margin-right: unit(30px / @base-font-size-px, em);
-        margin-left: unit(30px / @base-font-size-px, em);
-    });
+    .respond-to-min( @bp-sm-min, {
+        margin-right: unit( 30px / @base-font-size-px, em );
+        margin-left: unit( 30px / @base-font-size-px, em );
+    } );
 }
 
 //
@@ -524,12 +515,11 @@ blockquote {
 label {
     display: block;
     // 5px is eyeballed to 10px when considering line height.
-    margin-bottom: unit(5px / @base-font-size-px, em);
-    .webfont-regular();
+    margin-bottom: unit( 5px / @base-font-size-px, em );
 
     input[type="radio"],
     input[type="checkbox"] {
-        margin-right: unit(6px / @base-font-size-px, em);
+        margin-right: unit( 6px / @base-font-size-px, em );
     }
 }
 
@@ -548,13 +538,13 @@ select[multiple] {
     @font-size: 16px;
 
     display: inline-block;
-    margin: 0;
-    padding: unit(6 / @base-font-size-px, em);
-    font-family: Arial, sans-serif;
-    font-size: unit(@font-size / @base-font-size-px, em);
-    background: @input-bg;
+    padding: unit( 6 / @base-font-size-px, em );
     border: 1px solid @input-border;
     border-radius: 0;
+    margin: 0;
+    background: @input-bg;
+    font-family: Arial, sans-serif;
+    font-size: unit( @font-size / @base-font-size-px, em );
     vertical-align: top;
     -webkit-appearance: none;
     -webkit-user-modify: read-write-plaintext-only;
@@ -591,13 +581,13 @@ select[multiple].focus {
 }
 
 ::-webkit-input-placeholder {
-   color: @input-placeholder;
+    color: @input-placeholder;
 }
 ::-moz-placeholder {
-   color: @input-placeholder;
+    color: @input-placeholder;
 }
 :-ms-input-placeholder {
-   color: @input-placeholder;
+    color: @input-placeholder;
 }
 
 //
@@ -613,17 +603,15 @@ img {
 //
 
 figure {
-    margin-left: 0;
+    // reset browser default side margins
     margin-right: 0;
+    margin-left: 0;
 
     img {
         // Removes weird vertical spacing below images.
+        // TODO: Discuss whether this could just be universally applied to img
         vertical-align: middle;
     }
-}
-
-.figure__bordered img {
-    border: 1px solid @figure__bordered;
 }
 
 //

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -537,6 +537,7 @@ input[type="number"],
 textarea,
 select[multiple] {
     @font-size: 16px;
+    .u-webfont-regular();
 
     display: inline-block;
     padding: unit( 6px / @base-font-size-px, em );
@@ -544,7 +545,6 @@ select[multiple] {
     border-radius: 0;
     margin: 0;
     background: @input-bg;
-    font-family: Arial, sans-serif;
     font-size: unit( @font-size / @base-font-size-px, em );
     vertical-align: top;
     -webkit-appearance: none;

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -58,6 +58,12 @@
     }
 }
 
+// TODO: Deprecate these old mixin names once all of v4 is merged together.
+.webfont-regular { .u-webfont-regular(); }
+.webfont-italic  { .u-webfont-italic(); }
+.webfont-medium  { .u-webfont-medium(); }
+.webfont-demi    { .u-webfont-demi(); }
+
 //
 // Type hierarchy
 //
@@ -516,11 +522,6 @@ label {
     display: block;
     // 5px is eyeballed to 10px when considering line height.
     margin-bottom: unit( 5px / @base-font-size-px, em );
-
-    input[type="radio"],
-    input[type="checkbox"] {
-        margin-right: unit( 6px / @base-font-size-px, em );
-    }
 }
 
 //
@@ -588,6 +589,13 @@ select[multiple].focus {
 }
 :-ms-input-placeholder {
     color: @input-placeholder;
+}
+
+input[type="radio"],
+input[type="checkbox"] {
+    margin-top: unit( 4px / @base-font-size-px, em );
+    margin-right: unit( 7px / @base-font-size-px, em );
+    float: left;
 }
 
 //

--- a/src/cf-core/src/cf-media-queries.less
+++ b/src/cf-core/src/cf-media-queries.less
@@ -7,37 +7,37 @@
 // Media query mixins
 //
 
-.respond-to-min(@bp, @rules) {
-    @ems: unit((@bp / @base-font-size-px), em);
-    @media only all and (min-width: @ems) {
+.respond-to-min( @bp, @rules ) {
+    @ems: unit( ( @bp / @base-font-size-px ), em );
+    @media only all and ( min-width: @ems ) {
         @rules();
     }
 }
 
-.respond-to-max(@bp, @rules) {
-    @ems: unit((@bp / @base-font-size-px), em);
-    @media only all and (max-width: @ems) {
+.respond-to-max( @bp, @rules ) {
+    @ems: unit( ( @bp / @base-font-size-px ), em);
+    @media only all and ( max-width: @ems ) {
         @rules();
     }
 }
 
-.respond-to-range(@bp1, @bp2, @rules) {
-    @ems1: unit((@bp1 / @base-font-size-px), em);
-    @ems2: unit((@bp2 / @base-font-size-px), em);
-    @media only all and (min-width: @ems1) and (max-width: @ems2) {
+.respond-to-range( @bp1, @bp2, @rules ) {
+    @ems1: unit( ( @bp1 / @base-font-size-px ), em );
+    @ems2: unit( ( @bp2 / @base-font-size-px ), em );
+    @media only all and ( min-width: @ems1 ) and ( max-width: @ems2 ) {
         @rules();
     }
 }
 
 // TODO: Discuss whether to split this into min and max queries.
-.respond-to-dpi(@ratio, @rules) {
-    @dpi: (@ratio * 96dpi);
-    @media (-webkit-min-device-pixel-ratio: @ratio), (min-resolution: @dpi) {
+.respond-to-dpi( @ratio, @rules ) {
+    @dpi: ( @ratio * 96dpi );
+    @media ( -webkit-min-device-pixel-ratio: @ratio ), ( min-resolution: @dpi ) {
         @rules();
     }
 }
 
-.respond-to-print(@rules) {
+.respond-to-print( @rules ) {
     @media print {
         @rules();
     }

--- a/src/cf-core/src/cf-media-queries.less
+++ b/src/cf-core/src/cf-media-queries.less
@@ -29,6 +29,7 @@
     }
 }
 
+// TODO: Discuss whether to split this into min and max queries.
 .respond-to-dpi(@ratio, @rules) {
     @dpi: (@ratio * 96dpi);
     @media (-webkit-min-device-pixel-ratio: @ratio), (min-resolution: @dpi) {

--- a/src/cf-core/src/cf-utilities.less
+++ b/src/cf-core/src/cf-utilities.less
@@ -79,8 +79,12 @@
 
 .u-align-with-btn( @font-size: @base-font-size-px ) {
     display: inline-block;
-    padding-top: unit( 9px / @font-size, em );
     line-height: normal;
+    vertical-align: middle;
+}
+
+.u-align-with-btn {
+    .u-align-with-btn();
 }
 
 //
@@ -178,29 +182,15 @@
     }
 }
 
-.u-link-child__hover( @c: @link-text-hover ) {
-    a:hover &,
-    a.hover &,
-    a:focus &,
-    a.focus & {
-        color: @c;
-    }
-}
-
-.u-link__border() {
+.u-link__border {
     border-bottom-width: 1px;
-
-    &:hover,
-    &.hover {
-        border-bottom-width: 1px;
-    }
 }
 
-.u-link__no-border() {
+.u-link__no-border {
     border-bottom-width: 0 !important;
 }
 
-.u-link__hover-border() {
+.u-link__hover-border {
     border-bottom-width: 0 !important;
 
     &:hover,
@@ -263,6 +253,7 @@
 
 .u-show-on-mobile {
     display: none;
+
     .respond-to-max( @bp-xs-max {
         display: block;
     } );

--- a/src/cf-core/src/cf-utilities.less
+++ b/src/cf-core/src/cf-utilities.less
@@ -83,10 +83,6 @@
     vertical-align: middle;
 }
 
-.u-align-with-btn {
-    .u-align-with-btn();
-}
-
 //
 // Flexible proportional containers
 //
@@ -182,15 +178,15 @@
     }
 }
 
-.u-link__border {
+.u-link__border() {
     border-bottom-width: 1px;
 }
 
-.u-link__no-border {
+.u-link__no-border() {
     border-bottom-width: 0 !important;
 }
 
-.u-link__hover-border {
+.u-link__hover-border() {
     border-bottom-width: 0 !important;
 
     &:hover,

--- a/src/cf-core/src/cf-utilities.less
+++ b/src/cf-core/src/cf-utilities.less
@@ -276,10 +276,7 @@
     font-size: unit( 14px / @context, em );
 }
 
+small,
 .u-small-text {
-    .u-small-text();
-}
-
-small {
     .u-small-text();
 }

--- a/src/cf-core/src/cf-utilities.less
+++ b/src/cf-core/src/cf-utilities.less
@@ -23,6 +23,7 @@
         display: table;
         clear: both;
     }
+
     .lt-ie8 & {
         zoom: 1; // For IE 6/7 (triggers hasLayout)
     }
@@ -33,14 +34,14 @@
 //
 
 .u-visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  border: 0;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    border: 0;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
 }
 
 //
@@ -49,6 +50,7 @@
 
 .u-inline-block {
     display: inline-block;
+
     .lt-ie8 & {
         // Hack inline-block into submission
         display: inline;
@@ -75,9 +77,9 @@
 // Align with button
 //
 
-.u-align-with-btn(@font-size: @base-font-size-px) {
+.u-align-with-btn( @font-size: @base-font-size-px ) {
     display: inline-block;
-    padding-top: unit(9px / @font-size, em);
+    padding-top: unit( 9px / @font-size, em );
     line-height: normal;
 }
 
@@ -85,8 +87,8 @@
 // Flexible proportional containers
 //
 
-.u-flexible-container-mixin(@width: 16, @height: 9) {
-    @ratio: (@height / @width) * 100;
+.u-flexible-container-mixin( @width: 16, @height: 9 ) {
+    @ratio: ( @height / @width ) * 100;
 
     position: relative;
     padding-bottom: ~"@{ratio}%";
@@ -106,7 +108,7 @@
 }
 
 .u-flexible-container__4-3 {
-    .u-flexible-container-mixin(4,3);
+    .u-flexible-container-mixin( 4, 3 );
 }
 
 //
@@ -117,37 +119,37 @@
     .u-link__colors-base();
 }
 
-.u-link__colors(@c) {
-    .u-link__colors-base(@c, @c, @c, @c, @c,
-                         @c, @c, @c, @c, @c);
+.u-link__colors( @c ) {
+    .u-link__colors-base( @c, @c, @c, @c, @c,
+                          @c, @c, @c, @c, @c );
 }
 
-.u-link__colors(@c, @h) {
-    .u-link__colors-base(@c, @c, @h, @h, @c,
-                         @c, @c, @h, @h, @c);
+.u-link__colors( @c, @h ) {
+    .u-link__colors-base( @c, @c, @h, @h, @c,
+                          @c, @c, @h, @h, @c );
 }
 
-.u-link__colors(@c, @v, @h, @f, @a) {
-    .u-link__colors-base(@c, @v, @h, @f, @a,
-                         @c, @v, @h, @f, @a);
+.u-link__colors( @c, @v, @h, @f, @a ) {
+    .u-link__colors-base( @c, @v, @h, @f, @a,
+                          @c, @v, @h, @f, @a );
 }
 
-.u-link__colors(@c, @v, @h, @f, @a,
-                @bc, @bv, @bh, @bf, @ba) {
-    .u-link__colors-base(@c, @v, @h, @f, @a,
-                         @bc, @bv, @bh, @bf, @ba);
+.u-link__colors( @c, @v, @h, @f, @a,
+                 @bc, @bv, @bh, @bf, @ba ) {
+    .u-link__colors-base( @c, @v, @h, @f, @a,
+                          @bc, @bv, @bh, @bf, @ba );
 }
 
-.u-link__colors-base(@c:  @link-text,
-                     @v:  @link-text-visited,
-                     @h:  @link-text-hover,
-                     @f:  @link-text,
-                     @a:  @link-text-active,
-                     @bc: @link-underline,
-                     @bv: @link-underline-visited,
-                     @bh: @link-underline-hover,
-                     @bf: @link-underline,
-                     @ba: @link-underline-active) {
+.u-link__colors-base( @c:  @link-text,
+                      @v:  @link-text-visited,
+                      @h:  @link-text-hover,
+                      @f:  @link-text,
+                      @a:  @link-text-active,
+                      @bc: @link-underline,
+                      @bv: @link-underline-visited,
+                      @bh: @link-underline-hover,
+                      @bf: @link-underline,
+                      @ba: @link-underline-active ) {
     color: @c;
     border-color: @bc;
 
@@ -176,7 +178,7 @@
     }
 }
 
-.u-link-child__hover(@c: @link-text-hover) {
+.u-link-child__hover( @c: @link-text-hover ) {
     a:hover &,
     a.hover &,
     a:focus &,
@@ -246,38 +248,38 @@
 .u-w10pct  { width: 10%; }
 .u-w75pct  { width: 75%; }
 .u-w25pct  { width: 25%; }
-.u-w66pct  { width: unit((2 / 3) * 100, %); }
-.u-w33pct  { width: unit((1 / 3) * 100, %); }
+.u-w66pct  { width: unit( ( 2 / 3 ) * 100, % ); }
+.u-w33pct  { width: unit( ( 1 / 3 ) * 100, % ); }
 
 //
 // Width-specific display
 //
 
 .u-hide-on-mobile {
-    .respond-to-max(@bp-xs-max {
+    .respond-to-max( @bp-xs-max {
         display: none;
-    });
+    } );
 }
 
 .u-show-on-mobile {
     display: none;
-    .respond-to-max(@bp-xs-max {
+    .respond-to-max( @bp-xs-max {
         display: block;
-    });
+    } );
 }
 
 //
 // Small text utility
 //
 
-.u-small-text(@context: @base-font-size-px) {
-  font-size: unit(14px / @context, em);
+.u-small-text( @context: @base-font-size-px ) {
+    font-size: unit( 14px / @context, em );
 }
 
 .u-small-text {
-  .u-small-text();
+    .u-small-text();
 }
 
 small {
-  .u-small-text();
+    .u-small-text();
 }

--- a/src/cf-core/src/cf-utilities.less
+++ b/src/cf-core/src/cf-utilities.less
@@ -41,6 +41,10 @@
     margin: -1px;
     padding: 0;
     overflow: hidden;
+    // `clip` is deprecated, but retained for safety in making sure that this
+    // utility works as expected for screenreaders. Comma-separated syntax is
+    // not used because space-separated is more backward-compatible,
+    // per https://developer.mozilla.org/en-US/docs/Web/CSS/clip
     clip: rect(0 0 0 0);
 }
 

--- a/src/cf-core/src/cf-vars.less
+++ b/src/cf-core/src/cf-vars.less
@@ -13,14 +13,14 @@
 @base-line-height-px:           22px;
 @base-line-height:              unit(@base-line-height-px / @base-font-size-px);
 
-@size-xl:  48px; // Super-size
+@size-xl:                       48px; // Super-size
 
-@size-i:   34px; // h1-size
-@size-ii:  26px; // h2-size
-@size-iii: 22px; // h3-size
-@size-iv:  18px; // h4-size
-@size-v:   14px; // h5-site
-@size-vi:  12px; // h6-size
+@size-i:                        34px; // h1-size
+@size-ii:                       26px; // h2-size
+@size-iii:                      22px; // h3-size
+@size-iv:                       18px; // h4-size
+@size-v:                        14px; // h5-site
+@size-vi:                       12px; // h6-size
 
 
 @bp-xs-max:                     600px;
@@ -32,9 +32,6 @@
 @bp-lg-max:                     1230px;
 @bp-xl-min:                     @bp-lg-max + 1px;
 
-// To be deprecated
-@mobile-max:                    @bp-xs-max;
-@tablet-min:                    @bp-sm-min;
 
 // Color variables
 // $color- variables are from 18F's US Web Design Standards
@@ -65,6 +62,3 @@
 @input-border:                  #5b616b; // $color-gray
 @input-border-focus:            #3e94cf; // $color-focus
 @input-placeholder:             #aeb0b5; // $color-gray-light
-
-// .figure__bordered
-@figure__bordered:              #d6d7d9; // $color-gray-lighter

--- a/src/cf-core/src/cf-vars.less
+++ b/src/cf-core/src/cf-vars.less
@@ -36,8 +36,8 @@
 
 
 // Color variables
-// $color- variables are from 18F's US Web Design Standards
-// https://github.com/18F/web-design-standards/blob/18f-pages-staging/src/stylesheets/core/_variables.scss
+// $color- variables are from 18F's U.S. Web Design Standards
+// https://github.com/18F/web-design-standards/blob/master/src/stylesheets/core/_variables.scss
 
 // body
 @text:                          #212121; // $color-base

--- a/src/cf-core/src/cf-vars.less
+++ b/src/cf-core/src/cf-vars.less
@@ -23,6 +23,8 @@
 @size-vi:                       12px; // h6-size
 
 
+// Breakpoint variables
+
 @bp-xs-max:                     600px;
 @bp-sm-min:                     @bp-xs-max + 1px;
 @bp-sm-max:                     900px;

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -242,32 +242,30 @@ Adds a `.lt-ie8` fallback to hack inline block for IE 7 and below.
 
 Force word breaks within an element. Useful for small containers where text may over-run the width of the container.
 
-<div style="width: 100px;">
+<div class="u-break-word u-mb30" style="width: 100px; padding: 0.5em; border: 1px solid silver;">
     This link should break:
-    <br>
-    <a class="u-break-word" href="#">
+    <a href="#">
         something@something.com
     </a>
-    <br>
-    <br>
+</div>
+
+<div class="u-mb30" style="width: 100px; padding: 0.5em; border: 1px solid silver;">
     This link should not:
-    <br>
     <a href="#">
         something@something.com
     </a>
 </div>
 
 ```
-<div style="width: 100px;">
+<div class="u-break-word">
     This link should break:
-    <br>
-    <a class="u-break-word" href="#">
+    <a href="#">
         something@something.com
     </a>
-    <br>
-    <br>
+</div>
+
+<div>
     This link should not:
-    <br>
     <a href="#">
         something@something.com
     </a>

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -53,9 +53,6 @@ Ex. to set your base font size, add `@base-font-size-px: 17px;` to your project.
 @input-border:           #5b616b; // $color-gray
 @input-border-focus:     #3e94cf; // $color-focus
 @input-placeholder:      grayscale(#c7336e);
-
-// .figure__bordered
-@figure__bordered:       #d6d7d9; // $color-gray-lighter
 ```
 
 
@@ -596,10 +593,10 @@ Sets the element to 14px (in ems) based on the text size passed as `@context`.
 Sets the font-stack, weight, and style of an element.
 
 ```
-.webfont-regular();
-.webfont-italic();
-.webfont-medium();
-.webfont-demi();
+.u-webfont-regular();
+.u-webfont-italic();
+.u-webfont-medium();
+.u-webfont-demi();
 ```
 
 To use your own fonts in the webfont mixins, set your own font with the `@webfont-regular/italic/medium/demi` variables in your `theme-overrides.less` file.
@@ -1186,24 +1183,15 @@ Gives all images a default max-width of 100% of their container.
 
 ### Figure
 
+Resets browser default side margins for `figure` to 0,
+and removes bottom inline spacing from `img` elements within.
+
 <figure>
     <img src="http://placekitten.com/340/320">
 </figure>
 
 ```
 <figure>
-    <img src="http://placekitten.com/340/320">
-</figure>
-```
-
-### Bordered figure
-
-<figure class="figure__bordered">
-    <img src="http://placekitten.com/340/320">
-</figure>
-
-```
-<figure class="figure__bordered">
     <img src="http://placekitten.com/340/320">
 </figure>
 ```


### PR DESCRIPTION
This PR updates the few parts of cf-core that need updating to follow Atomic Design conventions.


## Changes

  - `.webfont-<style>()` mixins renamed to `.u-webfont-<style>()`
  - `body` font is now `@webfont-regular` (Arial, by default).


## Removals

- Deprecated items:
  - `@mobile-max`
  - `@tablet-min`
  - `.subheader`
  - `.superheader`
  - `.figure__bordered`


## Testing

- See instructions in #326 


## Review

- @jimmynotjim 
- @KimberlyMunoz 


## Todos

- Add `npm run link` support after #326 is merged.


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
