### PR TITLE
Adding eslint to Capital Framework

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,1092 @@
+# Enable ecmascript 6 features.
+ecmaFeatures:
+  arrowFunctions: false
+  binaryLiterals: false
+  blockBindings: false
+  classes: false
+  defaultParams: false
+  destructuring: false
+  forOf: true
+  generators: false
+  modules: false
+  objectLiteralComputedProperties: false
+  objectLiteralDuplicateProperties: false
+  objectLiteralShorthandMethods: false
+  objectLiteralShorthandProperties: false
+  octalLiterals: false
+  regexUFlag: false
+  regexYFlag: false
+  restParams: true
+  spread: false
+  superInFunctions: false
+  templateStrings: false
+  unicodeCodePointEscapes: false
+  globalReturn: false
+  jsx: true
+  experimentalObjectRestSpread: false
+
+parser: espree
+
+env:
+  browser: true
+  node: true
+  commonjs: false
+  shared-node-browser: true
+  es6: true
+  worker: false
+  amd: true
+  mocha: false
+  jasmine: false
+  jest: false
+  phantomjs: false
+  protractor: false
+  qunit: false
+  jquery: false
+  prototypejs: false
+  shelljs: false
+  meteor: false
+  mongo: false
+  applescript: false
+  serviceworker: true
+  atomtest: false
+  embertest: false
+  webextensions: false
+  greasemonkey: false
+
+globals:
+  $: false
+
+# Linting rules for ESLint.
+# 0's ignore a rule, 1's produce a warning, and 2's throw an error.
+# See http://eslint.org/docs/rules/ for full documentation.
+rules:
+
+  # Rules for flagging POSSIBLE ERRORS.
+
+  # Disallows assignment in conditional expressions.
+  no-cond-assign:
+    - 2
+    - except-parens
+
+  # Enforces flagging use of the console.
+  no-console: 1
+
+  # Disallows use of constant expressions in conditions.
+  no-constant-condition: 2
+
+  # Disallows control characters in regular expressions.
+  no-control-regex: 2
+
+  # Enforces flagging use of the debugger.
+  no-debugger: 2
+
+  # Disallow duplicate arguments in functions.
+  no-dupe-args: 2
+
+  # Disallows duplicate keys when creating object literals.
+  no-dupe-keys: 2
+
+  # Disallow a duplicate case label.
+  no-duplicate-case: 2
+
+  # Disallow the use of empty character classes in regular expressions.
+  no-empty-character-class: 2
+
+  # Disallows empty statements.
+  no-empty: 2
+
+  # Disallows assigning to the exception in a catch block.
+  no-ex-assign: 2
+
+  # Disallows double-negation boolean casts in a boolean context.
+  no-extra-boolean-cast: 2
+
+  # Disallows unnecessary parentheses.
+  no-extra-parens:
+    - 1
+    - all
+
+  # Disallows unnecessary semicolons.
+  no-extra-semi: 2
+
+  # Disallows overwriting functions written as declarations.
+  no-func-assign: 2
+
+  # Disallows function declarations in nested blocks.
+  no-inner-declarations:
+    - 2
+    - functions
+
+  # Disallows invalid regex strings in the RegExp constructor.
+  no-invalid-regexp: 2
+
+  # Disallows irregular whitespace outside of strings and comments.
+  no-irregular-whitespace: 2
+
+  # Disallows negation of the left operand of an in expression.
+  no-negated-in-lhs: 2
+
+  # Disallows use of the global Math and JSON objects as functions.
+  no-obj-calls: 2
+
+  # Disallow use of Object.prototypes builtins directly.
+  no-prototype-builtins: 0
+
+  # Disallows multiple spaces in a regular expression literal.
+  no-regex-spaces: 2
+
+  # Disallows sparse arrays.
+  # Array values should be explicitly defined.
+  no-sparse-arrays: 2
+
+  # Disallow confusing multiline expressions.
+  no-unexpected-multiline: 2
+
+  # Disallows unreachable statements after a return, throw, continue, or break.
+  no-unreachable: 2
+
+  # Disallow control flow statements in finally blocks.
+  no-unsafe-finally: 2
+
+  # Disallows comparisons with the value NaN.
+  use-isnan: 2
+
+  # Enforces valid JSDoc parameters and return types comments.
+  valid-jsdoc:
+    - 2
+    -
+      prefer:
+        return: returns
+      requireReturn: false
+      requireParamDescription: true
+      requireReturnDescription: true
+      requireReturnType: true
+
+  # Enforces that the results of typeof are compared against a valid string.
+  valid-typeof: 2
+
+
+  # Rules for encouraging BEST PRACTICES.
+
+  # Enforces getter/setter pairs in objects.
+  accessor-pairs:
+    - 1
+    -
+      getWithoutSet: false
+
+  # Enforces return statements in callbacks of array's methods.
+  array-callback-return: 2
+
+  # Enforces treating var statements as if they were block scoped.
+  block-scoped-var: 1
+
+  # Enforces specific maximum cyclomatic complexity.
+  complexity:
+    - 1
+    - 4
+
+  # Enforces return statements to either always or never specify values.
+  consistent-return: 2
+
+  # Enforces curly brace conventions for all control statements.
+  curly:
+    - 1
+    - multi-line
+    - consistent
+
+  # Enforces default case in switch statements.
+  default-case: 2
+
+  # Enforces consistent newlines before or after dots.
+  dot-location:
+    - 2
+    - property
+
+  # Enforces use of dot notation whenever possible.
+  # `allowKeywords` = false follows ECMAScript version 3 compatible style.
+  dot-notation:
+    - 2
+    -
+      allowKeywords: false
+      allowPattern: ''
+
+  # Enforces use of === and !== over == and !=.
+  eqeqeq:
+     - 2
+     - smart
+
+  # Enforces necessary if statements in for-in loops.
+  guard-for-in: 1
+
+  # Disallows use of alert, confirm, and prompt.
+  no-alert: 2
+
+  # Disallows use of arguments.caller or arguments.callee.
+  no-caller: 2
+
+  # Disallow lexical declarations in case clauses.
+  no-case-declarations: 2
+
+  # Disallows division operators explicitly at beginning of regex.
+  no-div-regex: 2
+
+  # Disallows else after a return in an if.
+  no-else-return: 2
+
+  # Disallow use of empty functions.
+  no-empty-function: 2
+
+  # Disallow use of empty destructuring patterns.
+  no-empty-pattern: 2
+
+  # Disallows comparisons to null without a type-checking operator.
+  no-eq-null: 2
+
+  # Disallows use of eval().
+  no-eval: 2
+
+  # Disallows adding to native types.
+  no-extend-native: 2
+
+  # Disallows unnecessary function binding.
+  no-extra-bind: 2
+
+  # Disallow unnecessary labels.
+  no-extra-label: 2
+
+  # Disallows fallthrough of case statements.
+  no-fallthrough: 1
+
+  # Disallows use of leading or trailing decimal points in numeric literals.
+  no-floating-decimal: 2
+
+  # Disallow the type conversions with shorter notations.
+  no-implicit-coercion:
+    - 1
+    -
+      boolean: true
+      number: true
+      string: true
+
+  # Disallow var and named functions in global scope.
+  no-implicit-globals: 2
+
+  # Disallows use of eval()-like methods.
+  no-implied-eval: 2
+
+  # Disallow this keyword outside of classes or class-like objects.
+  no-invalid-this: 0
+
+  # Disallows usage of __iterator__ property.
+  no-iterator: 2
+
+  # Disallows use of labeled statements.
+  no-labels: 2
+
+  # Disallows unnecessary nested blocks.
+  no-lone-blocks: 2
+
+  # Disallows creation of functions within loops.
+  no-loop-func: 2
+
+  # Disallow the use of magic numbers.
+  no-magic-numbers:
+    - 0
+    -
+      ignoreArrayIndexes: true
+      enforceConst: true
+      detectObjects: true
+
+  # Disallows use of multiple spaces.
+  no-multi-spaces:
+    - 2
+    -
+      exceptions:
+        BinaryExpression: false
+        Property: true
+
+  # Disallows use of multiline strings with a trailing backslash.
+  # This rule is needed for ECMAScript environments earlier than 5.
+  no-multi-str: 2
+
+  # Disallows reassignments of native objects.
+  no-native-reassign: 2
+
+  # Disallows use of new operator for Function object.
+  no-new-func: 2
+
+  # Disallows creating new instances of String, Number, and Boolean.
+  no-new-wrappers: 2
+
+  # Disallows use of new operator when not part of the assignment or comparison.
+  no-new: 1
+
+  # Disallows use of octal escape sequences in string literals, e.g. "\251".
+  no-octal-escape: 2
+
+  # Disallows use of octal literals.
+  no-octal: 2
+
+  # Disallow reassignment of function parameters.
+  no-param-reassign:
+    - 0
+    -
+      props: false
+
+  # Disallows usage of __proto__ property.
+  no-proto: 2
+
+  # Disallows declaring the same variable more then once.
+  no-redeclare: 2
+
+  # Disallows use of assignment in return statement.
+  no-return-assign:
+    - 2
+    - 'except-parens'
+
+  # Disallows use of javascript: urls.
+  no-script-url: 2
+
+  # Disallow assignments where both sides are exactly the same.
+  no-self-assign: 2
+
+  # Disallows comparisons where both sides are exactly the same.
+  no-self-compare: 2
+
+  # Disallows use of comma operator.
+  no-sequences: 1
+
+  # Restrict what can be thrown as an exception.
+  no-throw-literal: 2
+
+  # Disallow unmodified conditions of loops.
+  no-unmodified-loop-condition: 2
+
+  # Disallows usage of expressions in statement position.
+  no-unused-expressions: 2
+
+  # Disallow unused labels.
+  no-unused-labels: 2
+
+  # Disallow unnecessary .call() and .apply().
+  no-useless-call: 2
+
+  # Disallow unnecessary concatenation of literals or template literals.
+  no-useless-concat: 2
+
+  # Disallow unnecessary escape characters.
+  no-useless-escape: 1
+
+  # Disallows use of void operator.
+  no-void: 2
+
+  # Disallows use of configurable warning terms in comments, e. g. TODO.
+  no-warning-comments:
+    - 1
+    -
+      terms:
+        - '@todo'
+        - todo
+        - fixme
+        - xxx
+      location: start
+
+  # Disallows use of the with statement.
+  no-with: 2
+
+  # Require use of the second argument for parseInt().
+  radix: 2
+
+  # Require all vars on top of their containing scope.
+  vars-on-top: 0
+
+  # Require immediate function invocation to be wrapped in parentheses.
+  wrap-iife:
+    - 2
+    - inside
+
+  # Disallows Yoda conditions.
+  yoda:
+    - 2
+    - never
+    -
+      exceptRange: true
+      onlyEquality: false
+
+
+  # Rules for STRICT MODE.
+
+  # Controls location of Use Strict Directives.
+  # Ensures all function bodies are strict mode code, while global code is not.
+  # Caveat: when run on pre-concatenated code, global mode may look like
+  # function mode after concatenation.
+  strict:
+    - 2
+    - global
+
+
+  # Rules for VARIABLES.
+
+  # Require or disallow initialization in var declarations.
+  init-declarations: 0
+
+  # Disallows the catch clause parameter name being the same as a variable
+  # in the outer scope.
+  # This rule is needed for IE8- support.
+  no-catch-shadow: 2
+
+  # Disallows deletion of variables.
+  no-delete-var: 2
+
+  # Disallows labels that share a name with a variable.
+  no-label-var: 2
+
+  # Disallow specified global variables.
+  no-restricted-globals: 2
+
+  # Disallows shadowing of names such as arguments.
+  no-shadow-restricted-names: 2
+
+  # Disallows declaring variables already declared in the outer scope.
+  no-shadow:
+    - 1
+    -
+      hoist: functions
+
+  # Disallows use of undefined when initializing variables.
+  no-undef-init: 2
+
+  # Disallows use of undeclared vars unless mentioned in a /*global */ block.
+  no-undef:
+    - 2
+    - typeof: true
+
+  # Disallows use of undefined variable.
+  no-undefined: 2
+
+  # Disallows declaration of variables that are not used in the code.
+  no-unused-vars:
+    - 1
+    -
+      vars: all
+      varsIgnorePattern: ''
+      args: after-used
+      argsIgnorePattern: ''
+      caughtErrors: 'none'
+      caughtErrorsIgnorePattern: ''
+
+  # Disallows use of variables before they are defined.
+  no-use-before-define:
+    - 2
+    -
+      functions: false
+      classes: true
+
+
+  # Rules for Node.js and CommonJS.
+
+  # Enforce return after a callback.
+  # callback, cb, and next are possible callback function names.
+  callback-return:
+    - 2
+    -
+      - callback
+      - cb
+      - next
+
+  # Disallow require() outside of the top-level module scope.
+  global-require: 2
+
+  # Enforce error handling in callbacks.
+  # Matches any string that contains err or Err (err, error, anyError, an_err).
+  handle-callback-err:
+    - 2
+    - ^.*(e|E)rr
+
+  # Disallows mixing regular variable and require declarations.
+  # This rule may have inaccurate behavior in Node 0.6- and if UMD is used.
+  no-mixed-requires:
+    - 1
+    -
+      grouping: true
+      allowCall: true
+
+  # Disallows use of new operator with the require function.
+  no-new-require: 2
+
+  # Disallows string concatenation with __dirname and __filename.
+  no-path-concat: 2
+
+  # Disallows use of process.env.
+  # Only applicable to Node.js.
+  no-process-env: 2
+
+  # Disallows use of process.exit().
+  no-process-exit: 1
+
+  # Restrict usage of specific node modules.
+  no-restricted-modules: 0
+
+  # Disallows use of synchronous methods.
+  no-sync: 2
+
+
+  # Rules for STYLISTIC ISSUES.
+  # These rules are purely matters of style and are quite subjective.
+
+  # Enforce spacing inside array brackets.
+  array-bracket-spacing:
+    - 1
+    - always
+
+  # Enforce spacing inside single line blocks.
+  block-spacing:
+    - 2
+    - always
+
+  # Enforce one true brace style.
+  brace-style:
+    - 2
+    - 1tbs
+    -
+      allowSingleLine: true
+
+  # Enforce camel case names.
+  camelcase:
+    - 1
+    -
+      properties: always
+
+  # Consistent use of trailing commas in object and array literals.
+  # This rule is needed for IE8- support.
+  comma-dangle:
+    - 2
+    - never
+
+  # Enforce spacing before and after comma.
+  comma-spacing:
+    - 2
+    -
+      before: false
+      after: true
+
+  # Enforce one true comma style.
+  comma-style:
+    - 2
+    - last
+
+  # Require or disallow padding inside computed properties.
+  computed-property-spacing:
+    - 1
+    - never
+
+  # Enforce consistent naming when capturing the current execution context.
+  # This should be turned on if ESLint supports a regex for the
+  # matching value in the future for the ^[_]?self regex.
+  consistent-this:
+    - 0
+    - 'self'
+
+  # Enforce newline at the end of file, with no multiple empty lines.
+  eol-last:
+    - 2
+    - unix
+
+  # Enforce function expressions not having a name.
+  func-names: 0
+
+  # Enforce use of function declarations or expressions
+  # because of variable hoisting behavior.
+  func-style:
+    - 1
+    - declaration
+    -
+      allowArrowFunctions: true
+
+  # Blacklist certain identifiers to prevent them being used.
+  id-blacklist:
+    - 1
+    - e
+
+  # Enforces min/max identifier lengths (variable names, property names etc.).
+  id-length:
+    - 0
+    -
+      min: 3
+      max: 10
+      properties: never
+      exceptions:
+        - i
+
+  # Require identifiers to match the provided regular expression.
+  id-match:
+    - 0
+    - '^[a-z]+([A-Z][a-z]+)*$'
+    -
+      properties: false
+
+  # Set a specific tab width for your code.
+  indent:
+    - 2
+    - 2
+    -
+      SwitchCase: 1
+      VariableDeclarator:
+        var: 2
+        let: 2
+        const: 3
+
+  # Enforce whether double or single quotes should be used in JSX attributes.
+  jsx-quotes:
+    - 2
+    - prefer-single
+
+  # Enforce spacing between keys and values in object literal properties.
+  key-spacing:
+    - 1
+    -
+      beforeColon: false
+      afterColon: true
+      mode: minimum
+
+  # Enforce consistent spacing among keys/values in object literal properties.
+  keyword-spacing:
+    - 1
+    -
+      before: true
+
+  # Disallow mixed 'LF' and 'CRLF' as linebreaks.
+  linebreak-style:
+    - 2
+    - unix
+
+  # Enforces empty lines around comments.
+  lines-around-comment:
+    - 1
+    -
+      beforeBlockComment: true
+      afterBlockComment: false
+      beforeLineComment: false
+      afterLineComment: false
+      allowBlockStart: false
+      allowBlockEnd: false
+
+  # Specifies maximum depth that blocks can be nested.
+  max-depth:
+    - 1
+    - 5
+
+  # Specifies maximum length of a line in your program.
+  max-len:
+    - 1
+    -
+      code: 80
+      tabWidth: 4
+      comments: 80
+      ignorePattern: ''
+      ignoreTrailingComments: true
+      ignoreUrls: true
+
+  # Enforce a maximum file length.
+  max-lines:
+    - 0
+    -
+      max: 300
+      skipBlankLines: true
+      skipComments: true
+
+  # Specify the maximum depth callbacks can be nested.
+  max-nested-callbacks:
+    - 2
+    - 3
+
+  # Limits number of parameters that can be used in the function declaration.
+  max-params:
+    - 1
+    - 5
+
+  # Enforce a maximum number of statements allowed per line.
+  max-statements-per-line:
+    - 1
+    -
+      max: 2
+
+  # Specifies maximum number of statement allowed in a function.
+  max-statements:
+    - 1
+    - 25
+
+  # Enforce newlines between operands of ternary expressions.
+  multiline-ternary: 0
+
+  # Require a capital letter for constructors.
+  new-cap:
+    - 2
+    -
+      newIsCap: true
+      capIsNew: true
+      newIsCapExceptions: []
+      capIsNewExceptions: []
+
+  # Disallows omission of parentheses when invoking a constructor with no arguments.
+  new-parens: 2
+
+  # Disallow an empty newline after var statement.
+  newline-after-var:
+    - 0
+    - always
+
+  # Require or disallow an empty line after var declarations.
+  newline-before-return:
+    - 0
+
+  # Require a newline after each call in a method chain.
+  newline-per-chained-call:
+    - 0
+    -
+      ignoreChainWithDepth: 2
+
+  # Disallows use of the Array constructor.
+  no-array-constructor: 2
+
+  # Disallows use of bitwise operators.
+  no-bitwise: 0
+
+  # Disallow use of the continue statement.
+  no-continue: 1
+
+  # Disallows inline after code.
+  no-inline-comments: 1
+
+  # Disallows if as the only statement in an else block.
+  no-lonely-if: 2
+
+  # Disallow mixes of different operators.
+  no-mixed-operators: 1
+
+  # Disallows mixed spaces and tabs for indentation.
+  # Include "smart-tabs" option to suppresses warnings tabs used for alignment.
+  no-mixed-spaces-and-tabs: 2
+
+  # Disallows when more than 2 blank lines are used.
+  no-multiple-empty-lines:
+    - 1
+    -
+      max: 2
+      maxEOF: 1
+      maxBOF: 0
+
+  # Disallows negated conditions.
+  no-negated-condition: 2
+
+  # Disallows nested ternary expressions.
+  no-nested-ternary: 2
+
+  # Disallows use of the Object constructor.
+  no-new-object: 2
+
+  # Disallows use of unary operators, ++ and --.
+  no-plusplus: 0
+
+  # Disallow use of certain syntax in code.
+  no-restricted-syntax:
+    - 1
+    - WithStatement
+
+  # Disallows space between function identifier and invocation.
+  no-spaced-func: 2
+
+  # Disallows the use of ternary operators.
+  no-ternary: 0
+
+  # Disallows trailing whitespace at the end of lines.
+  no-trailing-spaces:
+    - 2
+    - skipBlankLines: false
+
+  # Disallows dangling underscores in identifiers.
+  no-underscore-dangle: 0
+
+  # Disallow the use of Boolean literals in conditional expressions.
+  no-unneeded-ternary: 0
+
+  # Disallow whitespace before properties.
+  no-whitespace-before-property: 2
+
+  # Enforce consistent line breaks inside braces.
+  object-curly-newline:
+    - 0
+    -
+      multiline: true
+      minProperties: 3
+
+  # Require or disallow padding inside curly braces.
+  object-curly-spacing:
+    - 1
+    - always
+    -
+      objectsInObjects: false
+      arraysInObjects: false
+
+  # Enforce placing object properties on separate lines.
+  object-property-newline:
+    - 1
+    -
+      allowMultiplePropertiesPerLine: true
+
+  # Require or disallow an newline around variable declarations.
+  one-var-declaration-per-line:
+    - 2
+    - initializations
+
+  # Disallows multiple var statements per function.
+  one-var:
+    - 0
+    - always
+
+  # Requires assignment operator shorthand or prohibit it entirely.
+  operator-assignment:
+    - 2
+    - always
+
+  # Enforce operators to be placed before or after line breaks.
+  operator-linebreak:
+    - 1
+    - after
+
+  # Enforces padding within blocks.
+  padded-blocks:
+    - 0
+    - always
+
+  # Requires quotes around object literal property names.
+  quote-props:
+    - 1
+    - consistent-as-needed
+    -
+      keywords: true
+      unnecessary: true
+      numbers: true
+
+  # Specifies whether double or single quotes should be used.
+  quotes:
+    - 2
+    - single
+    - avoid-escape
+
+  # Require JSDoc comment.
+  require-jsdoc:
+    - 1
+
+  # Disallows space before semicolon.
+  semi-spacing:
+    - 2
+    -
+      before: false
+      after: true
+
+  # Requires or disallows use of semicolons instead of ASI.
+  semi:
+    - 2
+    - always
+
+  # Enforces sorting variables within the same declaration block.
+  sort-vars: 0
+
+  # Requires space before blocks.
+  space-before-blocks:
+    - 2
+    -
+      functions: always
+      keywords: always
+      classes: always
+
+  # Requires space before function parentheses.
+  space-before-function-paren:
+    - 1
+    -
+      anonymous: never
+      named: never
+
+  # Requires spaces inside parentheses.
+  space-in-parens:
+    - 1
+    - always
+
+  # Requires spaces around operators.
+  space-infix-ops:
+    - 2
+    -
+      int32Hint: false
+
+  # Requires spaces before/after unary operators.
+  space-unary-ops:
+    - 2
+    -
+      words: true
+      nonwords: false
+
+  # Require or disallow a space immediately following // or /* in a comment.
+  spaced-comment:
+    - 2
+    - always
+    -
+      line:
+        markers:
+          - '/'
+        exceptions:
+          - '-'
+          - '+'
+      block:
+        markers:
+          - '!'
+        exceptions:
+          - '*'
+
+  # Require or disallow the Unicode BOM.
+  unicode-bom:
+    - 2
+    - never
+
+  # Requires regex literals to be wrapped in parentheses.
+  wrap-regex: 2
+
+
+  # Rules for ECMASCRIPT 6.
+  # These rules are only relevant to ES6 environments.
+
+  # Require braces in arrow function body.
+  arrow-body-style:
+    - 2
+    - as-needed
+
+  # Require parens in arrow function arguments.
+  arrow-parens:
+    - 2
+    - as-needed
+
+  # Require space before/after arrow function's arrow.
+  arrow-spacing:
+    - 2
+    -
+      before: true
+      after: true
+
+  # Verify super() callings in constructors.
+  constructor-super: 2
+
+  # Enforces the position of the * in generator functions.
+  generator-star-spacing:
+    - 2
+    -
+      before: true
+      after: false
+
+  # Disallow modifying variables of class declarations.
+  no-class-assign: 2
+
+  # Disallow arrow functions where they could be confused with comparisons.
+  no-confusing-arrow:
+    - 1
+    -
+      allowParens: true
+
+  # Disallow modifying variables that are declared using const.
+  no-const-assign: 2
+
+  # Disallow duplicate name in class members.
+  no-dupe-class-members: 2
+
+  # Disallow duplicate module imports.
+  no-duplicate-imports:
+    - 2
+    -
+      includeExports: true
+
+  # Disallow use of the new operator with the Symbol object.
+  # This rule should not be used in ES3/5 environments.
+  no-new-symbol: 0
+
+  # Restrict usage of specified node imports.
+  no-restricted-imports: 0
+
+  # Disallow to use this/super before super() calling in constructors.
+  no-this-before-super: 2
+
+  # Disallow unnecessary computed property keys in object literals.
+  no-useless-computed-key: 2
+
+  # Disallow unnecessary constructor.
+  no-useless-constructor: 2
+
+  # Disallow renaming import/export/destructured assignments to the same name.
+  no-useless-rename:
+    - 2
+    -
+      ignoreImport: false
+      ignoreExport: false
+      ignoreDestructuring: false
+
+  # Requires using let or const instead of var.
+  # This should be turned on when browser support is better.
+  no-var: 0
+
+  # Require method and property shorthand syntax for object literals.
+  object-shorthand:
+    - 0
+    - always
+
+  # Suggest using arrow functions as callbacks.
+  # Should not be enabled in ES3/5 environments.
+  prefer-arrow-callback: 0
+
+  # Suggest using of const declaration for variables that are never modified.
+  prefer-const: 1
+
+  # Suggest using Reflect methods where applicable.
+  # Should not be enabled in ES3/5 environments.
+  prefer-reflect: 0
+
+  # Suggest using the rest parameters instead of arguments.
+  # Should not be enabled in ES3/5 environments.
+  prefer-rest-params: 0
+
+  # Suggest using the spread operator instead of .apply().
+  # Should not be enabled in ES3/5 environments.
+  prefer-spread: 0
+
+  # Suggest using template literals instead of strings concatenation.
+  # Should not be enabled in ES3/5 environments.
+  prefer-template: 0
+
+  # Disallow generator functions that do not have yield.
+  require-yield: 1
+
+  # Enforce spacing between rest and spread operators and their expressions.
+  rest-spread-spacing:
+    - 2
+    - never
+
+  # Sort import declarations within module.
+  sort-imports:
+    - 1
+    -
+      ignoreCase: false
+      ignoreMemberSort: false
+      memberSyntaxSortOrder:
+        - none
+        - all
+        - multiple
+        - single
+
+  # Enforce spacing around embedded expressions of template strings.
+  template-curly-spacing:
+    - 1
+    - always
+
+  # Enforce spacing around the * in yield* expressions.
+  yield-star-spacing:
+    - 1
+    -
+      before: true
+      after: false

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-cssmin": "^0.1.7",
     "gulp-data": "^1.2.0",
     "gulp-debug": "^2.1.2",
