### PR TITLE
Fixed linting errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **capital-framework:** [PATCH] Fixed various linting errors and warnings in tests and gulp tasks.
 
 ### Removed
-- 
+-
 
 ## 3.6.1 - 2016-08-12
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@
   when you run `gulp`.
 */
 
-var requireDir = require('require-dir');
+var requireDir = require( 'require-dir' );
 
 // Require all tasks in gulp/tasks, including subfolders
-requireDir('./scripts/gulp', {recurse: true});
+requireDir( './scripts/gulp', { recurse: true } );

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,8 @@
+env:
+  qunit: true
+  browser: true
+  jquery: true
+rules:
+  wrap-iife: 0
+  no-process-env: 0
+  no-console: 0

--- a/test/accessibility/wcag.js
+++ b/test/accessibility/wcag.js
@@ -1,57 +1,72 @@
-var finalhandler = require('finalhandler');
-var fs = require('fs');
-var http = require('http');
-var serveStatic = require('serve-static');
-var path = require('path');
-var wcag = require('wcag');
-var logSymbols = require('log-symbols');
+'use strict';
 
-if (!process.env.ACHECKER_ID) {
-  console.error('Please export an ACHECKER_ID environment variable.');
-  process.exit(1);
+var finalhandler = require( 'finalhandler' );
+var fs = require( 'fs' );
+var http = require( 'http' );
+var serveStatic = require( 'serve-static' );
+var path = require( 'path' );
+var wcag = require( 'wcag' );
+var logSymbols = require( 'log-symbols' );
+
+if ( !process.env.ACHECKER_ID ) {
+  throw new Error( 'Please export an ACHECKER_ID environment variable.' );
 }
 
-fs.readdir(path.join(__dirname, '..', '..', '/tmp'), function(err, dirs) {
-  dirs.forEach(function(component) {
-    if (component.indexOf('cf-') !== 0) return;
-    startServer(component, testComponent);
-  });
-});
+fs.readdir( path.join( __dirname, '..', '..', '/tmp' ), function( err, dirs ) {
+  if ( err ) {
+    throw new Error( 'Didn\'t read directory.' );
+  }
+  dirs.forEach( function( component ) {
+    if ( component.indexOf( 'cf-' ) !== 0 ) return;
+    startServer( component, testComponent );
+  } );
+} );
 
-function startServer(component, cb) {
-  var serve = serveStatic(path.join(__dirname, '/tmp/' + component));
-  var server = http.createServer(function(req, res){
-    var done = finalhandler(req, res);
-    serve(req, res, done);
-  });
+/**
+ * Start server to run tests.
+ * @param {string} component  - The Capital Framework compontent to serve up.
+ * @param {function} cb - The callback
+ */
+function startServer( component, cb ) {
+  var serve = serveStatic( path.join( __dirname, '/tmp/' + component ) );
+  var server = http.createServer( function( req, res ) {
+    var done = finalhandler( req, res );
+    serve( req, res, done );
+  } );
 
   // Listen on a random port
   // TODO: This doesn't verify the port is available. We might get collisions.
-  server.listen(0);
 
-  server.on('listening', function() {
+  server.listen( 0 );
+
+  server.on( 'listening', function() {
     var port = server.address().port;
-    cb(component, server, port);
-  });
+    cb( component, server, port );
+  } );
 }
 
-function testComponent(component, server, port) {
+function testComponent( component, server, port ) {
   var options = {
     id: process.env.ACHECKER_ID,
     uri: 'http://localhost:' + port + '/usage.html',
     guide: '508'
   };
-  wcag(options, function (error, data) {
-    if (error) return console.error(error);
-    if (data.status === 'PASS') {
-      console.error(logSymbols.success, ' ' + options.guide + ': ' + component);
+
+  wcag( options, function( error, data ) {
+    if ( error ) return console.error( error );
+    if ( data.status === 'PASS' ) {
+      console.error(
+        logSymbols.success, ' ' + options.guide + ': ' + component
+      );
     } else {
-      console.error(logSymbols.error, ' ' + options.guide + ': ' + component);
-      console.error(data.errors);
-      // TODO: Rather than immediately exiting we should collect the names of all
-      // failed components and display them at the end.
-      process.exit(1);
+      console.error(
+        logSymbols.error, ' ' + options.guide + ': ' + component
+      );
+      console.error( data.errors );
+      // TODO: Rather than immediately exiting we should collect the names of
+      // all failed components and display them at the end.
+      process.exit( 1 );
     }
     server.close();
-  });
+  } );
 }

--- a/test/cf-expandables.js
+++ b/test/cf-expandables.js
@@ -1,385 +1,457 @@
-(function( $ ) {
-  /*
-    ======== A Handy Little QUnit Reference ========
-    http://api.qunitjs.com/
+'use strict';
 
-    Test methods:
-      module(name, {[setup][ ,teardown]})
-      test(name, callback)
-      expect(numberOfAssertions)
-      stop(increment)
-      start(decrement)
-    Test assertions:
-      ok(value, [message])
-      equal(actual, expected, [message])
-      notEqual(actual, expected, [message])
-      deepEqual(actual, expected, [message])
-      notDeepEqual(actual, expected, [message])
-      strictEqual(actual, expected, [message])
-      notStrictEqual(actual, expected, [message])
-      throws(block, [expected], [message])
-  */
+( function( $ ) {
+
+ /**
+  *  ======== A Handy Little QUnit Reference ========
+  *  http://api.qunitjs.com/
+  *
+  *  Test methods:
+  *    module(name, {[setup][ ,teardown]})
+  *    test(name, callback)
+  *    expect(numberOfAssertions)
+  *    stop(increment)
+  *    start(decrement)
+  *  Test assertions:
+  *    ok(value, [message])
+  *    equal(actual, expected, [message])
+  *    notEqual(actual, expected, [message])
+  *    deepEqual(actual, expected, [message])
+  *    notDeepEqual(actual, expected, [message])
+  *    strictEqual(actual, expected, [message])
+  *    notStrictEqual(actual, expected, [message])
+  *    throws(block, [expected], [message])
+  **/
 
   module( 'cf-expandables', {
     // This will run before each test in this module.
     setup: function() {
-      this.$testSubjectOne = $('#test-subject-one');
-      this.$testSubjectTwo = $('#test-subject-two');
-      this.$testSubjectThreeA = $('#test-subject-three-a');
-      this.$testSubjectThreeB = $('#test-subject-three-b');
-      this.$testSubjectFour = $('#test-subject-four');
-      this.$testSubjectFourA = $('#test-subject-four-a');
-      this.$testSubjectFourAContent = $('#test-subject-four-a_content');
-      this.$testSubjectFourB = $('#test-subject-four-b');
-      this.$testSubjectFourBContent = $('#test-subject-four-b_content');
+      this.$testSubjectOne = $( '#test-subject-one' );
+      this.$testSubjectTwo = $( '#test-subject-two' );
+      this.$testSubjectThreeA = $( '#test-subject-three-a' );
+      this.$testSubjectThreeB = $( '#test-subject-three-b' );
+      this.$testSubjectFour = $( '#test-subject-four' );
+      this.$testSubjectFourA = $( '#test-subject-four-a' );
+      this.$testSubjectFourAContent = $( '#test-subject-four-a_content' );
+      this.$testSubjectFourB = $( '#test-subject-four-b' );
+      this.$testSubjectFourBContent = $( '#test-subject-four-b_content' );
     }
-  });
+  } );
 
   test( 'Verify initial default collapsed state', function() {
     expect( 6 );
     ok(
-      !$('#test-subject-one .expandable_content').is(':visible'),
+      !$( '#test-subject-one .expandable_content' ).is( ':visible' ),
       'The content should be collapsed'
     );
     ok(
-      $('#test-subject-one .expandable_cue-open').is(':visible'),
+      $( '#test-subject-one .expandable_cue-open' ).is( ':visible' ),
       'The open cue should be visible'
     );
     ok(
-      !$('#test-subject-one .expandable_cue-close').is(':visible'),
+      !$( '#test-subject-one .expandable_cue-close' ).is( ':visible' ),
       'The close cue should be hidden'
     );
     ok(
-      ( $('#test-subject-one .expandable_target').attr('aria-pressed') === 'false' ),
+      $( '#test-subject-one .expandable_target' )
+        .attr( 'aria-pressed' ) === 'false',
       'The target should have an aria-pressed attribute set to false'
     );
     ok(
-      ( $('#test-subject-one .expandable_target').attr('aria-controls') === $('#test-subject-one .expandable_content').attr('id') ),
-      'The target should have an aria-controls attribute set to the id attribute of the content'
+      $( '#test-subject-one .expandable_target' ).attr( 'aria-controls' ) ===
+        $( '#test-subject-one .expandable_content' ).attr( 'id' ),
+      'The target should have an aria-controls attribute set to ' +
+      'the id attribute of the content'
     );
     ok(
-      ( $('#test-subject-one .expandable_content').attr('aria-expanded') === 'false' ),
+      $( '#test-subject-one .expandable_content' ).attr( 'aria-expanded' ) ===
+      'false',
       'The content should have an aria-expanded attribute set to false'
     );
-  });
+  } );
 
   test( 'Verify initial state when using the expanded modifier', function() {
     expect( 6 );
     ok(
-      $('#test-subject-two .expandable_content').is(':visible'),
+      $( '#test-subject-two .expandable_content' ).is( ':visible' ),
       'The content should be expanded'
     );
     ok(
-      $('#test-subject-two .expandable_cue-close').is(':visible'),
+      $( '#test-subject-two .expandable_cue-close' ).is( ':visible' ),
       'The close cue should be visible'
     );
     ok(
-      !$('#test-subject-two .expandable_cue-open').is(':visible'),
+      !$( '#test-subject-two .expandable_cue-open' ).is( ':visible' ),
       'The open cue should be hidden'
     );
     ok(
-      ( $('#test-subject-two .expandable_target').attr('aria-pressed') === 'true' ),
+      $( '#test-subject-two .expandable_target' ).attr( 'aria-pressed' ) ===
+        'true',
       'The target should have an aria-pressed attribute that is true'
     );
     ok(
-      ( $('#test-subject-two .expandable_target').attr('aria-controls') === $('#test-subject-two .expandable_content').attr('id') ),
-      'The target should have an aria-controls attribute set to the id attribute of the content'
+      $( '#test-subject-two .expandable_target' ).attr( 'aria-controls' ) ===
+        $( '#test-subject-two .expandable_content' ).attr( 'id' ),
+      'The target should have an aria-controls attribute set to ' +
+      'the id attribute of the content'
     );
     ok(
-      ( $('#test-subject-two .expandable_content').attr('aria-expanded') === 'true' ),
+      $( '#test-subject-two .expandable_content' ).attr( 'aria-expanded' ) ===
+        'true',
       'The content should have an aria-expanded attribute set to true'
     );
-  });
+  } );
 
-  asyncTest( 'Verify expandables can open after being closed by default', function() {
-    expect( 5 );
-    var $expandable = this.$testSubjectOne;
-    $expandable.find('.expandable_target').trigger('click');
-    setTimeout(function() {
-      ok(
-        $expandable.find('.expandable_content').is(':visible'),
-        'The content should no longer be collapsed'
-      );
-      ok(
-        $expandable.find('.expandable_cue-close').is(':visible'),
-        'The close cue should be visible'
-      );
-      ok(
-        !$expandable.find('.expandable_cue-open').is(':visible'),
-        'The open cue should be hidden'
-      );
-      ok(
-        ( $expandable.find('.expandable_target').attr('aria-pressed') === 'true' ),
-        'The target should have an aria-pressed attribute that is true'
-      );
-      ok(
-        ( $expandable.find('.expandable_content').attr('aria-expanded') === 'true' ),
-        'The content should have an aria-expanded attribute set to true'
-      );
-      start();
-    }, 900);
-  });
+  asyncTest( 'Verify expandables can open after being closed by default',
+    function() {
+      expect( 5 );
+      var $expandable = this.$testSubjectOne;
+      $expandable.find( '.expandable_target' ).trigger( 'click' );
+      setTimeout( function() {
+        ok(
+          $expandable.find( '.expandable_content' ).is( ':visible' ),
+          'The content should no longer be collapsed'
+        );
+        ok(
+          $expandable.find( '.expandable_cue-close' ).is( ':visible' ),
+          'The close cue should be visible'
+        );
+        ok(
+          !$expandable.find( '.expandable_cue-open' ).is( ':visible' ),
+          'The open cue should be hidden'
+        );
+        ok(
+          $expandable.find( '.expandable_target' ).attr( 'aria-pressed' ===
+          'true' ),
+          'The target should have an aria-pressed attribute that is true'
+        );
+        ok(
+          $expandable.find( '.expandable_content' ).attr( 'aria-expanded' ) ===
+            'true',
+          'The content should have an aria-expanded attribute set to true'
+        );
+        start();
+      }, 900 );
+    }
+  );
 
-  asyncTest( 'Verify expandables can close after being opened by a click', function() {
-    expect( 5 );
-    var $expandable = this.$testSubjectOne;
-    // This expandable was opened in the previous test
-    $expandable.find('.expandable_target').trigger('click');
-    setTimeout(function() {
-      ok(
-        !$expandable.find('.expandable_content').is(':visible'),
-        'The content should be collapsed'
-      );
-      ok(
-        $expandable.find('.expandable_cue-open').is(':visible'),
-        'The open cue should be visible'
-      );
-      ok(
-        !$expandable.find('.expandable_cue-close').is(':visible'),
-        'The close cue should be hidden'
-      );
-      ok(
-        ( $expandable.find('.expandable_target').attr('aria-pressed') === 'false' ),
-        'The target should have an aria-pressed attribute that is false'
-      );
-      ok(
-        ( $expandable.find('.expandable_content').attr('aria-expanded') === 'false' ),
-        'The content should have an aria-expanded attribute set to true'
-      );
-      start();
-    }, 1800);
-  });
+  asyncTest( 'Verify expandables can close after being opened by a click',
+    function() {
+      expect( 5 );
+      var $expandable = this.$testSubjectOne;
+      // This expandable was opened in the previous test
+      $expandable.find( '.expandable_target' ).trigger( 'click' );
+      setTimeout( function() {
+        ok(
+          !$expandable.find( '.expandable_content' ).is( ':visible' ),
+          'The content should be collapsed'
+        );
+        ok(
+          $expandable.find( '.expandable_cue-open' ).is( ':visible' ),
+          'The open cue should be visible'
+        );
+        ok(
+          !$expandable.find( '.expandable_cue-close' ).is( ':visible' ),
+          'The close cue should be hidden'
+        );
+        ok(
+          $expandable.find( '.expandable_target' ).attr( 'aria-pressed' ) ===
+            'false',
+          'The target should have an aria-pressed attribute that is false'
+        );
+        ok(
+          $expandable.find( '.expandable_content' ).attr( 'aria-expanded' ) ===
+            'false',
+          'The content should have an aria-expanded attribute set to true'
+        );
+        start();
+      }, 1800 );
+    }
+  );
 
-  asyncTest( 'Verify expandables can close after being open by default', function() {
-    expect( 5 );
-    var $expandable = this.$testSubjectTwo;
-    $expandable.find('.expandable_target').trigger('click');
-    setTimeout(function() {
-      ok(
-        !$expandable.find('.expandable_content').is(':visible'),
-        'The content should be collapsed'
-      );
-      ok(
-        $expandable.find('.expandable_cue-open').is(':visible'),
-        'The open cue should be visible'
-      );
-      ok(
-        !$expandable.find('.expandable_cue-close').is(':visible'),
-        'The close cue should be hidden'
-      );
-      ok(
-        ( $expandable.find('.expandable_target').attr('aria-pressed') === 'false' ),
-        'The target should have an aria-pressed attribute that is false'
-      );
-      ok(
-        ( $expandable.find('.expandable_content').attr('aria-expanded') === 'false' ),
-        'The content should have an aria-expanded attribute set to true'
-      );
-      start();
-    }, 900);
-  });
+  asyncTest( 'Verify expandables can close after being open by default',
+    function() {
+      expect( 5 );
+      var $expandable = this.$testSubjectTwo;
+      $expandable.find( '.expandable_target' ).trigger( 'click' );
+      setTimeout( function() {
+        ok(
+          !$expandable.find( '.expandable_content' ).is( ':visible' ),
+          'The content should be collapsed'
+        );
+        ok(
+          $expandable.find( '.expandable_cue-open' ).is( ':visible' ),
+          'The open cue should be visible'
+        );
+        ok(
+          !$expandable.find( '.expandable_cue-close' ).is( ':visible' ),
+          'The close cue should be hidden'
+        );
+        ok(
+          $expandable.find( '.expandable_target' ).attr( 'aria-pressed' ) ===
+            'false',
+          'The target should have an aria-pressed attribute that is false'
+        );
+        ok(
+          $expandable.find( '.expandable_content' ).attr( 'aria-expanded' ) ===
+          'false',
+          'The content should have an aria-expanded attribute set to true'
+        );
+        start();
+      }, 900 );
+    }
+  );
 
-  asyncTest( 'Verify expandables can open after being closed by a click', function() {
-    expect( 5 );
-    var $expandable = this.$testSubjectTwo;
-    // This expandable was opened in the previous test
-    $expandable.find('.expandable_target').trigger('click');
-    setTimeout(function() {
-      ok(
-        $expandable.find('.expandable_content').is(':visible'),
-        'The content should no longer be collapsed'
-      );
-      ok(
-        $expandable.find('.expandable_cue-close').is(':visible'),
-        'The close cue should be visible'
-      );
-      ok(
-        !$expandable.find('.expandable_cue-open').is(':visible'),
-        'The open cue should be hidden'
-      );
-      ok(
-        ( $expandable.find('.expandable_target').attr('aria-pressed') === 'true' ),
-        'The target should have an aria-pressed attribute that is true'
-      );
-      ok(
-        ( $expandable.find('.expandable_content').attr('aria-expanded') === 'true' ),
-        'The content should have an aria-expanded attribute set to true'
-      );
-      start();
-    }, 1800);
-  });
+  asyncTest( 'Verify expandables can open after being closed by a click',
+    function() {
+      expect( 5 );
+      var $expandable = this.$testSubjectTwo;
+      // This expandable was opened in the previous test
+      $expandable.find( '.expandable_target' ).trigger( 'click' );
+      setTimeout( function() {
+        ok(
+          $expandable.find( '.expandable_content' ).is( ':visible' ),
+          'The content should no longer be collapsed'
+        );
+        ok(
+          $expandable.find( '.expandable_cue-close' ).is( ':visible' ),
+          'The close cue should be visible'
+        );
+        ok(
+          !$expandable.find( '.expandable_cue-open' ).is( ':visible' ),
+          'The open cue should be hidden'
+        );
+        ok(
+          $expandable.find( '.expandable_target' ).attr( 'aria-pressed' ) ===
+            'true',
+          'The target should have an aria-pressed attribute that is true'
+        );
+        ok(
+          $expandable.find( '.expandable_content' ).attr( 'aria-expanded' ) ===
+            'true',
+          'The content should have an aria-expanded attribute set to true'
+        );
+        start();
+      }, 1800 );
+    }
+  );
 
-  asyncTest( 'Verify activating expandable in accordion closes auto-opened expandable sibling', function() {
-    expect( 10 );
-    var $expandableA = this.$testSubjectThreeA,
-        $expandableB = this.$testSubjectThreeB;
-    // Note: $expandableA starts out as open by having the expandable__expanded
-    // class set in the initial markup. This test activates $expandableB,
-    // ensures that B opened correctly, and then ensures that A is now closed.
-    $expandableB.find('.expandable_target').trigger('click');
-    setTimeout(function() {
-      ok(
-        $expandableB.find('.expandable_content').is(':visible'),
-        'Expandable B content should no longer be collapsed'
-      );
-      ok(
-        $expandableB.find('.expandable_cue-close').is(':visible'),
-        'Expandable B close cue should be visible'
-      );
-      ok(
-        !$expandableB.find('.expandable_cue-open').is(':visible'),
-        'Expandable B open cue should be hidden'
-      );
-      ok(
-        ( $expandableB.find('.expandable_target').attr('aria-pressed') === 'true' ),
-        'Expandable B target should have an aria-pressed attribute that is true'
-      );
-      ok(
-        ( $expandableB.find('.expandable_content').attr('aria-expanded') === 'true' ),
-        'Expandable B content should have an aria-expanded attribute set to true'
-      );
-      ok(
-        !$expandableA.find('.expandable_content').is(':visible'),
-        'Expandable A content should now be collapsed'
-      );
-      ok(
-        !$expandableA.find('.expandable_cue-close').is(':visible'),
-        'Expandable A close cue should now be hidden'
-      );
-      ok(
-        $expandableA.find('.expandable_cue-open').is(':visible'),
-        'Expandable A open cue should now be visible'
-      );
-      ok(
-        ( $expandableA.find('.expandable_target').attr('aria-pressed') === 'false' ),
-        'Expandable A target should now have an aria-pressed attribute that is false'
-      );
-      ok(
-        ( $expandableA.find('.expandable_content').attr('aria-expanded') === 'false' ),
-        'Expandable A content should now have an aria-expanded attribute set to false'
-      );
-      start();
-    }, 900);
-  });
+  asyncTest( 'Verify activating expandable in accordion closes ' +
+             'auto-opened expandable sibling',
+    function() {
+      expect( 10 );
+      var $expandableA = this.$testSubjectThreeA,
+          $expandableB = this.$testSubjectThreeB;
+      // Note: $expandableA starts out as open by having the
+      // expandable__expanded class set in the initial markup.
+      // This test activates $expandableB, ensures that B opened correctly,
+      // and then ensures that A is now closed.
+      $expandableB.find( '.expandable_target' ).trigger( 'click' );
+      setTimeout( function() {
+        ok(
+          $expandableB.find( '.expandable_content' ).is( ':visible' ),
+          'Expandable B content should no longer be collapsed'
+        );
+        ok(
+          $expandableB.find( '.expandable_cue-close' ).is( ':visible' ),
+          'Expandable B close cue should be visible'
+        );
+        ok(
+          !$expandableB.find( '.expandable_cue-open' ).is( ':visible' ),
+          'Expandable B open cue should be hidden'
+        );
+        ok(
+          $expandableB.find( '.expandable_target' ).attr( 'aria-pressed' ) ===
+            'true',
+          'Expandable B target should have an aria-pressed attribute ' +
+          'that is true'
+        );
+        ok(
+          $expandableB.find( '.expandable_content' ).attr( 'aria-expanded' ) ===
+            'true',
+          'Expandable B content should have an aria-expanded attribute ' +
+          'set to true'
+        );
+        ok(
+          !$expandableA.find( '.expandable_content' ).is( ':visible' ),
+          'Expandable A content should now be collapsed'
+        );
+        ok(
+          !$expandableA.find( '.expandable_cue-close' ).is( ':visible' ),
+          'Expandable A close cue should now be hidden'
+        );
+        ok(
+          $expandableA.find( '.expandable_cue-open' ).is( ':visible' ),
+          'Expandable A open cue should now be visible'
+        );
+        ok(
+          $expandableA.find( '.expandable_target' ).attr( 'aria-pressed' ) ===
+            'false',
+          'Expandable A target should now have an aria-pressed attribute ' +
+          'that is false'
+        );
+        ok(
+          $expandableA.find( '.expandable_content' ).attr( 'aria-expanded' ) ===
+            'false',
+          'Expandable A content should now have an aria-expanded attribute ' +
+          'set to false'
+        );
+        start();
+      }, 900 );
+    }
+  );
 
-  asyncTest( 'Verify activating expandable in accordion closes click-opened expandable sibling', function() {
-    expect( 10 );
-    var $expandableA = this.$testSubjectThreeA,
-        $expandableB = this.$testSubjectThreeB;
-    // Note: $expandableB was opened by click in the previous test.
-    $expandableA.find('.expandable_target').trigger('click');
-    setTimeout(function() {
-      ok(
-        $expandableA.find('.expandable_content').is(':visible'),
-        'Expandable A content should no longer be collapsed'
-      );
-      ok(
-        $expandableA.find('.expandable_cue-close').is(':visible'),
-        'Expandable A close cue should be visible'
-      );
-      ok(
-        !$expandableA.find('.expandable_cue-open').is(':visible'),
-        'Expandable A open cue should be hidden'
-      );
-      ok(
-        ( $expandableA.find('.expandable_target').attr('aria-pressed') === 'true' ),
-        'Expandable A target should have an aria-pressed attribute that is true'
-      );
-      ok(
-        ( $expandableA.find('.expandable_content').attr('aria-expanded') === 'true' ),
-        'Expandable A content should have an aria-expanded attribute set to true'
-      );
-      ok(
-        !$expandableB.find('.expandable_content').is(':visible'),
-        'Expandable B content should now be collapsed'
-      );
-      ok(
-        !$expandableB.find('.expandable_cue-close').is(':visible'),
-        'Expandable B close cue should now be hidden'
-      );
-      ok(
-        $expandableB.find('.expandable_cue-open').is(':visible'),
-        'Expandable B open cue should now be visible'
-      );
-      ok(
-        ( $expandableB.find('.expandable_target').attr('aria-pressed') === 'false' ),
-        'Expandable B target should now have an aria-pressed attribute that is false'
-      );
-      ok(
-        ( $expandableB.find('.expandable_content').attr('aria-expanded') === 'false' ),
-        'Expandable B content should now have an aria-expanded attribute set to false'
-      );
-      start();
-    }, 1800);
-  });
+  asyncTest( 'Verify activating expandable in accordion closes ' +
+             'click-opened expandable sibling',
+    function() {
+      expect( 10 );
+      var $expandableA = this.$testSubjectThreeA,
+          $expandableB = this.$testSubjectThreeB;
+      // Note: $expandableB was opened by click in the previous test.
+      $expandableA.find( '.expandable_target' ).trigger( 'click' );
+      setTimeout( function() {
+        ok(
+          $expandableA.find( '.expandable_content' ).is( ':visible' ),
+          'Expandable A content should no longer be collapsed'
+        );
+        ok(
+          $expandableA.find( '.expandable_cue-close' ).is( ':visible' ),
+          'Expandable A close cue should be visible'
+        );
+        ok(
+          !$expandableA.find( '.expandable_cue-open' ).is( ':visible' ),
+          'Expandable A open cue should be hidden'
+        );
+        ok(
+          $expandableA.find( '.expandable_target' ).attr( 'aria-pressed' ) ===
+            'true',
+          'Expandable A target should have an aria-pressed attribute ' +
+          'that is true'
+        );
+        ok(
+          $expandableA.find( '.expandable_content' ).attr( 'aria-expanded' ) ===
+           'true',
+          'Expandable A content should have an aria-expanded attribute ' +
+          'set to true'
+        );
+        ok(
+          !$expandableB.find( '.expandable_content' ).is( ':visible' ),
+          'Expandable B content should now be collapsed'
+        );
+        ok(
+          !$expandableB.find( '.expandable_cue-close' ).is( ':visible' ),
+          'Expandable B close cue should now be hidden'
+        );
+        ok(
+          $expandableB.find( '.expandable_cue-open' ).is( ':visible' ),
+          'Expandable B open cue should now be visible'
+        );
+        ok(
+          $expandableB.find( '.expandable_target' ).attr( 'aria-pressed' ) ===
+           'false',
+          'Expandable B target should now have an aria-pressed attribute ' +
+          'that is false'
+        );
+        ok(
+          $expandableB.find( '.expandable_content' ).attr( 'aria-expanded' ) ===
+            'false',
+          'Expandable B content should now have an aria-expanded attribute ' +
+          'set to false'
+        );
+        start();
+      }, 1800 );
+    }
+  );
 
-  test( 'Verify that expanding an expandable with nested expandables does not trigger expansion on the nested expandables', function() {
-    expect( 1 );
-    var expandable = this.$testSubjectFour.get( 0 ),
-        $expandableAContent = this.$testSubjectFourAContent,
-        $expandableBContent = this.$testSubjectFourBContent;
-    expandable.expand( 0 );
-    ok(
-      !$expandableAContent.is(':visible') && !$expandableBContent.is(':visible'),
-      'Nested expandables should remain collapsed after the parent is expanded.'
-    );
-  });
+  test( 'Verify that expanding an expandable with nested expandables ' +
+        'does not trigger expansion on the nested expandables',
+    function() {
+      expect( 1 );
+      var expandable = this.$testSubjectFour.get( 0 ),
+          $expandableAContent = this.$testSubjectFourAContent,
+          $expandableBContent = this.$testSubjectFourBContent;
+      expandable.expand( 0 );
+      ok(
+        !$expandableAContent.is( ':visible' ) &&
+          !$expandableBContent.is( ':visible' ),
+        'Nested expandables should remain collapsed ' +
+        'after the parent is expanded.'
+      );
+    }
+  );
 
-  test( 'Verify that expanding a nested expandable with nested expandables does not trigger expansion on the nested expandables', function() {
-    expect( 1 );
-    var expandableA = this.$testSubjectFourA.get( 0 ),
-        $expandableBContent = this.$testSubjectFourBContent;
-    expandableA.expand( 0 );
-    ok(
-      !$expandableBContent.is(':visible'),
-      'Nested expandables should remain collapsed after the parent is expanded.'
-    );
-  });
+  test( 'Verify that expanding a nested expandable with nested expandables ' +
+        'does not trigger expansion on the nested expandables',
+    function() {
+      expect( 1 );
+      var expandableA = this.$testSubjectFourA.get( 0 ),
+          $expandableBContent = this.$testSubjectFourBContent;
+      expandableA.expand( 0 );
+      ok(
+        !$expandableBContent.is( ':visible' ),
+        'Nested expandables should remain collapsed after ' +
+        'the parent is expanded.'
+      );
+    }
+  );
 
-  test( 'Verify that collapsing an expandable with nested expandables does not trigger collapsing on the nested expandables', function() {
-    expect( 1 );
-    var expandable = this.$testSubjectFour.get( 0 ),
-        expandableA = this.$testSubjectFourA.get( 0 ),
-        $expandableAContent = this.$testSubjectFourAContent,
-        expandableB = this.$testSubjectFourB.get( 0 ),
-        $expandableBContent = this.$testSubjectFourBContent;
-    expandableA.expand( 0 );
-    expandableB.expand( 0 );
-    expandable.collapse( 0 );
-    ok(
-      $expandableAContent.attr('aria-expanded') === 'true' && $expandableBContent.attr('aria-expanded') === 'true',
-      'Nested expandables should remain expanded after the parent is collapsed.'
-    );
-  });
+  test( 'Verify that collapsing an expandable with nested expandables ' +
+        'does not trigger collapsing on the nested expandables',
+    function() {
+      expect( 1 );
+      var expandable = this.$testSubjectFour.get( 0 ),
+          expandableA = this.$testSubjectFourA.get( 0 ),
+          $expandableAContent = this.$testSubjectFourAContent,
+          expandableB = this.$testSubjectFourB.get( 0 ),
+          $expandableBContent = this.$testSubjectFourBContent;
+      expandableA.expand( 0 );
+      expandableB.expand( 0 );
+      expandable.collapse( 0 );
+      ok(
+        $expandableAContent.attr( 'aria-expanded' ) === 'true' &&
+          $expandableBContent.attr( 'aria-expanded' ) === 'true',
+        'Nested expandables should remain expanded after ' +
+        'the parent is collapsed.'
+      );
+    }
+  );
 
   test( 'Verify the constrainValue method', function() {
     expect( 3 );
     ok(
-      ( $.fn.expandable.constrainValue( 100, 200, 50 ) === 100 ),
-      'The value 50 is less than the minimum so constrainValue should return the minimum'
+      $.fn.expandable.constrainValue( 100, 200, 50 ) === 100,
+      'The value 50 is less than the minimum so constrainValue ' +
+      'should return the minimum'
     );
     ok(
-      ( $.fn.expandable.constrainValue( 100, 200, 250 ) === 200 ),
-      'The value 250 is more than the maximum so constrainValue should return the maximum'
+      $.fn.expandable.constrainValue( 100, 200, 250 ) === 200,
+      'The value 250 is more than the maximum so constrainValue ' +
+      'should return the maximum'
     );
     ok(
-      ( $.fn.expandable.constrainValue( 100, 200, 150 ) === 150 ),
-      'The value 150 is between the minimum and maximum so constrainValue should return 150'
+      $.fn.expandable.constrainValue( 100, 200, 150 ) === 150,
+      'The value 150 is between the minimum and maximum so constrainValue ' +
+      'should return 150'
     );
-  });
+  } );
 
   test( 'Verify dynamic duration based on height', function() {
     expect( 2 );
-    $('#test-subject-one .expandable_content').height( 200 );
+    $( '#test-subject-one .expandable_content' ).height( 200 );
     ok(
-      ( $.fn.expandable.calculateExpandDuration( $('#test-subject-one .expandable_content').height() ) === 800 ),
+      $.fn.expandable.calculateExpandDuration(
+        $( '#test-subject-one .expandable_content' ).height()
+      ) === 800,
       'The duration should be (height * 4) when expanding'
     );
-    $('#test-subject-two .expandable_content').height( 200 ).trigger('click');
+    $( '#test-subject-two .expandable_content' ).height( 200 )
+      .trigger( 'click' );
     ok(
-      ( $.fn.expandable.calculateCollapseDuration( $('#test-subject-two .expandable_content').height() ) === 400 ),
+      $.fn.expandable.calculateCollapseDuration(
+          $( '#test-subject-two .expandable_content' ).height()
+      ) === 400,
       'The duration should be (height * 2) when collapsing'
     );
-  });
+  } );
 
