### PR TITLE
Remove .form-group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - `.figure__bordered`
   - `.u-link-child__hover`
   - Ability to use radio buttons and checkboxes within a `label`
+- **cf-forms**: [MAJOR] Removed deprecated items:
+  - `.form-group` and `.form-group_item`
 
 ### Fixed
 - **cf-typography:** [PATCH] Fixed old variables removed from cf-core

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -137,18 +137,6 @@ textarea {
 }
 
 //
-// Form group
-//
-
-.form-group + .form-group {
-    margin-top: unit(30px / @base-font-size-px, em );
-}
-
-.form-group_item + .form-group_item {
-    margin-top: unit( 15px / @base-font-size-px, em );
-}
-
-//
 // Input with button
 //
 


### PR DESCRIPTION
Form group is currently being used inconsistently across many projects
for layout purposes. This commit removes it, we'll have a PR for how we
can handle atomic design and form layout this sprint.

## Review
- @cfarm 