+    "gulp-eslint": "^3.0.1",
     "gulp-foreach": "^0.1.0",
     "gulp-if": "^2.0.0",
     "gulp-ignore": "^2.0.1",

--- a/scripts/gulp/lint.js
+++ b/scripts/gulp/lint.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var gulp = require( 'gulp' );
+var plugins = require( 'gulp-load-plugins' )();
+
+/**
+ * Generic lint a script source.
+ * @param {string} src The path to the source JavaScript.
+ * @returns {Object} An output stream from gulp.
+ */
+function _genericLint( src ) {
+  return gulp.src( src, { base: './' } )
+    .pipe( plugins.eslint() )
+    .pipe( plugins.eslint.format() );
+}
+
+/**
+ * Lints the gulpfile for errors.
+ */
+gulp.task( 'lint:build', function() {
+  return _genericLint( [
+    'gulpfile.js',
+    'gulp/**/*.js'
+  ] );
+} );
+
+/**
+ * Lints the test js files for errors.
+ */
+gulp.task( 'lint:tests', function() {
+  return _genericLint( [
+    'test/accessibility/*.js',
+    'test/*.js'
+  ] );
+} );
+
+/**
+ * Lints the source js files for errors.
+ */
+gulp.task( 'lint:scripts', function() {
+  return _genericLint( [ 'src/**/src/*.js' ] );
+} );
+
+/**
+ * Lints all the js files for errors
+ */
+gulp.task( 'lint', [
+  'lint:build',
+  'lint:tests',
+  'lint:scripts'
+] );


### PR DESCRIPTION
Fixes part of #33. Eslint is a linter we use on many of our projects. The default eslintrc
files comes from our front-end standards.

Right now there's 124 errors and 521 warnings. Those should be fixed in
another PR.

## Additions

- Adds `gulp-eslint` and gulp tasks and directions.


## Testing

- run `gulp lint`

## Review

- @contolini 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/17678706/3926647c-6306-11e6-94ec-818f7a66bd2b.png)

👆 That'll be fixed in another PR.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)