-}( jQuery ));
+}( jQuery ) );

--- a/test/cf-expandables.js
+++ b/test/cf-expandables.js
@@ -121,8 +121,8 @@
           'The open cue should be hidden'
         );
         ok(
-          $expandable.find( '.expandable_target' ).attr( 'aria-pressed' ===
-          'true' ),
+          $expandable.find( '.expandable_target' ).attr( 'aria-pressed') ===
+          'true',
           'The target should have an aria-pressed attribute that is true'
         );
         ok(

--- a/test/cf-tables.js
+++ b/test/cf-tables.js
@@ -1,98 +1,113 @@
-(function( $ ) {
-  /*
-    ======== A Handy Little QUnit Reference ========
-    http://api.qunitjs.com/
+'use strict';
 
-    Test methods:
-      module(name, {[setup][ ,teardown]})
-      test(name, callback)
-      expect(numberOfAssertions)
-      stop(increment)
-      start(decrement)
-    Test assertions:
-      ok(value, [message])
-      equal(actual, expected, [message])
-      notEqual(actual, expected, [message])
-      deepEqual(actual, expected, [message])
-      notDeepEqual(actual, expected, [message])
-      strictEqual(actual, expected, [message])
-      notStrictEqual(actual, expected, [message])
-      throws(block, [expected], [message])
-  */
+( function( $ ) {
+
+ /**
+  *  ======== A Handy Little QUnit Reference ========
+  *  http://api.qunitjs.com/
+  *
+  *  Test methods:
+  *    module(name, {[setup][ ,teardown]})
+  *    test(name, callback)
+  *    expect(numberOfAssertions)
+  *    stop(increment)
+  *    start(decrement)
+  *  Test assertions:
+  *    ok(value, [message])
+  *    equal(actual, expected, [message])
+  *    notEqual(actual, expected, [message])
+  *    deepEqual(actual, expected, [message])
+  *    notDeepEqual(actual, expected, [message])
+  *    strictEqual(actual, expected, [message])
+  *    notStrictEqual(actual, expected, [message])
+  *    throws(block, [expected], [message])
+  **/
 
   module( 'cf-tables', {
     // This will run before each test in this module.
     setup: function() {
-      this.$testOne = $('#test-one');
+      this.$testOne = $( '#test-one' );
     }
-  });
+  } );
 
   test( '".sortable__start-up class sorts on load', function() {
     expect( 3 );
     ok(
-      $('#test-one tbody tr:nth-child(1) td:nth-child(3)').text().trim() === '1.2 mi',
+      $( '#test-one tbody tr:nth-child(1) td:nth-child(3)' )
+        .text().trim() === '1.2 mi',
       'Row 1 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(5) td:nth-child(3)').text().trim() === '2.6 mi',
+      $( '#test-one tbody tr:nth-child(5) td:nth-child(3)' )
+        .text().trim() === '2.6 mi',
       'Row 3 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(7) td:nth-child(3)').text().trim() === '11.1 mi',
+      $( '#test-one tbody tr:nth-child(7) td:nth-child(3)' )
+        .text().trim() === '11.1 mi',
       'Row 7 is correct'
     );
-  });
+  } );
 
   test( 'Column sorts low-to-high on click ', function() {
     expect( 3 );
-    $('#lang-sort').click();
+    $( '#lang-sort' ).click();
     ok(
-      $('#test-one tbody tr:nth-child(1) td:nth-child(2)').text().trim() === 'English',
+      $( '#test-one tbody tr:nth-child(1) td:nth-child(2)' )
+        .text().trim() === 'English',
       'Row 1 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(4) td:nth-child(2)').text().trim() === 'English, French, Spanish',
+      $( '#test-one tbody tr:nth-child(4) td:nth-child(2)' )
+        .text().trim() === 'English, French, Spanish',
       'Row 4 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(7) td:nth-child(2)').text().trim() === 'English, Spanish',
+      $( '#test-one tbody tr:nth-child(7) td:nth-child(2)' )
+        .text().trim() === 'English, Spanish',
       'Row 7 is correct'
     );
