### PR TITLE
Add support for bleeding heroes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-core:** [MAJOR] Update to atomic naming conventions:
   - `.webfont-<style>()` mixins renamed to `.u-webfont-<style>()`
   - `body` font is now `@webfont-regular` (Arial, by default).
+- **cf-layout:** [MAJOR] Update hero to atomic naming conventions
+- **cf-layout:** [MAJOR] Enable hero images that bleed off the top and bottom of
+  the hero container when in the two-column layout
 - **cf-pagination** [MAJOR] Update to atomic naming conventions:
 
 ### Removed
@@ -22,7 +25,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - `.u-link-child__hover`
   - Ability to use radio buttons and checkboxes within a `label`
 
-## Fixed
+### Fixed
 - **cf-typography:** [PATCH] Fixed old variables removed from cf-core
 
 ## 3.6.1 - 2016-08-12

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "release": "./scripts/travis/release.sh",
     "build": "gulp build",
     "test": "gulp test && node test/accessibility/wcag.js",
-    "cf-link": "cd ./src/cf-core && npm link && cd ../cf-buttons/ && npm link && cd ../cf-typography && npm link && cd ../cf-pagination && npm link"
+    "cf-link": "cd ./src/cf-core && npm link && cd ../cf-buttons && npm link && cd ../cf-typography && npm link && cd ../cf-layout && npm link && npm link && cd ../cf-pagination && npm link"
   },
   "devDependencies": {
     "bluebird": "^3.0.5",

--- a/src/cf-layout/src/molecules/heroes.less
+++ b/src/cf-layout/src/molecules/heroes.less
@@ -15,12 +15,14 @@
 @hero-overlay-bg:     #5b616b; // $color-gray
 @hero-overlay-text:   white;
 
+
 .m-hero {
     background-color: @hero-bg;
 
     .respond-to-min( @bp-sm-min, {
         display: table;
         width: 100%;
+        height: @hero-desktop-height;
     } );
 
     &_wrapper {
@@ -28,13 +30,12 @@
         padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
 
         .respond-to-min( @bp-sm-min, {
-            padding-right: unit( 15px / @base-font-size-px, em );
-            padding-left: unit( 15px / @base-font-size-px, em );
+            display: table-row;
         } );
 
-        .respond-to-min( @bp-med-min, {
-            padding-top: unit( 45px / @base-font-size-px, em );
-            padding-bottom: unit( 45px / @base-font-size-px, em );
+        .respond-to-max( @bp-xs-max, {
+            padding-top: unit( @grid_gutter-width / @base-font-size-px, em );
+            padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
         } );
     }
 
@@ -44,6 +45,10 @@
         .respond-to-min( @bp-sm-min, {
             .grid_column( 7, 12 );
 
+            padding: unit( @grid_gutter-width / @base-font-size-px, em )
+                     unit( 15px / @base-font-size-px, em );
+
+            // Keep the text vertically centered
             display: table-cell;
             vertical-align: middle;
         } );
@@ -71,53 +76,102 @@
         } );
     }
 
-    &_subhead:not( :last-child ) {
-        margin-bottom: unit( @grid_gutter-width / @size-iv, em );
-
-        .respond-to-min( @bp-med-min, {
-            margin-bottom: unit( @grid_gutter-width / @size-iii, em );
-        } );
+    &_subhead:last-child {
+        margin-bottom: 0;
     }
 
     &_cta {
-        display: block;
+        &:not( .btn ) {
+            border-bottom-width: 1px;
+        }
+
+        .respond-to-min( @bp-sm-min, {
+            margin-bottom: 0;
+        } );
     }
 
-    &_image {
+    &_image-wrapper {
         .grid_column( 1, 1 );
-
-        // height is the same as min-height in a table
-        height: unit( @hero-image-height / @base-font-size-px, em );
-
-        background-position: center;
-        background-repeat: no-repeat;
-        background-size: cover;
 
         .respond-to-min( @bp-sm-min, {
             .grid_column( 5, 12 );
 
-            // Keep the text and image vertically centered
+            // Keep the image vertically centered
             display: table-cell;
             vertical-align: middle;
-
-            background-size: contain;
         } );
 
         .respond-to-max( @bp-xs-max, {
             margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
         } );
+
+        &__bleed-vertical {
+            position: relative;
+
+            .m-hero_image {
+                display: block;
+                height: auto;
+            }
+
+            .m-hero_image__bleeding {
+                width: 100%;
+                height: 100%;
+                position: absolute;
+                top: 0;
+                background-position: center;
+                background-repeat: no-repeat;
+                background-size: cover;
+            }
+
+            .respond-to-max( @bp-xs-max, {
+                .m-hero_image__bleeding {
+                    display: none;
+                }
+            } );
+
+            .respond-to-min( @bp-sm-min, {
+                .m-hero_image {
+                    display: none;
+                }
+            } );
+
+            .respond-to-min( @bp-med-min, {
+                .m-hero_image {
+                    display: none;
+                }
+            } );
+        }
+    }
+
+    &_image {
+        // height is the same as min-height in a table
+        height: unit( @hero-image-height / @base-font-size-px, em );
+
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: contain;
     }
 
     &__overlay {
-        .m-hero_wrapper {
-            background-repeat: no-repeat;
-        }
+        background-repeat: no-repeat;
+        background-size: cover;
 
         .respond-to-max( @bp-xs-max, {
+            // Overwrite the image that is set in the markup because
+            // we're showing the image container below instead
+            background-image: none !important;
+
             .m-hero_wrapper {
-                // Overwrite the image that is set in the markup because
-                // we're showing the image container below instead
-                background: transparent !important;
+                // Remove wrapper bottom padding
+                padding-bottom: 0;
+            }
+
+            .m-hero_image-wrapper {
+                border-width: 0;
+            }
+
+            .m-hero_image {
+                background-size: cover;
             }
         } );
 

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -1265,28 +1265,33 @@ A hero consists of a headline, a small amount of additional text,
 an optional call to action, and an illustration.
 Its background color is flush with the sides of the screen, and the content is centered with wrapper classes.
 
-The illustration can be customized by setting the `background-image` property on the `.hero_image` element.
+The illustration can be customized by setting the `background-image` property on the `.m-hero_image` element.
 
 On small screens (or where media queries are not supported),
-the text spans the full width of the `.hero_wrapper` and the illustration is displayed underneath.
+the text spans the full width of the `.m-hero_wrapper` and the illustration is displayed underneath.
 
 For larger screen sizes, media queries are used to position the illustration to the right of the text.
 
-On desktop, the hero should not exceed 285px in height.
+At the grid's maximum width and above, the hero should not exceed 285px in height.
 The image should be 195px in height to conform to this standard.
 
+### Standard hero with illustration
+
 <section class="m-hero">
     <div class="m-hero_wrapper wrapper">
         <div class="m-hero_text">
             <h1 class="m-hero_heading">Hero title</h1>
             <p class="m-hero_subhead">
-                Hero text goes here
+                Hero text goes here. This paragraph has a recommended maximum length of 185 characters.
+                This paragraph has a recommended maximum length of 185 characters.
             </p>
-            <p class="m-hero_cta">
-                <a>Call to action</a>
-            </p>
+            <a class="m-hero_cta" href="#">
+                Call to action
+            </a>
         </div>
-        <div class="m-hero_image" style="background-image: url('http://placekitten.com/g/400/195')"></div>
+        <div class="m-hero_image-wrapper">
+            <div class="m-hero_image" style="background-image: url('http://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')"></div>
+        </div>
     </div>
 </section>
 
@@ -1296,13 +1301,46 @@ The image should be 195px in height to conform to this standard.
         <div class="m-hero_text">
             <h1 class="m-hero_heading">Hero title</h1>
             <p class="m-hero_subhead">
-                Hero text goes here
+                Hero text goes here. This paragraph has a recommended maximum length of 185 characters.
+                This paragraph has a recommended maximum length of 185 characters.
             </p>
-            <p class="m-hero_cta">
-                <a>Call to action</a>
-            </p>
+            <a class="m-hero_cta" href="#">
+                Call to action
+            </a>
         </div>
-        <div class="m-hero_image" style="background-image: url('http://placekitten.com/g/400/195')"></div>
+        <div class="m-hero_image-wrapper">
+            <div class="m-hero_image" style="background-image: url('http://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')"></div>
+        </div>
     </div>
 </section>
 ```
+
+### Hero with bleeding illustration
+{: class="u-mt30"}
+
+_Examples coming when we can hotlink to the images live on our server,
+so they don't have to be included in this repo._
+
+### Hero with photograph
+{: class="u-mt30"}
+
+The text overlays the photograph at larger screen sizes.
+It's best to avoid a non-button call to action in these,
+as it's unlikely that the Pacific Blue will have accessible contrast with a
+non-white (or light gray) background.
+
+<section class="m-hero m-hero__overlay"
+         style="background-image: url('http://files.consumerfinance.gov/f/images/PC_hero.original.jpg')">
+    <div class="m-hero_wrapper wrapper">
+        <div class="m-hero_text">
+            <h1 class="m-hero_heading">Hero title</h1>
+            <p class="m-hero_subhead">
+                Hero text goes here. This paragraph has a recommended maximum length of 185 characters.
+                This example paragraph is 151 characters long.
+            </p>
+        </div>
+        <div class="m-hero_image-wrapper">
+            <div class="m-hero_image" style="background-image: url('http://files.consumerfinance.gov/f/images/pc_mobile_1.original.jpg')"></div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
This PR enables hero images that bleed off the top and bottom of the hero container when in the two-column layout.

It supersedes #381 with its botched merge and duplicommits.


## Additions

- A new `__bleed-vertical` modifier to trigger the various vertical bleed styles.


## Changes

- Major (as in breaking) refactor of heroes, generally. The big changes here relate to updating the markup for bleed to work for a variable hero height and enabling an alternate image for the single-column layout.


## Testing

- See jimmynotjim/capital-framework-sandbox#16


## Review

- @cfpb/front-end-team-admin 


## Screenshots

### Max width
![screen shot 2016-08-12 at 17 16 31](https://cloud.githubusercontent.com/assets/1044670/17637310/df7d38b2-60b0-11e6-9633-5e91fdad6831.png)

### Min width at two columns
![screen shot 2016-08-12 at 17 17 56](https://cloud.githubusercontent.com/assets/1044670/17637321/e9a37a40-60b0-11e6-9de0-a1d26bd37c4a.png)

### Single-column layout with alternate image
![screen shot 2016-08-12 at 17 18 43](https://cloud.githubusercontent.com/assets/1044670/17637355/114c58d2-60b1-11e6-9d2a-945336920ec4.png)


## Todos

- Add bleeding hero examples to usage.md once one of these is live and I can hotlink to the images, rather than including them in this repo.


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
