### PR TITLE
Atomizing cf-tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-core:** [MAJOR] Moved the base form styles to cf-form
 - **cf-buttons** [PATCH] Standardized and optimized less code
 - **cf-forms** [MINOR] Updated large target radios/checkboxes to use field molecule
+- **cf-tables:** [MAJOR] Atomized cf-tables.
 
 ### Removed
 - **cf-core:** [MAJOR] Removed deprecated items:

--- a/src/cf-tables/package.json
+++ b/src/cf-tables/package.json
@@ -14,10 +14,9 @@
   },
   "dependencies": {
     "cf-core": "^3.0.0",
-    "jquery": "~1.11.0"
+    "atomic-component": "github:cfpb/AtomicComponent"
   },
   "keywords": [
-    "tables",
-    "jquery"
+    "tables"
   ]
 }

--- a/src/cf-tables/src/cf-table-row-links.js
+++ b/src/cf-tables/src/cf-table-row-links.js
@@ -1,0 +1,54 @@
+
+/* ==========================================================================
+   Table Row Links
+
+   Mixin for adding row link click functionality to table organism.
+
+   ========================================================================== */
+
+'use strict';
+
+var closest = require( 'atomic-component/src/utilities/dom-closest' ).closest;
+
+var TableRowLinks = {
+
+  events: {
+    'click tbody tr': 'onRowLinkClick'
+  },
+
+  ui: {
+    base: '.o-table__row-links'
+  },
+
+  /**
+   * Handle a click of the table.
+   *
+   * @param {Object} event Mouse event for click on the table.
+   */
+  onRowLinkClick: function( event ) {
+    var target = event.target;
+    if( target && target.tagName === 'A' ) {
+      return
+    }
+    target = closest( event.target, 'tr' );
+    var link = target.querySelector( 'a' );
+    if( link ) window.location = link.getAttribute( 'href' );
+  },
+
+  /**
+   * Handle initilization of Table Row Links. Added for standalone
+   * use cases.
+   *
+   */
+  init: function() {
+    var elements = document.querySelector( TableRowLinks.ui.base );
+    for ( var i = 0; i < elements.length; ++i ) {
+      if( elements[i].hasAttribute( 'data-bound' ) === false ) {
+        elements[i].addEventListener( 'click', table,
+        TableRowLinks.onRowLinkClick );
+      }
+    }
+  }
+};
+
+module.exports = TableRowLinks;

