### PR TITLE
Moved base form styles from cf-core to cf-forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-layout:** [MAJOR] Updated featured content module to atomic naming conventions
   - added featured content module modifiers for right and center image anchors
 - **cf-pagination** [MAJOR] Update to atomic naming conventions:
+- **cf-core** [MAJOR] Moved the base form styles to cf-forms
 
 ### Removed
 - **cf-core:** [MAJOR] Removed deprecated items:

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -515,87 +515,8 @@ blockquote {
 }
 
 //
-// Form labels
+// Form elements have been moved to the cf-forms component
 //
-
-label {
-    display: block;
-    // 5px is eyeballed to 10px when considering line height.
-    margin-bottom: unit( 5px / @base-font-size-px, em );
-}
-
-//
-// Form elements
-//
-
-input[type="text"],
-input[type="search"],
-input[type="email"],
-input[type="url"],
-input[type="tel"],
-input[type="number"],
-textarea,
-select[multiple] {
-    @font-size: 16px;
-    .u-webfont-regular();
-
-    display: inline-block;
-    padding: unit( 6px / @base-font-size-px, em );
-    border: 1px solid @input-border;
-    border-radius: 0;
-    margin: 0;
-    background: @input-bg;
-    font-size: unit( @font-size / @base-font-size-px, em );
-    vertical-align: top;
-    appearance: none;
-}
-
-// Overrides extra left padding.
-// http://stackoverflow.com/questions/11127891/how-can-i-get-rid-of-horizontal-padding-or-indent-in-html5-search-inputs-in-webk
-::-webkit-search-decoration {
-    appearance: none;
-}
-
-// The .focus class is only included for documentation demos and should not
-// be used in production.
-input[type="text"]:focus,
-input[type="text"].focus,
-input[type="search"]:focus,
-input[type="search"].focus,
-input[type="email"]:focus,
-input[type="email"].focus,
-input[type="url"]:focus,
-input[type="url"].focus,
-input[type="tel"]:focus,
-input[type="tel"].focus,
-input[type="number"]:focus,
-input[type="number"].focus,
-textarea:focus,
-textarea.focus,
-select[multiple]:focus,
-select[multiple].focus {
-    border: 1px solid @input-border-focus;
-    outline: 1px solid @input-border-focus;
-    outline-offset: 0;
-    box-shadow: none;
-}
-
-::-webkit-input-placeholder {
-    color: @input-placeholder;
-}
-::-moz-placeholder {
-    color: @input-placeholder;
-}
-:-ms-input-placeholder {
-    color: @input-placeholder;
-}
-
-input[type="radio"],
-input[type="checkbox"] {
-    margin-top: unit( 4px / @base-font-size-px, em );
-    margin-right: unit( 7px / @base-font-size-px, em );
-    float: left;
-}
 
 //
 // Images

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -59,9 +59,97 @@
 // Form labels
 //
 
+label {
+    display: block;
+    // 5px is eyeballed to 10px when considering line height.
+    margin-bottom: unit( 5px / @base-font-size-px, em );
+}
+
 .form-label-header {
     .heading-5();
     margin-bottom: unit(10px / @font-size, em );
+}
+
+//
+// Form elements
+//
+
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="number"],
+textarea,
+select[multiple] {
+    @font-size: 16px;
+    .u-webfont-regular();
+
+    display: inline-block;
+    padding: unit( 6px / @base-font-size-px, em );
+    border: 1px solid @input-border;
+    border-radius: 0;
+    margin: 0;
+    background: @input-bg;
+    font-size: unit( @font-size / @base-font-size-px, em );
+    vertical-align: top;
+    appearance: none;
+
+    &.warning {
+        border: 1px solid @input-warning;
+        outline: 1px solid @input-warning;
+    }
+}
+
+.warning + .@{cf-forms_input-icon-class} {
+    color: @input-warning;
+}
+
+// Overrides extra left padding.
+// http://stackoverflow.com/questions/11127891/how-can-i-get-rid-of-horizontal-padding-or-indent-in-html5-search-inputs-in-webk
+::-webkit-search-decoration {
+    appearance: none;
+}
+
+// The .focus class is only included for documentation demos and should not
+// be used in production.
+input[type="text"]:focus,
+input[type="text"].focus,
+input[type="search"]:focus,
+input[type="search"].focus,
+input[type="email"]:focus,
+input[type="email"].focus,
+input[type="url"]:focus,
+input[type="url"].focus,
+input[type="tel"]:focus,
+input[type="tel"].focus,
+input[type="number"]:focus,
+input[type="number"].focus,
+textarea:focus,
+textarea.focus,
+select[multiple]:focus,
+select[multiple].focus {
+    border: 1px solid @input-border-focus;
+    outline: 1px solid @input-border-focus;
+    outline-offset: 0;
+    box-shadow: none;
+}
+
+::-webkit-input-placeholder {
+    color: @input-placeholder;
+}
+::-moz-placeholder {
+    color: @input-placeholder;
+}
+:-ms-input-placeholder {
+    color: @input-placeholder;
+}
+
+input[type="radio"],
+input[type="checkbox"] {
+    margin-top: unit( 4px / @base-font-size-px, em );
+    margin-right: unit( 7px / @base-font-size-px, em );
+    float: left;
 }
 
 //


### PR DESCRIPTION
This doesn't do anything other than move the styles so they're organized in one place. It's a first step in a larger atomic re-write of our form styles. This change is bound to be contentious and therefore deemed important enough to do separate from everything else.

## Changes

- Moved base form styles to cf-forms

## Testing

- checkout and run `npm run cf-link`
- open new tab and cd to your sandbox repo
- in the sandbox tab run `npm link cf-forms`
- in the sandbox tab run `npm run build`
- in the sandbox tab run `npm start`
- navigate to the cf-forms examples and ensure everything looks as it did (mostly inputs)

## Review

- @mistergone 
- @cfarm 
- @Scotchester 

## Notes

- @Scotchester has voiced that he's not in favor of this change because they are basic html elements not needing classes. While I agree, I find it's super confusing that form elements are the only ones styled in two places and believe this is a usability improvement for new (and even existing) developers.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)