### PR TITLE
Standardized Select with other form fields

### DIFF
--- a/src/cf-forms/src/atoms/select.less
+++ b/src/cf-forms/src/atoms/select.less
@@ -1,0 +1,68 @@
+.a-select {
+    position: relative;
+    border: 1px solid @select-border;
+
+    select {
+        height: unit( 30px / @base-font-size-px, em );
+        width: 100%;
+        padding: unit( 4px / @base-font-size-px, em )
+                 unit( 6px / @base-font-size-px, em );
+        border: 0;
+        outline: 2px solid transparent;
+        appearance: none;
+        background-color: @input-bg;
+        border-radius: 0;
+        color: @text;
+
+        &:hover,
+        &:active,
+        &:focus {
+            outline-color: @input-border__focused;
+            outline-offset: 0;
+        }
+    }
+
+    select[disabled] {
+        color: @input-text__disabled;
+        background-color: @input-bg__disabled;
+        cursor: not-allowed;
+
+        &:hover {
+            outline: 2px solid transparent;
+        }
+    }
+
+    select option:disabled {
+        color: @input-disabled;
+    }
+
+    &:after {
+        width: unit( 30px / @base-font-size-px, em );
+        height: unit( 30px / @base-font-size-px, em );
+        border-left: 1px solid @select-border;
+        position: absolute;
+        top: 0;
+        right: 0;
+        background-color: @select-icon-bg;
+        color: @select-icon;
+        content: @cf-icon-down;
+        font-family: 'CFPB Minicons';
+        line-height: unit( 30px / @base-font-size-px, em );
+        text-align: center;
+        pointer-events: none;
+    }
+}
+
+
+// TODO Add modernizr to CF so this works
+// Right now modern IE doesn't support pointer events causing nothing
+// to happen when you click on the dropdown error.
+
+.no-csspointerevents .a-select {
+    &:after {
+        height: 0;
+        width: 0;
+        border: 0;
+        content: '';
+    }
+}

--- a/src/cf-forms/src/atoms/select.less
+++ b/src/cf-forms/src/atoms/select.less
@@ -28,7 +28,7 @@
         cursor: not-allowed;
 
         &:hover {
-            outline: 2px solid transparent;
+            outline: none;
         }
     }
 

--- a/src/cf-forms/src/atoms/select.less
+++ b/src/cf-forms/src/atoms/select.less
@@ -1,14 +1,14 @@
 .a-select {
+
     position: relative;
     border: 1px solid @select-border;
 
     select {
-        height: unit( 30px / @base-font-size-px, em );
+        height: unit( @select-height / @base-font-size-px, em );
         width: 100%;
         padding: unit( 4px / @base-font-size-px, em )
                  unit( 6px / @base-font-size-px, em );
         border: 0;
-        outline: 2px solid transparent;
         appearance: none;
         background-color: @input-bg;
         border-radius: 0;
@@ -17,7 +17,7 @@
         &:hover,
         &:active,
         &:focus {
-            outline-color: @input-border__focused;
+            outline: 2px solid @input-border__focused;
             outline-offset: 0;
         }
     }
@@ -37,8 +37,7 @@
     }
 
     &:after {
-        width: unit( 30px / @base-font-size-px, em );
-        height: unit( 30px / @base-font-size-px, em );
+        width: unit( @select-height / @base-font-size-px, em );
         border-left: 1px solid @select-border;
         position: absolute;
         top: 0;
@@ -47,7 +46,7 @@
         color: @select-icon;
         content: @cf-icon-down;
         font-family: 'CFPB Minicons';
-        line-height: unit( 30px / @base-font-size-px, em );
+        line-height: unit( @select-height / @base-font-size-px, em );
         text-align: center;
         pointer-events: none;
     }

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -64,7 +64,7 @@
 
 @import (less) 'molecules/big-checkboxes.less';
 @import (less) 'molecules/big-radio-buttons.less';
-@import (less) 'molecules/field.less';
+@import (less) 'molecules/form-fields.less';
 
 //
 // Import organisms
@@ -102,76 +102,5 @@
         &__link.btn__secondary {
             background-color: #fff;
         }
