### PR TITLE
Remove the super input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - Ability to use radio buttons and checkboxes within a `label`
 - **cf-forms**: [MAJOR] Removed deprecated items:
   - `.form-group` and `.form-group_item`
+  - `.input__super`
 
 ### Fixed
 - **cf-typography:** [PATCH] Fixed old variables removed from cf-core

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -43,11 +43,6 @@
 
 @input-big-target-bg__disabled: #aeb0b5; // $color-gray-light
 
-// Sizing variables
-
-// .input__super
-@input__super-font-size:        18px;
-
 
 // Import external dependencies
 
@@ -79,22 +74,6 @@
 
 @import (less) 'organisms/form.less';
 @import (less) 'organisms/form-input-group.less';
-
-//
-// Super input
-//
-
-.input__super {
-    &[type="text"],
-    &[type="search"],
-    &[type="email"],
-    &[type="url"],
-    &[type="tel"],
-    &[type="number"] {
-        padding: unit( 10px / @input__super-font-size, em );
-        font-size: unit( @input__super-font-size / @base-font-size-px, em );
-    }
-}
 
 //
 // Form icons
@@ -140,10 +119,6 @@
         box-sizing: border-box;
         width: 100%;
         padding-right: unit(65px / @btn-font-size, em );
-
-        &.input__super {
-            padding-right: unit(90px / @super-btn-font-size, em );
-        }
     }
 
     .btn {
@@ -151,10 +126,6 @@
         position: absolute;
         right: unit( 15px / @btn-font-size, em );
         top: 0;
-
-        &__super {
-            right: unit( 15px / @super-btn-font-size, em );
-        }
 
         /* pa11y fails unless the background color is explicitly set */
         &__link.btn__secondary {

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -16,7 +16,6 @@ The cf-forms component provides extensions to the basic form styles for Capital 
 - [Labels](#labels)
     - [Label header](#label-header)
 - [Inputs](#inputs)
-    - [Super input](#super-input)
     - [Input states](#input-states)
     - [Input icons](#input-icons)
 - [Groups](#groups)
@@ -24,9 +23,7 @@ The cf-forms component provides extensions to the basic form styles for Capital 
     - [Real world example](#real-world-example)
 - [Buttons](#buttons)
     - [Default input and button](#default-input-and-button)
-    - [Super input and button](#super-input-and-button)
     - [Button inside input](#button-inside-input)
-    - [Super button inside of a super input](#super-button-inside-of-a-super-input)
 
 ## Variables
 
@@ -50,12 +47,6 @@ Theme variables for setting the color and sizes throughout the project. Overwrit
 @input-disabled:                #cdb5cd;
 ```
 
-### Sizing variables
-
-```
-// .input__super
-@input__super-font-size:        18px;
-```
 
 ## Labels
 
@@ -72,18 +63,6 @@ Theme variables for setting the color and sizes throughout the project. Overwrit
 ```
 
 ## Inputs
-
-### Super input
-
-An input that matches the height of a super button.
-
-<input class="input__super" type="text" value="Super input" title="Test input">
-<button class="btn btn__super">Super</button>
-
-```
-<input class="input__super" type="text" value="Super input" title="Test input"></input>
-<button class="btn btn__super">Super</button>
-```
 
 ### Input states
 
@@ -302,28 +281,6 @@ Provides sizeable margins between groups of form elements.
 </div>
 ```
 
-### Super input and button
-
-<div class="o-form__input-w-btn">
-    <div class="o-form__input-w-btn_input-container">
-        <input class="input__super" type="text" title="Test input">
-    </div>
-    <div class="o-form__input-w-btn_btn-container">
-        <button class="a-btn a-btn__super">Search</button>
-    </div>
-</div>
-
-```
-<div class="o-form__input-w-btn">
-    <div class="o-form__input-w-btn_input-container">
-        <input class="input__super" type="text" title="Test input">
-    </div>
-    <div class="o-form__input-w-btn_btn-container">
-        <button class="a-btn a-btn__super">Search</button>
-    </div>
-</div>
-```
-
 ### Button inside input
 
 #### Default button inside of an default input
@@ -344,32 +301,6 @@ Provides sizeable margins between groups of form elements.
            value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable."
            title="Test input">
     <button class="btn btn__link">
-        Clear
-        <span class="cf-icon cf-icon-delete"></span>
-    </button>
-</div>
-```
-
-#### Super button inside of a super input
-
-<div class="btn-inside-input">
-    <input class="input__super"
-           type="text"
-           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable."
-           title="Test input">
-    <button class="btn btn__super btn__link btn__secondary">
-        Clear
-        <span class="cf-icon cf-icon-delete"></span>
-    </button>
-</div>
-
-```
-<div class="btn-inside-input">
-    <input class="input__super"
-           type="text"
-           value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable."
-           title="Test input">
-    <button class="btn btn__super btn__link btn__secondary">
         Clear
         <span class="cf-icon cf-icon-delete"></span>
     </button>


### PR DESCRIPTION
Look at that deleted code. Looks good right? As @jimmynotjim and I were pairing on #398, we realized that the super input isn't in the design manual nor being used. Since the atomic conversion is a good time to remove stuff we aren't using, this might be a great candidate for removal.

## Removals

- `input__super`

## Review

- @cfpb/cfgov-frontends 

## Notes

- Obviously, we either merge #398 or this one, not both 😉 
