### PR TITLE
Quick bugfix for old variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - `.webfont-<style>()` mixins renamed to `.u-webfont-<style>()`
   - `body` font is now `@webfont-regular` (Arial, by default).
 
-
 ### Removed
 - **cf-core:** [MAJOR] Removed deprecated items:
   - `@mobile-max`
@@ -21,6 +20,9 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - `.figure__bordered`
   - `.u-link-child__hover`
   - Ability to use radio buttons and checkboxes within a `label`
+
+### Fixed
+- **cf-typography:** [PATCH] Fixed old variables removed from cf-core
 
 ## 3.5.0 - 2016-05-26
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release": "./scripts/travis/release.sh",
     "build": "gulp build",
     "test": "gulp test && node test/accessibility/wcag.js",
-    "cf-link": "cd ./src/cf-core && npm link && cd ../cf-buttons/ && npm link"
+    "cf-link": "cd ./src/cf-core && npm link && cd ../cf-buttons/ && npm link && cd ../cf-typography && npm link"
   },
   "devDependencies": {
     "bluebird": "^3.0.5",

--- a/src/cf-typography/src/cf-typography.less
+++ b/src/cf-typography/src/cf-typography.less
@@ -423,7 +423,7 @@
         font-size: unit(@font-size / @base-font-size-px, em);
     }
 
-    .respond-to-max(@mobile-max, {
+    .respond-to-max( @bp-xs-max, {
         .block-link();
 
         &:after {


### PR DESCRIPTION
Quick bugfix for old variables

## Fixes

- Fixed old variables removed from cf-core

## Testing

- run `npm run cf-link` in this repo.
- run `npm run cf-link && npm link cf-typography` in the sandbox.
- run `npm run build` and there should be zero errors.

## Review

- @Scotchester 
- @KimberlyMunoz 
- @contolini 

## Notes

- Didn't bother with updating the link script in the sandbox at this time

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

