### PR TITLE
Fix disabled select state hover

### DIFF
--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -343,6 +343,10 @@ textarea {
     select[disabled] {
         color: @input-disabled-text;
         background-color: @input-disabled;
+
+        &:hover {
+            outline: 2px solid transparent;
+        }
     }
 
     select option:disabled {


### PR DESCRIPTION
Small fix to remove the blue outline on hover from the disabled select element.

## Additions

- hover style for disabled select to return the outline to its default transparent style.

## Review

- @jimmynotjim 

## Screenshots

#### Before
![screen shot 2016-08-22 at 6 26 56 pm](https://cloud.githubusercontent.com/assets/702526/17873928/5a67dea0-6896-11e6-9829-64d5cea063e2.png)

#### After
![screen shot 2016-08-22 at 6 26 43 pm](https://cloud.githubusercontent.com/assets/702526/17873929/5a6ae0be-6896-11e6-9de3-57d02bc0836a.png)

## Notes

- focus and active styles are irrelevant here since there is no focus or active state on a disabled input (browser default behavior)
- hover style is the same as the default select outline style



## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