--- a/src/cf-tables/src/cf-table-sortable.js
+++ b/src/cf-tables/src/cf-table-sortable.js
@@ -1,0 +1,207 @@
+
+/* ==========================================================================
+   Table Sortablle
+
+   Mixin for sorting table organism.
+
+   ========================================================================== */
+
+'use strict';
+
+var config = require( 'atomic-component/src/utilities/config' );
+var closest = require( 'atomic-component/src/utilities/dom-closest' ).closest;
+var DIRECTIONS = config.DIRECTIONS;
+var UNDEFINED = config.UNDEFINED;
+
+var TableSortable = {
+
+  classes: {
+    sortDown: 'sorted-down',
+    sortUp:   'sorted-up'
+  },
+
+  events: {
+    'click .sortable': 'onSortableClick'
+  },
+
+  ui: {
+    base:       '.o-table__sortable',
+    tableBody:  'tbody',
+    sortButton: '.sorted-up, .sorted-down'
+  },
+
+  /**
+   * Function used to create computed and triggered properties.
+   */
+  initialize: function() {
+    this.sortClass = UNDEFINED;
+    this.sortColumnIndex = UNDEFINED;
+    this.sortDirection = UNDEFINED;
+    this.tableData = [];
+    this.bindProperties();
+    if ( this.ui.sortButton ) {
+      this.sortColumnIndex = this.getColumnIndex();
+      this.sortDirection = this.contains( this.ui.sortButton, this.classes.sortDown )
+      					   ? DIRECTIONS.DOWN : DIRECTIONS.UP;
+      this.updateTable();
+    }
+  },
+
+  /**
+   * Function used to create computed and trigger properties.
+   */
+  bindProperties: function() {
+    var sortDirection;
+
+    Object.defineProperty( this, 'sortDirection', {
+      configurable: true,
+      get: function() {
+        return sortDirection;
+      },
+      set: function( value ) {
+        if ( value === DIRECTIONS.UP ) {
+          this.sortClass = this.classes.sortUp;
+        } else if( value === DIRECTIONS.DOWN ) {
+          this.sortClass = this.classes.sortDown;
+        }
+        sortDirection = value;
+      }
+    } );
+  },
+
+  /**
+   * Function used to get the column index of the active sort column.
+   *
+   * @param { HTMLNode } element - The element used as the sortable.
+   */
+  getColumnIndex: function( element ) {
+    return closest( element || this.ui.sortButton, 'td, th' ).cellIndex;
+  },
+
+  /**
+   * Function used to update the table data and dom.
+   */
+  updateTable: function() {
+    return this.updateTableData() && this.updateTableDom();
+  },
+
+  /**
+   * Function used to get, sort, and update the table data array.
+   *
+   * @param { number } columnIndex - The index of the column used for sorting.
+   */
+  updateTableData: function( columnIndex ) {
+    var cell;
+    var rows = this.ui.tableBody.querySelectorAll( 'tr' );
+    var sortType;
+    this.tableData = [];
+    columnIndex = columnIndex || this.sortColumnIndex;
+
+    for ( var i = 0; i < rows.length; ++i ) {
+      cell = rows[i].cells[ columnIndex ];
+      if( cell ) {
+        cell = cell.textContent.trim();
+      }
+      this.tableData.push( [ cell, rows[ i ] ] );
+    }
+
+    sortType = this.ui.sortButton.getAttribute( 'data-sort_type' );
+    this.tableData.sort( this.tableDataSorter( this.sortDirection, sortType ) );
+
+    return this.tableData;
+  },
+
+  /**
+   * Function used to update the table DOM.
+   */
+  updateTableDom: function() {
+    var documentFragment;
+    var tableBody = this.ui.tableBody;
+
+    // Empty the table body to prepare for sorting the rows
+    // TODO: It might make sense to use innerHTML
+    // from a performance and garbage collection standpoint.
+    while ( tableBody.lastChild ) {
+      tableBody.removeChild( tableBody.lastChild );
+    }
+
+    documentFragment = document.createDocumentFragment();
+    for ( var i = 0; i < this.tableData.length; i++ ) {
+      documentFragment.appendChild( this.tableData[i][1] );
+    }
+
+    tableBody.appendChild( documentFragment );
+    this.trigger( 'table:updated' );
+
+    return tableBody;
+  },
+
+  /**
+   * Function used to create a function for sorting table data.
+   * Passed to Array.sort method.
+   *
+   * @param { number } direction - A number where a negative number indicates a
+   * reverse sort.
+   * @param { sortType } sortType - A string used for sort types. By default,
+   * the values are sorted by their native type. If this value is set to
+   * 'number', then the cells' numeric values are used.
+   * @returns function - A function to be used by the Array.sort method, where
+   * the parameters 'a' and 'b' is each an Array (of Arrays) to be sorted
+   */
+  tableDataSorter : function( direction, sortType ) {
+    return function( a, b ) {
+       var sign = 1;
+       var order = 0;
+       var regex = /[^\d.-]/g;
+
+      // Set a and b to the first Array in each Array-of-Arrays
+      a = a[0];
+      b = b[0];
+
+      // For number sort, convert a & b to numbers.
+      if ( sortType === 'number' ) {
+        a = Number( a.replace( regex, '' ) );
+        b = Number( b.replace( regex, '' ) );
+      }
+
+      if ( direction === DIRECTIONS.DOWN ) {
+        sign = -1
+      }
+
+      // Sort the values
+      if ( a < b ) {
+        order =  sign * -1;
+      } else if ( a > b ) {
+        order = sign;
+      }
+
+      return order;
+    };
+  },
+
+  /**
+   * Function used as callback for the sortable click event.
+   *
+   * @param { Event } event - DOM event.
+   */
+  onSortableClick: function( event ) {
+    if( this.ui.sortButton ) {
+      this.removeClass( this.ui.sortButton, this.sortClass );
+    }
+    if ( this.ui.sortButton === event.target ) {
+      this.sortDirection = ~this.sortDirection;
+    } else {
+      this.ui.sortButton = event.target;
+      this.sortColumnIndex = this.getColumnIndex();
+      this.sortDirection = DIRECTIONS.UP;
+    }
+    // The active sort class is changing when the sort direction changes.
+    this.addClass( this.ui.sortButton, this.sortClass );
+    this.updateTable();
+
+    return this;
+  }
+
+};
+
+module.exports = TableSortable;