-  });
+  } );
 
   test( 'Column sorts high-to-low on second click ', function() {
     expect( 3 );
-    $('#lang-sort').click();
+    $( '#lang-sort' ).click();
     ok(
-      $('#test-one tbody tr:nth-child(7) td:nth-child(2)').text().trim() === 'English',
+      $( '#test-one tbody tr:nth-child(7) td:nth-child(2)' )
+        .text().trim() === 'English',
       'Row 7 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(4) td:nth-child(2)').text().trim() === 'English, French, Spanish',
+      $( '#test-one tbody tr:nth-child(4) td:nth-child(2)' )
+        .text().trim() === 'English, French, Spanish',
       'Row 4 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(1) td:nth-child(2)').text().trim() === 'English, Spanish',
+      $( '#test-one tbody tr:nth-child(1) td:nth-child(2)' )
+        .text().trim() === 'English, Spanish',
       'Row 1 is correct'
     );
-  });
+  } );
 
   test( 'Column sorts low-to-high on click for "number" sort type', function() {
     expect( 3 );
-    $('#dist-sort').click();
+    $( '#dist-sort' ).click();
     ok(
-      $('#test-one tbody tr:nth-child(1) td:nth-child(3)').text().trim() === '1.2 mi',
+      $( '#test-one tbody tr:nth-child(1) td:nth-child(3)' )
+        .text().trim() === '1.2 mi',
       'Row 1 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(5) td:nth-child(3)').text().trim() === '2.6 mi',
+      $( '#test-one tbody tr:nth-child(5) td:nth-child(3)' )
+        .text().trim() === '2.6 mi',
       'Row 3 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(7) td:nth-child(3)').text().trim() === '11.1 mi',
+      $( '#test-one tbody tr:nth-child(7) td:nth-child(3)' )
+        .text().trim() === '11.1 mi',
       'Row 7 is correct'
     );