-    }
-}
-
-//
-// m-select menu
-//
-
-.m-select {
-    position: relative;
-    margin-top: 0.5em;
-    border: 1px solid @select-border;
-
-    select {
-        height: unit( 30px / @base-font-size-px, em );
-        width: 100%;
-        padding: unit( 4px / @base-font-size-px, em )
-                 unit( 6px / @base-font-size-px, em );
-        border: 0;
-        outline: 2px solid transparent;
-        appearance: none;
-        background-color: @input-bg;
-        border-radius: 0;
-        color: @text;
-
-        &:hover,
-        &:active,
-        &:focus {
-            outline-color: @input-border__focused;
-            outline-offset: 0;
-        }
-    }
-
-    select[disabled] {
-        color: @input-text__disabled;
-        background-color: @input-bg__disabled;
-        cursor: not-allowed;
-
-        &:hover {
-            outline: 2px solid transparent;
-        }
-    }
-
-    select option:disabled {
-        color: @input-disabled;
-    }
-
-    &:after {
-        width: unit( 30px / @base-font-size-px, em );
-        height: unit( 30px / @base-font-size-px, em );
-        border-left: 1px solid @select-border;
-        position: absolute;
-        top: 0;
-        right: 0;
-        background-color: @input-disabled;
-        color: @select-icon;
-        content: @cf-icon-down;
-        font-family: 'CFPB Minicons';
-        line-height: unit( 30px / @base-font-size-px, em );
-        text-align: center;
-        pointer-events: none;
-    }
-}
-
-// @todo: add modernizr to CF so this works:
-
-.no-csspointerevents .m-select {
-    &:after {
-        height: 0;
-        width: 0;
-        border: 0;
-        content: '';
     }
 }

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -43,6 +43,10 @@
 @input-big-target-bg__disabled: #aeb0b5; // $color-gray-light
 
 
+// Sizing variables
+
+@select-height:                  30px;
+
 // Import external dependencies
 
 @import (less) '../../cf-grid/src/cf-grid.less';

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -32,6 +32,7 @@
 // select
 @select-border:                 @gray-40;
 @select-icon:                   @gray-80;
+@select-icon-bg:                @gray-5;
 
 // Large target area variables
 @input-big-target-bg:           #d6d7d9; // $color-gray-lighter
@@ -55,6 +56,7 @@
 //
 
 @import (less) 'atoms/label.less';