--- a/src/cf-tables/src/cf-tables.js
+++ b/src/cf-tables/src/cf-tables.js
@@ -1,164 +1,28 @@
-/**
- * cf-tables
- * https://github.com/cfpb/cf-tables
- *
- * A public domain work of the Consumer Financial Protection Bureau
- */
 
-global.jQuery = require('jquery');
+/* ==========================================================================
+   TableOrganism
 
-( function( $ ) {
-  'use strict';
+   ========================================================================== */
 
-  var SortableTable = function( table, options ) {
-    /*  At the moment, there are no default settings, but here's an object
-        for their future use! */
-    var defaults = {},
-    // settings is defaults combined with user options
-    settings = {},
-    // rows is an Array of Arrays, serving as a model of the table
-    rows = [],
-    $table = $( table ),
-    $sortButtons = $table.find( '.sortable' );
+'use strict';
 
-    /**
-     * Initializes the SortableTable
-     * @param { object } options - Customizble options object
-     */
-    function _init( options ) {
-      settings = $.extend( {}, defaults, options );
-      _clickHandler();
-      // If the following classes exist, start by sorting those columns.
-      $table.find( '.sortable__start-up, .sortable__start-up' ).click();
-    }
+var config = require( 'atomic-component/src/utilities/config' );
+var Organism = require( 'atomic-component/src/components/Organism' );
+var TableSortable = require( './cf-table-sortable' );
+var TableRowLinks = require( './cf-table-row-links' );
 
-    /**
-     * Sorting function for Array.sort()
-     *
-     * @param { number } sign - A number where a negative number indicates a
-     * reverse sort.
-     * @param { sortType } sortType - A string used for sort types. By default,
-     * the values are sorted by their native type. If this value is set to
-     * 'number', then the cells' numeric values are used.
-     * @returns function - A function to be used by the Array.sort method, where
-     * the parameters 'a' and 'b' is each an Array (of Arrays) to be sorted
-     */
+var TableOrganism = Organism.extend( {
 
-    function _arraySorter( sign, sortType ) {
-      return function( a, b ) {
-        // Set a and b to the first Array in each Array-of-Arrays
-        a = a[0];
-        b = b[0];
+  ui: {
+    base: '.o-table'
+  },
 
-        // For number sort, convert a & b to numbers.
-        if ( sortType === 'number' ) {
-          a = Number( a.replace( /[^\d.-]/g, '' ) );
-          b = Number( b.replace( /[^\d.-]/g, '' ) );
-        }
+  modifiers: [TableSortable, TableRowLinks]
 
-        // Sort the values
-        if ( a < b ) {
-          return sign * -1;
-        }
-        if ( a > b ) {
-          return sign;
-        }
-        return 0;
-      };
-    }
+} );
 
-    /**
-     * Updates internal model of table (rows[])
-     * @param { number } index - The index of the column used for sorting,
-     * which is used as the "key" for rows[] - it is set as the only value
-     * in the first array.
-     */
-    function _getRows( index ) {
-      var child = index + 1;
-      // Clear the model
-      rows.length = 0;
-      // Find the value in each row of the column we're sorting by,
-      // add it to the rows Array
-      $table.find( 'tbody tr' ).each( function() {
-        // indices count from 0, but nth-child counts from 1
-        var key = $( this ).find( 'td:nth-child(' + child + ')' ).text().trim();
-        rows.push( [ key, $( this ) ] );
-      } );
-    }
+TableOrganism.constants.DIRECTIONS = config.DIRECTIONS;
 
-    /**
-     * Updates the table in the DOM
-     * @param { number } index - The index of the column used for sorting
-     */
-    function _updateTable( index ) {
-      // Empty the tbody to prepare for sorted rows
-      $table.find( 'tbody' ).empty();
+TableOrganism.init();
 
-      // Insert sorted rows
-      for ( var i = 0; i < rows.length; i++ ) {
-        $table.find( 'tbody' ).append( rows[i][1] );
-      }
-    }
-
-    /**
-     * Handler for click events on the column header
-     * No parameters - uses SortableTable properties, updates the DOM.
-     */
-    function _clickHandler() {
-      $sortButtons.on( 'click', function() {
-        var $button = $( this ),
-            $headercell = $button.closest( 'th, td' ),
-            $table = $headercell.closest( '.table__sortable' ),
-            sortType = $button.attr( 'data-sort_type' ),
-            sign = 1,
-            $firstChild = $table.find( 'tr:first-child' ),
-            index = $firstChild.children( 'th, td' ).index( $headercell );
-
-        _getRows( index );
-
-        // Determine sign
-        if ( $button.hasClass( 'sorted-up' ) || $button.hasClass( 'sortable__start-down' ) ) {
-          sign = -1;
-        }
-
-        $sortButtons.removeClass( 'sortable__start-down sortable__start-up' );
-        $sortButtons.removeClass( 'sorted-down sorted-up' );
-
-        // Add correct class
-        if ( sign === 1 ) {
-          $button.addClass( 'sorted-up' );
-        } 
-        else {
-          $button.addClass( 'sorted-down' );
-        }
-
-        // Perform the row sort
-        rows.sort( _arraySorter( sign, sortType ) );
-
-        _updateTable( index );
-
-      } );
-    }
-
-    _init( options );
-
-  };
-
-  /**
-   * Instatiates the SortableTable
-   * @param { object } options - An options object
-   * @returns { object } Attached objects for each matched element
-   */
-  $.fn.sortableTable = function( options ) {
-    return this.each( function() {
-      ( options || ( options = {} ) ).$element = $( this );
-      var scol = new SortableTable( this, options );
-    } );
-  };
-
-  $( document ).ready( function() {
-    $( '.table__sortable' ).sortableTable();
-  } );
-
-
-}( jQuery ) );
+module.exports = TableOrganism;