-  });
+  } );
 
 
-}( jQuery ));
+}( jQuery ) );


### PR DESCRIPTION
Fixed a large, large number of linting errors by:
- Running `eslint --fix` on several files
- Creating new linting rules for test files (We use this approach in
  cfgov-refresh)
- Chopping up extra lines in some of our tests


## Testing

- Without merging #382, you can run eslint by running `npm i eslint -g` on each affected file

```sh
eslint gulpfile.js
eslint test/accessibility/wcag.js
eslint test/cf-expandables.js
eslint test/cf-tables.js
```

## Review

- @anselmbradford 

## Screenshots

### Before

lint:build

![image](https://cloud.githubusercontent.com/assets/1860176/17681436/bc8bf0ae-6313-11e6-9f48-a71835a35691.png)

lint:scripts

![image](https://cloud.githubusercontent.com/assets/1860176/17681456/d2e09b16-6313-11e6-91fe-fb2f30bcbdc1.png)

lint:tests

![image](https://cloud.githubusercontent.com/assets/1860176/17681477/f47194c4-6313-11e6-8706-c62165fc36d1.png)


### After

Nothing for lint:build

lint:scripts

![image](https://cloud.githubusercontent.com/assets/1860176/17681328/1c3f794a-6313-11e6-8abd-e42ffaffac1c.png)

lint:tests

![image](https://cloud.githubusercontent.com/assets/1860176/17681331/21c799c4-6313-11e6-9bf9-15959586dcfa.png)