+@import (less) 'atoms/select.less';
 @import (less) 'atoms/text-input.less';
 
 

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -113,71 +113,8 @@
     color: @input-icon__error;
 
     &__select {
-        .a-select {
-            position: relative;
+        .a-label + .a-select {
             margin-top: 0.5em;
-            border: 1px solid @select-border;
-
-            select {
-                height: unit( 30px / @base-font-size-px, em );
-                width: 100%;
-                padding: unit( 4px / @base-font-size-px, em )
-                         unit( 6px / @base-font-size-px, em );
-                border: 0;
-                outline: 2px solid transparent;
-                appearance: none;
-                background-color: @input-bg;
-                border-radius: 0;
-                color: @text;
-
-                &:hover,
-                &:active,
-                &:focus {
-                    outline-color: @input-border__focused;
-                    outline-offset: 0;
-                }
-            }
-
-            select[disabled] {
-                color: @input-text__disabled;
-                background-color: @input-bg__disabled;
-                cursor: not-allowed;
-
-                &:hover {
-                    outline: 2px solid transparent;
-                }
-            }
-
-            select option:disabled {
-                color: @input-disabled;
-            }
-
-            &:after {
-                width: unit( 30px / @base-font-size-px, em );
-                height: unit( 30px / @base-font-size-px, em );
-                border-left: 1px solid @select-border;
-                position: absolute;
-                top: 0;
-                right: 0;
-                background-color: @input-disabled;
-                color: @select-icon;
-                content: @cf-icon-down;
-                font-family: 'CFPB Minicons';
-                line-height: unit( 30px / @base-font-size-px, em );
-                text-align: center;
-                pointer-events: none;
-            }
-        }
-    }
-
-    // @todo: add modernizr to CF so this works:
-
-    .no-csspointerevents .m-select {
-        &:after {
-            height: 0;
-            width: 0;
-            border: 0;
-            content: '';
         }
     }
 }

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -1,4 +1,4 @@
-.m-field {
+.m-form-field {
     .a-text-input {
         box-sizing: border-box;
         width: 100%;
@@ -111,4 +111,73 @@
 
 .a-error-message .cf-icon-delete-round {
     color: @input-icon__error;
+
+    &__select {
+        .a-select {
+            position: relative;
+            margin-top: 0.5em;
+            border: 1px solid @select-border;
+
+            select {
+                height: unit( 30px / @base-font-size-px, em );
+                width: 100%;
+                padding: unit( 4px / @base-font-size-px, em )
+                         unit( 6px / @base-font-size-px, em );
+                border: 0;
+                outline: 2px solid transparent;
+                appearance: none;
+                background-color: @input-bg;
+                border-radius: 0;
+                color: @text;
+
+                &:hover,
+                &:active,
+                &:focus {
+                    outline-color: @input-border__focused;
+                    outline-offset: 0;
+                }
+            }
+
+            select[disabled] {
+                color: @input-text__disabled;
+                background-color: @input-bg__disabled;
+                cursor: not-allowed;
+
+                &:hover {
+                    outline: 2px solid transparent;
+                }
+            }
+
+            select option:disabled {
+                color: @input-disabled;
+            }
+
+            &:after {
+                width: unit( 30px / @base-font-size-px, em );
+                height: unit( 30px / @base-font-size-px, em );
+                border-left: 1px solid @select-border;
+                position: absolute;
+                top: 0;
+                right: 0;
+                background-color: @input-disabled;
+                color: @select-icon;
+                content: @cf-icon-down;
+                font-family: 'CFPB Minicons';
+                line-height: unit( 30px / @base-font-size-px, em );
+                text-align: center;
+                pointer-events: none;
+            }
+        }
+    }
+
+    // @todo: add modernizr to CF so this works:
+
+    .no-csspointerevents .m-select {
+        &:after {
+            height: 0;
+            width: 0;
+            border: 0;
+            content: '';
+        }
+    }
 }

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -96,6 +96,63 @@ Inputs should always be paired with a label for accessibility reasons.
 <textarea class="a-text-input" id="textarea-example">Lorem Ipsum</textarea>
 ```
 
+### Basic checkboxes
+
+<div class="m-form-field__checkbox">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox">
+    <label class="a-label" for="test_checkbox">Label</label>
+</div>
+
+```
+<div class="m-form-field__checkbox">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox">
+    <label class="a-label" for="test_checkbox">Label</label>
+</div>
+```
+
+### Basic radio buttons
+
+<div class="m-form-field__radio">
+    <input class="a-radio" type="radio" id="test_radio">
+    <label class="a-label" for="test_radio">Label</label>
+</div>
+
+```
+<div class="m-form-field__radio">
+    <input class="a-radio" type="radio" id="test_radio">
+    <label class="a-label" for="test_radio">Label</label>
+</div>
+```
+
+### Select box
+
+<div class="m-form-field__select">
+    <label class="a-label" for="test_select">Label</label>
+    <div class="a-select">
+        <select id="test_select">
+            <option value="option1">Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+            <option value="option4">Option 4</option>
+        </select>
+    </div>
+</div>
+
+```
+<div class="m-form-field__select">
+    <label class="a-label" for="test_select">Label</label>
+    <div class="a-select">
+        <select id="test_select">
+            <option value="option1">Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+            <option value="option4">Option 4</option>
+        </select>
+    </div>
+</div>
+```
+
+
 ### Input states
 
 See the 'Form icons' section below for guidance on adding icons to states.


### PR DESCRIPTION
Standardized the select box to match the other form fields. Also renamed `.m-field` to `.m-form-field` to make it more clear where all the form fields live and differentiate between something like `fieldset`

## Testing

- Test against https://github.com/cfpb/capital-framework-sandbox/pull/27

## Screenshots

![image](https://cloud.githubusercontent.com/assets/1860176/18595550/3849118c-7c13-11e6-994a-6b37b22efac7.png)