--- a/src/cf-tables/src/cf-tables.less
+++ b/src/cf-tables/src/cf-tables.less
@@ -13,7 +13,10 @@
 
 @table-cell-bg:              #ffffff; // $color-white
 @table-cell-bg_alt:          #f1f1f1; // $color-gray-lightest
+@table-row-link-bg-hover:    #205493; // $color-cool-blue
+@table-row-link-hover-color: #ffffff; // $color-white
 @table-scrolling-border:     #e4e2e0; // $color-gray-warm-light
+
 
 // Mixins
 .striped-table() {
@@ -25,13 +28,26 @@
     }
 }
 
-// .table
-
-.table_cell__right-align {
+.o-table_cell__right-align {
     text-align: right;
 }
 
-.table-wrapper__scrolling {
+.o-table__row-links {
+    .respond-to-min( @bp-med-min, {
+        tr:hover {
+            td {
+                background: @table-row-link-bg-hover;
+                color: @table-row-link-hover-color;
+                cursor: pointer;
+            }
+            a {
+                color: @table-row-link-hover-color;
+            }
+        }
+    } );
+}
+
+.o-table-wrapper__scrolling {
     box-sizing: border-box;
     overflow-y: hidden;
     table {
@@ -40,7 +56,7 @@
     }
 }
 
-.table__sortable {
+.o-table__sortable {
     button.sortable {
         width: 100%;
         height: 100%;
@@ -81,20 +97,24 @@
 }
 
 .respond-to-min( @bp-sm-min, {
-    .table__striped {
+    .o-table__striped {
         .striped-table();
     }
-});
+} );
 
 .respond-to-max( @bp-xs-max, {
-    .table__striped > tbody > tr:nth-child(even) {
+    .o-table {
+        width: 100%;
+    }
+
+    .o-table__striped tr:nth-child(even) {
         & > th,
         & > td {
             background: @table-cell-bg;
         }
     }
 
-    .table__stack-on-small {
+    .o-table__stack-on-small {
         tr,
         td {
             display: block;
@@ -120,7 +140,7 @@
         }
     }
 
-    .table__entry-header-on-small {
+    .o-table__entry-header-on-small {
         & > tbody td:first-child {
             padding-bottom: .75em;
             border-bottom: 1px solid @table-border;
@@ -141,4 +161,4 @@
             margin-bottom: unit( 30px / @base-font-size-px, em );
         }
     }
-});
+} );

--- a/src/cf-tables/usage.md
+++ b/src/cf-tables/usage.md
@@ -14,6 +14,7 @@ The [`cf-core`](../core) component is a dependency of this component."
 - [Variables](#variables)
 - [Striped table](#striped-table)
 - [Right-aligned cells](#right-aligned-cells)
+- [Row Links](#row-links)
 - [Sortable tables](#sortable-tables)
 - [Responsive tables](#responsive-tables)
 
@@ -34,10 +35,10 @@ Ex. to set your table cell's background color, add `@table-cell-bg: #fefefe;` to
 
 ## Striped tables
 
-The `.table__striped` class adds stripes to the table rows.
+The `.o-table__striped` class adds stripes to the table rows.
 This striping is not visible on small screens.
 
-<table class="table__striped">
+<table class="o-table o-table__striped">
   <thead>
     <tr>
       <th>Column 1</th>
@@ -70,7 +71,7 @@ This striping is not visible on small screens.
 </table>
 
 ```
-<table class="table__striped">
+<table class="o-table o-table__striped">
   <thead>
     <tr>
       <th>Column 1</th>
@@ -106,10 +107,10 @@ This striping is not visible on small screens.
 
 ## Right-aligned cells
 
-The use of the `.table_cell__right-align` class on a TD aligns the text right -
+The use of the `.o-table_cell__right-align` class on a TD aligns the text right -
 see the third column above.
 
-<table class="table__stack-on-small">
+<table class="o-table o-table__stack-on-small">
   <thead>
     <tr>
       <th>Column 1</th>
@@ -132,7 +133,7 @@ see the third column above.
 </table>
 
 ```
-<table class="table__stack-on-small">
+<table class="o-table o-table__stack-on-small">
   <thead>
     <tr>
       <th>Column 1</th>
@@ -154,6 +155,63 @@ see the third column above.
   </tbody>
 </table>
 ```
+
+
+## Tables with Row Links
+
+The `.o-table_cell__row-links` class is added to a table to enable highlighting and hyperlinking rows which
+contain links.
+
+<table class="o-table o-table__row-links">
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-label="Column 1">
+          <a href="https://example.com/">Example 1</a>
+      </td>
+      <td data-label="Column 2">Cell A2</td>
+      <td data-label="Column 3" >Cell A3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">
+          <a href="https://example.com/">Example 2</a>
+      </td>
+      <td data-label="Column 2">Cell B2</td>
+      <td data-label="Column 3">Cell B3</td>
+    </tr>
+  </tbody>
+</table>
+
+```
+<table class="o-table o-table__row-links">
+  <thead>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+      <th>Column 3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-label="Column 1">Row A</td>
+      <td data-label="Column 2">Cell A2</td>
+      <td data-label="Column 3">Cell A3</td>
+    </tr>
+    <tr>
+      <td data-label="Column 1">Row B</td>
+      <td data-label="Column 2">Cell B2</td>
+      <td data-label="Column 3">Cell B3</td>
+    </tr>
+  </tbody>
+</table>
+```
+
 
 ## Sortable Tables
 
@@ -161,7 +219,7 @@ The cf-tables module also includes a sortable table utility.
 
 ### Making a table sortable
 
-By adding the `.table__sortable` class to a table, the table becomes sortable.
+By adding the `.o-table__sortable` class to a table, the table becomes sortable.
 To allow the table to be sorted by a column, add a button to the `th` of the
 column like so:
 
@@ -187,7 +245,7 @@ To sort by number value, add the `data-sort_type="number"` attribute
 to the sorting button:
 
 ```
-<table class="table__sortable">
+<table class="o-table o-table__sortable">
   ...
     <th>
       <button class="sortable" data-sort_type="number">Column Name</button>
@@ -198,28 +256,27 @@ to the sorting button:
 
 ### Sorting table on page load
 
-To sort the table on page load, use the `.sortable__start-up` and
-`.sortable__start-down` classes:
+To sort the table on page load, use the `.sorted-up` and `.sorted-up` classes:
 
 ```
-<table class="table__sortable">
+<table class="o-table o-table__sortable">
   ...
     <th>
-      <button class="sortable sortable__start-up">Column Name</button>
+      <button class="sortable sorted-up">Column Name</button>
     </th>
   ...
 </table>
 ```
 
-- `.sortable__start-up` starts with the column sorted smallest to largest (or
+- `.sorted-up` starts with the column sorted smallest to largest (or
 lowest to highest)
 
-- `.sortable__start-down` starts with the column sorted largest to smallest (or
+- `.sorted-down` starts with the column sorted largest to smallest (or
 highest to lowest)
 
 ### Sample Sortable Table
 
-<table class="table__sortable">
+<table class="o-table o-table__sortable">
   <thead>
       <tr>
           <th>
@@ -231,7 +288,7 @@ highest to lowest)
             </button>
           </th>
           <th>
-            <button class="sortable sortable__start-up" data-sort_type="number">
+            <button class="sortable sorted-up" data-sort_type="number">
               Distance
             </button>
           </th>
@@ -319,7 +376,7 @@ highest to lowest)
 </table>
 
 ```
-<table class="table__sortable">
+<table class="o-table o-table__sortable">
   <thead>
       <tr>
           <th>
@@ -331,7 +388,7 @@ highest to lowest)
             </button>
           </th>
           <th>
-            <button class="sortable sortable__start-up" data-sort_type="number">
+            <button class="sortable sorted-up" data-sort_type="number">
               Distance
             </button>
           </th>
@@ -432,14 +489,14 @@ highest to lowest)
 
 ### Responsive stacked table
 
-The `.table__stack-on-small` class adds the "stacked" table style for small screens.
+The `.o-table__stack-on-small` class adds the "stacked" table style for small screens.
 _Please note that tables are not responsive without adding one of the small screen classes._
 
 Also note that the `data-label` attribute is used to label each entry in a table
 for small screen responsive views.
 Always include the `data-label` attribute for each cell.
 
-<table class="table__stack-on-small">
+<table class="o-table o-table__stack-on-small">
   <thead>
     <tr>
       <th>Column 1</th>
@@ -472,7 +529,7 @@ Always include the `data-label` attribute for each cell.
 </table>
 
 ```
-<table class="table__stack-on-small">
+<table class="o-table o-table__stack-on-small">
   <thead>
     <tr>
       <th>Column 1</th>
@@ -507,7 +564,7 @@ Always include the `data-label` attribute for each cell.
 
 ### Responsive stacked table with header
 
-The `.table__entry-header-on-small` class in addition to `.table__stack-on-small` class
+The `.o-table__entry-header-on-small` class in addition to `.o-table__stack-on-small` class
 changes the first column to be styled as an entry header.
 This style requires both classes be added.
 _Note that tables are not responsive without adding one of the small screen classes._
@@ -515,7 +572,9 @@ _Note that tables are not responsive without adding one of the small screen clas
 Also note that the `data-label` attribute is used to label each entry.
 Always include the `data-label` attribute for each cell.
 
-<table class="table__stack-on-small table__entry-header-on-small">
+<table class="o-table
+              o-table__stack-on-small
+              o-table__entry-header-on-small">
   <thead>
     <tr>
       <th>Column 1</th>
@@ -548,7 +607,9 @@ Always include the `data-label` attribute for each cell.
 </table>
 
 ```
-<table class="table__stack-on-small table__entry-header-on-small">
+<table class="o-table
+              o-table__stack-on-small
+              o-table__entry-header-on-small">
   <thead>
     <tr>
       <th>Column 1</th>
@@ -583,14 +644,14 @@ Always include the `data-label` attribute for each cell.
 
 ### Responsive table - Horizontal scroll variation
 
-The `.table-wrapper__scrolling` class must be added to the parent element of
+The `.o-table-wrapper__scrolling` class must be added to the parent element of
 the table (by adding a wrapping `<div>`, in most cases).
 The `<table>` element does not need additional markup in this case.
 The "Comparative with horizontal scroll" style also adds striped rows
 to the table contained within, and
-remains striped on small screens (unlike the `table__striped `class, below).
+remains striped on small screens (unlike the `o-table__striped `class, below).
 
-<div class="table-wrapper__scrolling">
+<div class="o-table o-table-wrapper__scrolling">
   <table>
     <thead>
       <tr>
@@ -650,7 +711,7 @@ remains striped on small screens (unlike the `table__striped `class, below).
 </div>
 
 ```
-<div class="table-wrapper__scrolling">
+<div class="o-table o-table-wrapper__scrolling">
   <table>
     <thead>
       <tr>

--- a/test/cf-tables.html
+++ b/test/cf-tables.html
@@ -15,7 +15,7 @@
      -->
     <!-- <div id="qunit-fixture"> -->
 
-        <table id="test-one" class="table__sortable">
+        <table id="test-one" class="o-table o-table__sortable">
             <thead>
                 <tr>
                     <th>
@@ -27,7 +27,7 @@
                       </button>
                     </th>
                     <th>
-                      <button class="sortable sortable__start-up" id="dist-sort" data-sort_type="number">
+                      <button class="sortable sorted-up" id="dist-sort" data-sort_type="number">
                         Distance
                       </button>
                     </th>
@@ -120,9 +120,5 @@
     <!-- Load local lib and tests. -->
     <script src="../tmp/cf-tables/cf-tables.js"></script>
     <script src="cf-tables.js"></script>
-    <!-- Removing access to jQuery and $. But it'll still be available as _$, if
-    you REALLY want to mess around with jQuery in the console. REMEMBER WE
-    ARE TESTING A PLUGIN HERE, THIS HELPS ENSURE BEST PRACTICES. REALLY. -->
-    <script>window._$ = jQuery.noConflict(true);</script>
 </body>
 </html>

--- a/test/cf-tables.js
+++ b/test/cf-tables.js
@@ -19,80 +19,87 @@
       notStrictEqual(actual, expected, [message])
       throws(block, [expected], [message])
   */
+  var getElement;
 
   module( 'cf-tables', {
     // This will run before each test in this module.
     setup: function() {
-      this.$testOne = $('#test-one');
+      getElement = document.querySelector.bind( document );
+      this.testOne = getElement( '#test-one' );
     }
   });
 
-  test( '".sortable__start-up class sorts on load', function() {
+  test( '".sort-up class sorts on load', function( assert ) {
     expect( 3 );
+
     ok(
-      $('#test-one tbody tr:nth-child(1) td:nth-child(3)').text().trim() === '1.2 mi',
+      getElement('#test-one tbody tr:nth-child(1) td:nth-child(3)').innerText.trim() === '1.2 mi',
       'Row 1 is correct'
     );
+
     ok(
-      $('#test-one tbody tr:nth-child(5) td:nth-child(3)').text().trim() === '2.6 mi',
+      getElement('#test-one tbody tr:nth-child(5) td:nth-child(3)').innerText.trim() === '2.6 mi',
       'Row 3 is correct'
     );
+
     ok(
-      $('#test-one tbody tr:nth-child(7) td:nth-child(3)').text().trim() === '11.1 mi',
+      getElement('#test-one tbody tr:nth-child(7) td:nth-child(3)').innerText.trim() === '11.1 mi',
       'Row 7 is correct'
     );
-  });
+
+  } );
+
 
   test( 'Column sorts low-to-high on click ', function() {
     expect( 3 );
-    $('#lang-sort').click();
+    getElement('#lang-sort').click();
     ok(
-      $('#test-one tbody tr:nth-child(1) td:nth-child(2)').text().trim() === 'English',
+      getElement('#test-one tbody tr:nth-child(1) td:nth-child(2)').innerText.trim() === 'English',
       'Row 1 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(4) td:nth-child(2)').text().trim() === 'English, French, Spanish',
+      getElement('#test-one tbody tr:nth-child(4) td:nth-child(2)').innerText.trim() === 'English, French, Spanish',
       'Row 4 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(7) td:nth-child(2)').text().trim() === 'English, Spanish',
+      getElement('#test-one tbody tr:nth-child(7) td:nth-child(2)').innerText.trim() === 'English, Spanish',
       'Row 7 is correct'
     );
   });
 
   test( 'Column sorts high-to-low on second click ', function() {
     expect( 3 );
-    $('#lang-sort').click();
+    getElement('#lang-sort').click();
     ok(
-      $('#test-one tbody tr:nth-child(7) td:nth-child(2)').text().trim() === 'English',
+      getElement('#test-one tbody tr:nth-child(7) td:nth-child(2)').innerText.trim() === 'English',
       'Row 7 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(4) td:nth-child(2)').text().trim() === 'English, French, Spanish',
+      getElement('#test-one tbody tr:nth-child(4) td:nth-child(2)').innerText.trim() === 'English, French, Spanish',
       'Row 4 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(1) td:nth-child(2)').text().trim() === 'English, Spanish',
+      getElement('#test-one tbody tr:nth-child(1) td:nth-child(2)').innerText.trim() === 'English, Spanish',
       'Row 1 is correct'
     );
   });
 
   test( 'Column sorts low-to-high on click for "number" sort type', function() {
     expect( 3 );
-    $('#dist-sort').click();
+    getElement('#dist-sort').click();
     ok(
-      $('#test-one tbody tr:nth-child(1) td:nth-child(3)').text().trim() === '1.2 mi',
+      getElement('#test-one tbody tr:nth-child(1) td:nth-child(3)').innerText.trim() === '1.2 mi',
       'Row 1 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(5) td:nth-child(3)').text().trim() === '2.6 mi',
+      getElement('#test-one tbody tr:nth-child(5) td:nth-child(3)').innerText.trim() === '2.6 mi',
       'Row 3 is correct'
     );
     ok(
-      $('#test-one tbody tr:nth-child(7) td:nth-child(3)').text().trim() === '11.1 mi',
+      getElement('#test-one tbody tr:nth-child(7) td:nth-child(3)').innerText.trim() === '11.1 mi',
       'Row 7 is correct'
     );
   });
 
 
-}( jQuery ));
+}());


### PR DESCRIPTION
Atomizing cf-tables

## Additions

- Added `src/cf-tables/src/cf-table-row-links.js` as a modifier for the base table organism. This also can be used as a standalone module if you don't wan't the overhead of an atomic component.

- Added `src/cf-tables/src/cf-table-sortable.js` as a modifier for the base table organism. This also replaces the old `cf-table` functionality. 

## Changes

- Modified `src/cf-tables/src/cf-tables.js` to inherit from AtomicComponent.
- Modified `src/cf-tables/usage.md` to add documentation for `row-links` and add the appropriate table organism prefix.
- Modified `src/cf-tables/src/cf-tables.less` to use the appropriate table organism prefix.  Added the `row-links` modifier class.

## Testing

- Run `npm install && gulp test`

## Review

- @cfpb/cfgov-frontends 

## Notes
- I made many  [AtomicComponent](https://github.com/cfpb/AtomicComponent) design decisions based based on my personal preferences. Will adjust as the group sees fit. 

## Todos

- Write more tests.
- Release version 1.0 of [AtomicComponent](https://github.com/cfpb/AtomicComponent). Reference this version in cf-tables `package.json`.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
