### PR TITLE
Add atomic inline form validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - Select form fields
   - Checkboxes and radio buttons
   - Input with Button
+  - Atomized and simplified inline form validation
+- **cf-core:** [MAJOR] Moved the base form styles to cf-form
 
 ### Removed
 - **cf-core:** [MAJOR] Removed deprecated items:
@@ -36,6 +38,9 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - `.form-group` and `.form-group_item`
   - `.input__super`
   - `.form-l` classes, in favor of content-l classes in cf-layout
+  - `@cf-forms_input-icon-class`
+  - `@input-icon__warning`
+  - `@input-icon__success`
 
 ### Fixed
 - **cf-typography:** [PATCH] Fixed old variables removed from cf-core

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -28,8 +28,6 @@
 
 // Input icons
 @input-icon__error:             @red;
-@input-icon__warning:           @gold;
-@input-icon__success:           @green;
 
 // select
 @select-border:                 @gray-40;
@@ -75,32 +73,6 @@
 @import (less) 'organisms/form.less';
 @import (less) 'organisms/form-input-group.less';
 
-//
-// Form icons
-//
-
-@cf-forms_input-icon-class: cf-form_input-icon;
-
-.@{cf-forms_input-icon-class} {
-    @font-size: 20px;
-
-    position: relative;
-    top: unit(6px / @font-size, em );
-    margin-left: unit(4px / @font-size, em );
-    font-size: unit(@font-size / @base-font-size-px, em );
-}
-
-.a-text-input__error + .@{cf-forms_input-icon-class} {
-    color: @input-icon__error;
-}
-
-.a-text-input__warning + .@{cf-forms_input-icon-class} {
-    color: @input-icon__warning;
-}
-
-.a-text-input__success + .@{cf-forms_input-icon-class} {
-    color: @input-icon__success;
-}
 
 //
 // Button inside input

--- a/src/cf-forms/src/molecules/field.less
+++ b/src/cf-forms/src/molecules/field.less
@@ -104,7 +104,7 @@
 
     &__error {
         .a-error-message {
-            margin-top: 15px;
+            margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
         }
     }
 }

--- a/src/cf-forms/src/molecules/field.less
+++ b/src/cf-forms/src/molecules/field.less
@@ -101,4 +101,14 @@
             }
         }
     }
+
+    &__error {
+        .a-error-message {
+            margin-top: 15px;
+        }
+    }
+}
+
+.a-error-message .cf-icon-delete-round {
+    color: @input-icon__error;
 }

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -100,30 +100,6 @@ Inputs should always be paired with a label for accessibility reasons.
 
 See the 'Form icons' section below for guidance on adding icons to states.
 
-#### Error state
-
-<input class="error" type="text" value="Invalid input" title="Test input">
-
-```
-<input class="error" type="text" value="Invalid input" title="Test input">
-```
-
-#### Warning state
-
-<input class="warning" type="text" value="Invalid input" title="Test input">
-
-```
-<input class="warning" type="text" value="Invalid input" title="Test input">
-```
-
-#### Success state
-
-<input class="success" type="text" value="Validated input" title="Test input">
-
-```
-<input class="success" type="text" value="Validated input" title="Test input">
-```
-
 #### Disabled state
 
 <input class="disabled"
@@ -142,16 +118,34 @@ See the 'Form icons' section below for guidance on adding icons to states.
        title="Test input">
 ```
 
-### Input icons
+### Inline Form Validation
 
-Form input icons add small positioning tweaks to Capital Framework icons.
-
-<input type="text" value="" title="Test input">
-<span class="cf-form_input-icon cf-icon cf-icon-email"></span>
+<div class="m-field m-field__error">
+    <label class="a-label__heading" for="form-input-error">Label</label>
+    <input class="a-text-input a-text-input__error"
+           type="text"
+           value="Invalid input"
+           id="form-input-error"
+           aria-describedby="form-input-error_message">
+    <div class="a-error-message" id="form-input-error_message" role="alert">
+        <span class="cf-icon cf-icon-delete-round" aria-hidden="true"></span>
+        This is a required question, please answer.
+    </div>
+</div>
 
 ```
-<input type="text" value="" title="Test input">
-<span class="cf-form_input-icon cf-icon cf-icon-email"></span>
+<div class="m-field m-field__error">
+    <label class="a-label__heading" for="form-input-error">Label</label>
+    <input class="a-text-input a-text-input__error"
+           type="text"
+           value="Invalid input"
+           id="form-input-error"
+           aria-describedby="form-input-error_message">
+    <div class="a-error-message" id="form-input-error_message" role="alert">
+        <span class="cf-icon cf-icon-delete-round" aria-hidden="true"></span>
+        This is a required question, please answer.
+    </div>
+</div>
 ```
 
 #### Error icon


### PR DESCRIPTION
Removed the older form validation and replaced with atomic form
validation following the guidelines here:
http://cfarm.github.io/design-manual/ui-toolkit/form-fields.html

## Testing

- Pull down this branch to test on another repo. https://github.com/cfpb/capital-framework-sandbox/pull/28

## Review

- @cfpb/cfgov-frontends 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/18532809/9b9963ee-7aac-11e6-8964-ca31de39b33c.png)
