### PR TITLE
General cleanup of the buttons component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - Input with Button
   - Atomized and simplified inline form validation
 - **cf-core:** [MAJOR] Moved the base form styles to cf-form
+- **cf-buttons** [PATCH] Standardized and optimized less code
 
 ### Removed
 - **cf-core:** [MAJOR] Removed deprecated items:

--- a/src/cf-buttons/src/atoms/button-links.less
+++ b/src/cf-buttons/src/atoms/button-links.less
@@ -4,24 +4,22 @@
 
 .a-btn__link {
   padding: 0;
+
   border-bottom: 1px dotted @link-underline;
   border-radius: 0;
-  // This margin is necessary to vertically align link buttons with
-  // regular buttons.
-  margin: unit( @btn-v-padding / @btn-font-size, em) 0;
 
   &,
   &:link,
   &:visited {
-    border-bottom-color: @link-underline-visited;
     background-color: transparent;
+    border-bottom-color: @link-underline-visited;
     color: @link-text-visited;
   }
 
   &:hover,
   &.hover {
-    border-bottom: 1px solid @link-underline-hover;
     background-color: transparent;
+    border-bottom: 1px solid @link-underline-hover;
     color: @link-text-hover;
   }
 
@@ -38,73 +36,71 @@
     background-color: transparent;
     color: @link-text-active;
   }
-}
 
-.lt-ie8 {
-  button.a-btn__link,
-  input.a-btn__link {
+  .lt-ie8 button&,
+  .lt-ie8 input& {
     padding: 0;
   }
-}
 
-//
-// Secondary button link
-//
+  //
+  // Secondary button link
+  //
 
-.a-btn__link.a-btn__secondary {
-  &,
-  &:link,
-  &:visited {
-    border-bottom-color: @btn__secondary-bg;
-    background-color: transparent;
-    color: @btn__secondary-bg;
+  &.a-btn__secondary {
+    &,
+    &:link,
+    &:visited {
+      border-bottom-color: @btn__secondary-bg;
+      background-color: transparent;
+      color: @btn__secondary-bg;
+    }
+
+    &:hover,
+    &.hover {
+      border-bottom-color: @btn__secondary-bg-hover;
+      color: @btn__secondary-bg-hover;
+    }
+
+    &:focus,
+    &.focus {
+      outline-color: @btn__secondary-bg;
+    }
+
+    &:active,
+    &.active {
+      border-bottom-color: @btn__secondary-bg-active;
+      color: @btn__secondary-bg-active;
+    }
   }
 
-  &:hover,
-  &.hover {
-    border-bottom-color: @btn__secondary-bg-hover;
-    color: @btn__secondary-bg-hover;
-  }
+  //
+  // Destructive action button link
+  //
 
-  &:focus,
-  &.focus {
-    outline-color: @btn__secondary-bg;
-  }
+  &.a-btn__warning {
+    &,
+    &:link,
+    &:visited {
+      border-bottom-color: @btn__warning-bg;
+      background-color: transparent;
+      color: @btn__warning-bg;
+    }
 
-  &:active,
-  &.active {
-    border-bottom-color: @btn__secondary-bg-active;
-    color: @btn__secondary-bg-active;
-  }
-}
+    &:hover,
+    &.hover {
+      border-bottom-color: @btn__warning-bg-hover;
+      color: @btn__warning-bg-hover;
+    }
 
-//
-// Destructive action button link
-//
+    &:focus,
+    &.focus {
+      outline-color: @btn__warning-bg;
+    }
 
-.a-btn__link.a-btn__warning {
-  &,
-  &:link,
-  &:visited {
-    border-bottom-color: @btn__warning-bg;
-    background-color: transparent;
-    color: @btn__warning-bg;
-  }
-
-  &:hover,
-  &.hover {
-    border-bottom-color: @btn__warning-bg-hover;
-    color: @btn__warning-bg-hover;
-  }
-
-  &:focus,
-  &.focus {
-    outline-color: @btn__warning-bg;
-  }
-
-  &:active,
-  &.active {
-    border-bottom-color: @btn__warning-bg-active;
-    color: @btn__warning-bg-active;
+    &:active,
+    &.active {
+      border-bottom-color: @btn__warning-bg-active;
+      color: @btn__warning-bg-active;
+    }
   }
 }

--- a/src/cf-buttons/src/atoms/buttons-with-icons.less
+++ b/src/cf-buttons/src/atoms/buttons-with-icons.less
@@ -1,1549 +1,793 @@
 @import '../atoms/buttons.less';
 
-//
-// Button icons
-//
-
 // Icon directions
 
 .a-btn_icon-position-left {
   &:before {
     padding-right: unit( 10.5px / @btn-font-size, em );
-    border-right: 1px solid @btn-text; // Fallback
-    border-right: 1px solid fade( @btn-text, 40% );
+    border-right: 1px solid mix( @btn-bg, @btn-text, 50% );
     margin-right: unit( 7px / @btn-font-size, em );
-  }
-
-  .a-btn__secondary &:before {
-    border-right-color: @btn__secondary-text; // Fallback
-    border-right-color: fade( @btn__secondary-text, 40% );
-  }
-
-  .a-btn__warning &:before {
-    border-right-color: @btn__warning-text; // Fallback
-    border-right-color: fade( @btn__warning-text, 40% );
-  }
-
-  .a-btn__disabled &:before,
-  .a-btn[disabled] &:before {
-    border-right-color: @btn__disabled-text; // Fallback
-    border-right-color: fade( @btn__disabled-text, 40% );
   }
 }
 
 .a-btn_icon-position-right {
   &:after  {
-    padding-left: unit( 10.5px / @btn-font-size, em);
-    border-right: 0;
-    border-left: 1px solid @btn-text; // Fallback
-    border-left: 1px solid fade(@btn-text, 40%);
-    margin-left: unit( 7px / @btn-font-size, em);
-  }
-  .a-btn__secondary & {
-    border-left-color: @btn__secondary-text; // Fallback
-    border-left-color: fade(@btn__secondary-text, 40%);
-  }
-  .a-btn__warning & {
-    border-left-color: @btn__warning-text; // Fallback
-    border-left-color: fade(@btn__warning-text, 40%);
-  }
-  .a-btn__disabled &,
-  .a-btn[disabled] & {
-    border-left-color: @btn__disabled-text; // Fallback
-    border-left-color: fade(@btn__disabled-text, 40%);
+    padding-left: unit( 10.5px / @btn-font-size, em );
+    border-left: 1px solid mix( @btn-bg, @btn-text, 50% );
+    margin-left: unit( 7px / @btn-font-size, em );
   }
 }
 
 
-// Navigation icons
+.a-btn_icon-position-left:before,
+.a-btn_icon-position-right:after {
+  font-family: 'CFPB Minicons';
 
-.a-btn_icon__left {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn__secondary& {
+    border-color: mix( @btn__secondary-bg, @btn__secondary-text, 50% );
+  }
+
+  .a-btn__warning& {
+    border-color: mix( @btn__warning-bg, @btn__warning-text, 50% );
+  }
+
+  .a-btn__disabled&,
+  .a-btn[disabled]& {
+    border-color: mix( @btn__disabled-bg, @btn__disabled-text, 50% );
+  }
+
+  // Navigation icons
+
+  .a-btn_icon__left& {
     content: @cf-icon-left;
   }
-}
 
-.a-btn_icon__left-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__left-round& {
     content: @cf-icon-left-round;
   }
-}
 
-.a-btn_icon__right {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__right& {
     content: @cf-icon-right;
   }
-}
 
-.a-btn_icon__right-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__right-round& {
     content: @cf-icon-right-round;
   }
-}
 
-.a-btn_icon__up {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__up& {
     content: @cf-icon-up;
   }
-}
 
-.a-btn_icon__up-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__up-round& {
     content: @cf-icon-up-round;
   }
-}
 
-.a-btn_icon__down {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__down& {
     content: @cf-icon-down;
   }
-}
 
-.a-btn_icon__down-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__down-round& {
     content: @cf-icon-down-round;
   }
-}
 
-.a-btn_icon__arrow-left {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__arrow-left& {
     content: @cf-icon-arrow-left;
   }
-}
 
-.a-btn_icon__arrow-left-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__arrow-left-round& {
     content: @cf-icon-arrow-left-round;
   }
-}
 
-.a-btn_icon__right {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__right& {
     content: @cf-icon-right;
   }
-}
 
-.a-btn_icon__right-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__right-round& {
     content: @cf-icon-right-round;
   }
-}
 
-.a-btn_icon__up {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__up& {
     content: @cf-icon-up;
   }
-}
 
-.a-btn_icon__up-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__up-round& {
     content: @cf-icon-up-round;
   }
-}
 
-.a-btn_icon__down {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__down& {
     content: @cf-icon-down;
   }
-}
 
-.a-btn_icon__down-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__down-round& {
     content: @cf-icon-down-round;
   }
-}
 
-// Status icons
+  // Status icons
 
-.a-btn_icon__approved {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__approved& {
     content: @cf-icon-approved;
   }
-}
 
-.a-btn_icon__approved-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__approved-round& {
     content: @cf-icon-approved-round;
   }
-}
 
-.a-btn_icon__error {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__error& {
     content: @cf-icon-error;
   }
-}
 
-.a-btn_icon__error-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__error-round& {
     content: @cf-icon-error-round;
   }
-}
 
-.a-btn_icon__help {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__help& {
     content: @cf-icon-help;
   }
-}
 
-.a-btn_icon__help-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__help-round& {
     content: @cf-icon-help-round;
   }
-}
 
-.a-btn_icon__delete {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__delete& {
     content: @cf-icon-delete;
   }
-}
 
-.a-btn_icon__delete-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__delete-round& {
     content: @cf-icon-delete-round;
   }
-}
 
-.a-btn_icon__plus {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__plus& {
     content: @cf-icon-plus;
   }
-}
 
-.a-btn_icon__plus-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__plus-round& {
     content: @cf-icon-plus-round;
   }
-}
 
-.a-btn_icon__minus {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__minus& {
     content: @cf-icon-minus;
   }
-}
 
-.a-btn_icon__minus-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__minus-round& {
     content: @cf-icon-minus-round;
   }
-}
 
-.a-btn_icon__update {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__update& {
     content: @cf-icon-update;
   }
-}
 
-.a-btn_icon__update-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__update-round& {
     content: @cf-icon-update-round;
   }
-}
 
-// Social icons
+  // Social icons
 
-.a-btn_icon__youtube {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__youtube& {
     content: @cf-icon-youtube;
   }
-}
 
-.a-btn_icon__youtube-square {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__youtube-square& {
     content: @cf-icon-youtube-square;
   }
-}
 
-.a-btn_icon__linkedin {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__linkedin& {
     content: @cf-icon-linkedin;
   }
-}
 
-.a-btn_icon__linkedin-square {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__linkedin-square& {
     content: @cf-icon-linkedin-square;
   }
-}
 
-.a-btn_icon__facebook {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__facebook& {
     content: @cf-icon-facebook;
   }
-}
 
-.a-btn_icon__facebook-square {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__facebook-square& {
     content: @cf-icon-facebook-square;
   }
-}
 
-.a-btn_icon__flickr {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__flickr& {
     content: @cf-icon-flickr;
   }
-}
 
-.a-btn_icon__flickr-square {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__flickr-square& {
     content: @cf-icon-flickr-square;
   }
-}
 
-.a-btn_icon__twitter {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__twitter& {
     content: @cf-icon-twitter;
   }
-}
 
-.a-btn_icon__twitter-square {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__twitter-square& {
     content: @cf-icon-twitter-square;
   }
-}
 
-.a-btn_icon__github {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__github& {
     content: @cf-icon-github;
   }
-}
 
-.a-btn_icon__github-square {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__github-square& {
     content: @cf-icon-github-square;
   }
-}
 
-.a-btn_icon__email-social {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__email-social& {
     content: @cf-icon-email-social;
   }
-}
 
-.a-btn_icon__email-social-square {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__email-social-square& {
     content: @cf-icon-email-social-square;
   }
-}
 
-// Communication icons
+  // Communication icons
 
-.a-btn_icon__web {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
-    content: @cf-icon-web;
+  .a-btn_icon__web& {
+      content: @cf-icon-web;
   }
-}
 
-.a-btn_icon__web-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__web-round& {
     content: @cf-icon-web-round;
   }
-}
 
-.a-btn_icon__email {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__email& {
     content: @cf-icon-email;
   }
-}
 
-.a-btn_icon__email-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__email-round& {
     content: @cf-icon-email-round;
   }
-}
 
-.a-btn_icon__mail {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__mail& {
     content: @cf-icon-mail;
   }
-}
 
-.a-btn_icon__mail-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__mail-round& {
     content: @cf-icon-mail-round;
   }
-}
 
-.a-btn_icon__phone {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__phone& {
     content: @cf-icon-phone;
   }
-}
 
-.a-btn_icon__phone-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__phone-round& {
     content: @cf-icon-phone-round;
   }
-}
 
-.a-btn_icon__technology {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__technology& {
     content: @cf-icon-technology;
   }
-}
 
-.a-btn_icon__technology-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__technology-round& {
     content: @cf-icon-technology-round;
   }
-}
 
-.a-btn_icon__fax {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__fax& {
     content: @cf-icon-fax;
   }
-}
 
-.a-btn_icon__fax-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__fax-round& {
     content: @cf-icon-fax-round;
   }
-}
-// Document icons
 
-.a-btn_icon__document {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  // Document icons
+
+  .a-btn_icon__document& {
     content: @cf-icon-document;
   }
-}
 
-.a-btn_icon__document-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__document-round& {
     content: @cf-icon-document-round;
   }
-}
 
-.a-btn_icon__pdf {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__pdf& {
     content: @cf-icon-pdf;
   }
-}
 
-.a-btn_icon__pdf-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__pdf-round& {
     content: @cf-icon-pdf-round;
   }
-}
 
-.a-btn_icon__upload {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__upload& {
     content: @cf-icon-upload;
   }
-}
 
-.a-btn_icon__upload-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__upload-round& {
     content: @cf-icon-upload-round;
   }
-}
 
-.a-btn_icon__download {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__download& {
     content: @cf-icon-download;
   }
-}
 
-.a-btn_icon__download-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__download-round& {
     content: @cf-icon-download-round;
   }
-}
 
-.a-btn_icon__copy {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__copy& {
     content: @cf-icon-copy;
   }
-}
 
-.a-btn_icon__copy-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__copy-round& {
     content: @cf-icon-copy-round;
   }
-}
 
-.a-btn_icon__edit {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__edit& {
     content: @cf-icon-edit;
   }
-}
 
-.a-btn_icon__edit-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__edit-round& {
     content: @cf-icon-edit-round;
   }
-}
 
-.a-btn_icon__attach {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__attach& {
     content: @cf-icon-attach;
   }
-}
 
-.a-btn_icon__attach {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__attach& {
     content: @cf-icon-attach-round;
   }
-}
 
-.a-btn_icon__print {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__print& {
     content: @cf-icon-print;
   }
-}
 
-.a-btn_icon__print-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__print-round& {
     content: @cf-icon-print-round;
   }
-}
 
-.a-btn_icon__appendix {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__appendix& {
     content: @cf-icon-appendix;
   }
-}
 
-.a-btn_icon__appendix-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__appendix-round& {
     content: @cf-icon-appendix-round;
   }
-}
 
-.a-btn_icon__supplement {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__supplement& {
     content: @cf-icon-supplement;
   }
-}
 
-.a-btn_icon__supplement-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__supplement-round& {
     content: @cf-icon-supplement-round;
   }
-}
 
-.a-btn_icon__rss {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__rss& {
     content: @cf-icon-rss;
   }
-}
 
-.a-btn_icon__rss-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__rss-round& {
     content: @cf-icon-rss-round;
   }
-}
 
-// Financial products
+  // Financial products
 
-.a-btn_icon__bank-account {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__bank-account& {
     content: @cf-icon-bank-account;
   }
-}
 
-.a-btn_icon__bank-account-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__bank-account-round& {
     content: @cf-icon-bank-account-round;
   }
-}
 
-.a-btn_icon__credit-card {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__credit-card& {
     content: @cf-icon-credit-card;
   }
-}
 
-.a-btn_icon__credit-card-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__credit-card-round& {
     content: @cf-icon-credit-card-round;
   }
-}
 
-.a-btn_icon__loan {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__loan& {
     content: @cf-icon-loan;
   }
-}
 
-.a-btn_icon__loan-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__loan-round& {
     content: @cf-icon-loan-round;
   }
-}
 
-.a-btn_icon__money-transfer {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__money-transfer& {
     content: @cf-icon-money-transfer;
   }
-}
 
-.a-btn_icon__money-transfer-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__money-transfer-round& {
     content: @cf-icon-money-transfer-round;
   }
-}
 
-.a-btn_icon__mortgage {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__mortgage& {
     content: @cf-icon-mortgage;
   }
-}
 
-.a-btn_icon__mortgage-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__mortgage-round& {
     content: @cf-icon-mortgage-round;
   }
-}
 
-.a-btn_icon__debt-collection {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__debt-collection& {
     content: @cf-icon-debt-collection;
   }
-}
 
-.a-btn_icon__debt-collection-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__debt-collection-round& {
     content: @cf-icon-debt-collection-round;
   }
-}
 
-.a-btn_icon__credit-report {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__credit-report& {
     content: @cf-icon-credit-report;
   }
-}
 
-.a-btn_icon__credit-report-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__credit-report-round& {
     content: @cf-icon-credit-report-round;
   }
-}
 
-.a-btn_icon__money {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__money& {
     content: @cf-icon-money;
   }
-}
 
-.a-btn_icon__money-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__money-round& {
     content: @cf-icon-money-round;
   }
-}
 
-.a-btn_icon__quick-cash {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__quick-cash& {
     content: @cf-icon-quick-cash;
   }
-}
 
-.a-btn_icon__quick-cash-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__quick-cash-round& {
     content: @cf-icon-quick-cash-round;
   }
-}
 
-.a-btn_icon__contract {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__contract& {
     content: @cf-icon-contract;
   }
-}
 
-.a-btn_icon__contract-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__contract-round& {
     content: @cf-icon-contract-round;
   }
-}
 
-.a-btn_icon__complaint {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__complaint& {
     content: @cf-icon-complaint;
   }
-}
 
-.a-btn_icon__complaint-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__complaint-round& {
     content: @cf-icon-complaint-round;
   }
-}
 
-.a-btn_icon__getting-credit-card {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__getting-credit-card& {
     content: @cf-icon-getting-credit-card;
   }
-}
 
-.a-btn_icon__getting-credit-card-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__getting-credit-card-round& {
     content: @cf-icon-getting-credit-card-round;
   }
-}
 
-.a-btn_icon__buying-car {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__buying-car& {
     content: @cf-icon-buying-car;
   }
-}
 
-.a-btn_icon__buying-car-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__buying-car-round& {
     content: @cf-icon-buying-car-round;
   }
-}
 
-.a-btn_icon__paying-college {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__paying-college& {
     content: @cf-icon-paying-college;
   }
-}
 
-.a-btn_icon__paying-college-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__paying-college-round& {
     content: @cf-icon-paying-college-round;
   }
-}
 
-.a-btn_icon__owning-home {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__owning-home& {
     content: @cf-icon-owning-home;
   }
-}
 
-.a-btn_icon__owning-home-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__owning-home-round& {
     content: @cf-icon-owning-home-round;
   }
-}
 
-.a-btn_icon__debt {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__debt& {
     content: @cf-icon-debt;
   }
-}
 
-.a-btn_icon__debt-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__debt-round& {
     content: @cf-icon-debt-round;
   }
-}
 
-.a-btn_icon__building-credit {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__building-credit& {
     content: @cf-icon-building-credit;
   }
-}
 
-.a-btn_icon__building-credit-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__building-credit-round& {
     content: @cf-icon-building-credit-round;
   }
-}
 
-.a-btn_icon__prepaid-cards {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__prepaid-cards& {
     content: @cf-icon-prepaid-cards;
   }
-}
 
-.a-btn_icon__prepaid-cards-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__prepaid-cards-round& {
     content: @cf-icon-prepaid-cards-round;
   }
-}
 
-.a-btn_icon__payday-loan {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__payday-loan& {
     content: @cf-icon-payday-loan;
   }
-}
 
-.a-btn_icon__payday-loan-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__payday-loan-round& {
     content: @cf-icon-payday-loan-round;
   }
-}
 
-.a-btn_icon__retirement {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__retirement& {
     content: @cf-icon-retirement-round;
   }
-}
 
-.a-btn_icon__retirement-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__retirement-round& {
     content: @cf-icon-retirement-round;
   }
-}
 
-// Web icons
 
-.a-btn_icon__user {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  // Web icons
+
+  .a-btn_icon__user& {
     content: @cf-icon-user;
   }
-}
 
-.a-btn_icon__user-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__user-round& {
     content: @cf-icon-user-round;
   }
-}
 
-.a-btn_icon__wifi {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__wifi& {
     content: @cf-icon-wifi;
   }
-}
 
-.a-btn_icon__wifi-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__wifi-round& {
     content: @cf-icon-wifi-round;
   }
-}
 
-.a-btn_icon__search {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__search& {
     content: @cf-icon-search;
   }
-}
 
-.a-btn_icon__search-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__search-round& {
     content: @cf-icon-search-round;
   }
-}
 
-.a-btn_icon__link {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__link& {
     content: @cf-icon-link;
   }
-}
 
-.a-btn_icon__link-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__link-round& {
     content: @cf-icon-link-round;
   }
-}
 
-.a-btn_icon__external-link {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__external-link& {
     content: @cf-icon-external-link;
   }
-}
 
-.a-btn_icon__external-link-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__external-link-round& {
     content: @cf-icon-external-link-round;
   }
-}
 
-.a-btn_icon__audio-mute {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__audio-mute& {
     content: @cf-icon-audio-mute;
   }
-}
 
-.a-btn_icon__audio-mute-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__audio-mute-round& {
     content: @cf-icon-audio-mute-round;
   }
-}
 
-.a-btn_icon__audio-low {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__audio-low& {
     content: @cf-icon-audio-low;
   }
-}
 
-.a-btn_icon__audio-low-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__audio-low-round& {
     content: @cf-icon-audio-low-round;
   }
-}
 
-.a-btn_icon__audio-medium {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__audio-medium& {
     content: @cf-icon-audio-medium;
   }
-}
 
-.a-btn_icon__audio-medium-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__audio-medium-round& {
     content: @cf-icon-audio-medium-round;
   }
-}
 
-.a-btn_icon__audio-max {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__audio-max& {
     content: @cf-icon-audio-max;
   }
-}
 
-.a-btn_icon__audio-max-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__audio-max-round& {
     content: @cf-icon-audio-max-round;
   }
-}
 
-.a-btn_icon__favorite {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__favorite& {
     content: @cf-icon-favorite;
   }
-}
 
-.a-btn_icon__favorite-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__favorite-round& {
     content: @cf-icon-favorite-round;
   }
-}
 
-.a-btn_icon__bookmark {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__bookmark& {
     content: @cf-icon-bookmark;
   }
-}
 
-.a-btn_icon__bookmark-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__bookmark-round& {
     content: @cf-icon-bookmark-round;
   }
-}
 
-.a-btn_icon__unbookmark {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__unbookmark& {
     content: @cf-icon-unbookmark;
   }
-}
 
-.a-btn_icon__unbookmark-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__unbookmark-round& {
     content: @cf-icon-unbookmark-round;
   }
-}
 
-.a-btn_icon__settings {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__settings& {
     content: @cf-icon-settings;
   }
-}
 
-.a-btn_icon__settings-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__settings-round& {
     content: @cf-icon-settings-round;
   }
-}
 
-.a-btn_icon__menu {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__menu& {
     content: @cf-icon-menu;
   }
-}
 
-.a-btn_icon__menu-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__menu-round& {
     content: @cf-icon-menu-round;
   }
-}
 
-.a-btn_icon__lock {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__lock& {
     content: @cf-icon-lock;
   }
-}
 
-.a-btn_icon__lock-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__lock-round& {
     content: @cf-icon-lock-round;
   }
-}
 
-.a-btn_icon__unlock {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__unlock& {
     content: @cf-icon-unlock;
   }
-}
 
-.a-btn_icon__unlock-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__unlock-round& {
     content: @cf-icon-unlock-round;
   }
-}
 
-.a-btn_icon__clock {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__clock& {
     content: @cf-icon-clock;
   }
-}
 
-.a-btn_icon__clock-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__clock-round& {
     content: @cf-icon-clock-round;
   }
-}
 
-.a-btn_icon__chart {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__chart& {
     content: @cf-icon-chart;
   }
-}
 
-.a-btn_icon__chart-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__chart-round& {
     content: @cf-icon-chart-round;
   }
-}
 
-.a-btn_icon__play {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__play& {
     content: @cf-icon-play;
   }
-}
 
-.a-btn_icon__play-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__play-round& {
     content: @cf-icon-play-round;
   }
-}
 
-.a-btn_icon__history {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__history& {
     content: @cf-icon-history;
   }
-}
 
-.a-btn_icon__history-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__history-round& {
     content: @cf-icon-history-round;
   }
-}
 
-.a-btn_icon__table-of-contents {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__table-of-contents& {
     content: @cf-icon-table-of-contents;
   }
-}
 
-.a-btn_icon__table-of-contents-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__table-of-contents-round& {
     content: @cf-icon-table-of-contents-round;
   }
-}
 
-.a-btn_icon__newspaper {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__newspaper& {
     content: @cf-icon-newspaper;
   }
-}
 
-.a-btn_icon__newspaper-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__newspaper-round& {
     content: @cf-icon-newspaper-round;
   }
-}
 
-.a-btn_icon__microphone {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__microphone& {
     content: @cf-icon-microphone;
   }
-}
 
-.a-btn_icon__microphone-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__microphone-round& {
     content: @cf-icon-microphone-round;
   }
-}
 
-.a-btn_icon__bullhorn {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__bullhorn& {
     content: @cf-icon-bullhorn;
   }
-}
 
-.a-btn_icon__bullhorn-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__bullhorn-round& {
     content: @cf-icon-bullhorn-round;
   }
-}
 
-.a-btn_icon__double-quote {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__double-quote& {
     content: @cf-icon-double-quote;
   }
-}
 
-.a-btn_icon__double-quote-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__double-quote-round& {
     content: @cf-icon-double-quote-round;
   }
-}
 
-.a-btn_icon__speech-bubble {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__speech-bubble& {
     content: @cf-icon-speech-bubble;
   }
-}
 
-.a-btn_icon__speech-bubble-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__speech-bubble-round& {
     content: @cf-icon-speech-bubble-round;
   }
-}
 
-.a-btn_icon__information {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__information& {
     content: @cf-icon-information;
   }
-}
 
-.a-btn_icon__information-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__information-round& {
     content: @cf-icon-information-round;
   }
-}
 
-.a-btn_icon__lightbulb {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__lightbulb& {
     content: @cf-icon-lightbulb;
   }
-}
 
-.a-btn_icon__dialogue {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__dialogue& {
     content: @cf-icon-dialogue;
   }
-}
 
-.a-btn_icon__dialogue-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__dialogue-round& {
     content: @cf-icon-dialogue-round;
   }
-}
 
-.a-btn_icon__date {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__date& {
     content: @cf-icon-date;
   }
-}
 
-.a-btn_icon__date-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-  font-family: 'CFPB Minicons';
-  content: @cf-icon-date-round;
+  .a-btn_icon__date-round& {
+    content: @cf-icon-date-round;
   }
-}
 
-.a-btn_icon__closing-quote {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__closing-quote& {
     content: @cf-icon-closing-quote;
   }
-}
 
-.a-btn_icon__closing-quote-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__closing-quote-round& {
     content: @cf-icon-closing-quote-round;
   }
-}
 
-.a-btn_icon__livestream {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__livestream& {
     content: @cf-icon-livestream;
   }
-}
 
-.a-btn_icon__livestream-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__livestream-round& {
     content: @cf-icon-livestream-round;
   }
-}
 
-.a-btn_icon__parents {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__parents& {
     content: @cf-icon-parents;
   }
-}
 
-.a-btn_icon__parents-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__parents-round& {
     content: @cf-icon-parents-round;
   }
-}
 
-.a-btn_icon__servicemembers {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__servicemembers& {
     content: @cf-icon-servicemembers;
   }
-}
 
-.a-btn_icon__servicemembers-round {
-  &.a-btn_icon-position-left:before,
-  &.a-btn_icon-position-right:after {
-    font-family: 'CFPB Minicons';
+  .a-btn_icon__servicemembers-round& {
     content: @cf-icon-servicemembers-round;
   }
 }

--- a/src/cf-buttons/src/atoms/buttons.less
+++ b/src/cf-buttons/src/atoms/buttons.less
@@ -32,7 +32,7 @@
 // Sizing variables
 
 // .btn
-@btn-font-size:                 16px;
+@btn-font-size:                 @base-font-size-px;
 @btn-border-radius-size:        4px;
 @btn-v-padding:                 8px;
 @btn-h-padding:                 14px;
@@ -46,23 +46,25 @@
 //
 
 .a-btn {
+  .webfont-medium();
+
+  appearance: none;
+
   display: inline-block;
+
   box-sizing: border-box;
   padding:
     unit( @btn-v-padding / @btn-font-size, em )
     unit( @btn-h-padding / @btn-font-size, em );
   border: 0;
-  border-radius: unit( @btn-border-radius-size / @btn-font-size, em );
   margin: 0;
 
-  .webfont-medium();
+  border-radius: unit( @btn-border-radius-size / @btn-font-size, em );
   cursor: pointer;
   font-size: unit( @btn-font-size / @base-font-size-px, em );
   line-height: normal;
   text-decoration: none;
   transition: background-color 0.1s;
-  vertical-align: middle;
-  appearance: none;
 
   &,
   &:link,
@@ -72,13 +74,14 @@
   }
 
   &:hover,
-  &.hover {
+  &.hover,
+  &:focus,
+  &.focus {
     background-color: @btn-bg-hover;
   }
 
   &:focus,
   &.focus {
-    background-color: @btn-bg-hover;
     outline: 1px dotted @btn-bg;
     // outline-offset is not supported everywhere but it adds a nice touch
     // in browsers where it is.
@@ -96,125 +99,117 @@
     // Helps with inconsistent input.btn height in FireFox but not completely
     border: 0;
   }
-}
-
-.lt-ie8 {
-  // Fixes scroll rendering bug
-  // http://snipplr.com/view/518/
-  & {
-    background: url( null ) fixed no-repeat;
-  }
 
   // Fixes button and input sizes in IE7
-  button.a-btn,
-  input.a-btn {
+  .lt-ie8 button&,
+  .lt-ie8 input& {
     overflow: visible;
     padding-top: unit( @btn-v-padding-modifier-ie * @btn-v-padding / @btn-font-size, em );
     padding-bottom: unit( @btn-v-padding-modifier-ie * @btn-v-padding / @btn-font-size, em );
   }
-}
 
-//
-// Secondary button
-//
+  //
+  // Secondary button
+  //
 
-.a-btn__secondary {
-  &,
-  &:link,
-  &:visited {
-    background-color: @btn__secondary-bg;
-    color: @btn__secondary-text;
+  &__secondary {
+    &,
+    &:link,
+    &:visited {
+      background-color: @btn__secondary-bg;
+      color: @btn__secondary-text;
+    }
+
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus {
+      background-color: @btn__secondary-bg-hover;
+    }
+
+    &:focus,
+    &.focus {
+      outline-color: @btn__secondary-bg;
+    }
+
+    &:active,
+    &.active {
+      background-color: @btn__secondary-bg-active;
+    }
   }
 
-  &:hover,
-  &.hover {
-    background-color: @btn__secondary-bg-hover;
+  //
+  // Destructive action button
+  //
+
+  &__warning {
+    &,
+    &:link,
+    &:visited {
+      background-color: @btn__warning-bg;
+      color: @btn__warning-text;
+    }
+
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus {
+      background-color: @btn__warning-bg-hover;
+    }
+
+    &:focus,
+    &.focus {
+      outline-color: @btn__warning-bg;
+    }
+
+    &:active,
+    &.active {
+      background-color: @btn__warning-bg-active;
+    }
   }
 
-  &:focus,
-  &.focus {
-    background-color: @btn__secondary-bg-hover;
-    outline-color: @btn__secondary-bg;
+  //
+  // Disabled button
+  //
+
+  &__disabled,
+  &[disabled] {
+    &,
+    &:link,
+    &:visited,
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus,
+    &:active,
+    &.active {
+      background-color: @btn__disabled-bg;
+      color: @btn__disabled-text;
+      cursor: default; // Fallback for IE/Opera
+      cursor: not-allowed;
+    }
+
+    &:focus,
+    &.focus {
+      outline-color: @btn__disabled-outline;
+    }
   }
 
-  &:active,
-  &.active {
-    background-color: @btn__secondary-bg-active;
-  }
-}
+  //
+  // Super button
+  //
 
-//
-// Destructive action button
-//
+  &__super {
+    padding:
+      unit( 11px / @super-btn-font-size, em )
+      unit( 29px / @super-btn-font-size, em );
+    font-size: unit( @super-btn-font-size / @base-font-size-px, em );
 
-.a-btn__warning {
-  &,
-  &:link,
-  &:visited {
-    background-color: @btn__warning-bg;
-    color: @btn__warning-text;
-  }
-
-  &:hover,
-  &.hover {
-    background-color: @btn__warning-bg-hover;
-  }
-
-  &:focus,
-  &.focus {
-    background-color: @btn__warning-bg-hover;
-    outline-color: @btn__warning-bg;
-  }
-
-  &:active,
-  &.active {
-    background-color: @btn__warning-bg-active;
-  }
-}
-
-//
-// Disabled button
-//
-
-.a-btn__disabled,
-.a-btn[disabled] {
-  &,
-  &:link,
-  &:visited,
-  &:hover,
-  &.hover,
-  &:focus,
-  &.focus,
-  &:active,
-  &.active {
-    background-color: @btn__disabled-bg;
-    color: @btn__disabled-text;
-    cursor: default; // Fallback for IE/Opera
-    cursor: not-allowed;
-  }
-
-  &:focus,
-  &.focus {
-    outline-color: @btn__disabled-outline;
-  }
-}
-
-//
-// Super button
-//
-
-.a-btn__super {
-  padding:
-    unit( 11px / @super-btn-font-size, em )
-    unit( 29px / @super-btn-font-size, em );
-  font-size: unit( @super-btn-font-size / @base-font-size-px, em );
-}
-
-.lt-ie8 {
-  // Fixes button and input sizes in IE7
-  button.a-btn__super,
-  input.a-btn__super {
-    padding-top: unit( @btn-v-padding-modifier-ie * 15px / @super-btn-font-size, em );
-    padding-bottom: unit( @btn-v-padding-modifier-ie * 15px / @super-btn-font-size, em );
+    // Fixes button and input sizes in IE7
+    .lt-ie8 button&,
+    .lt-ie8 input& {
+      padding-top: unit( @btn-v-padding-modifier-ie * 15px / @super-btn-font-size, em );
+      padding-bottom: unit( @btn-v-padding-modifier-ie * 15px / @super-btn-font-size, em );
+    }
   }
 }

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -292,136 +292,120 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 ### Button Links
 
 #### Default state
-<a href="#" class="a-btn__link">Button Link</a>
-<a href="#" class="a-btn__link a-btn__secondary">Secondary Button Link</a>
-<a href="#" class="a-btn__link a-btn__warning">Warning Button Link</a>
+<a href="#" class="a-btn a-btn__link">Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__warning">Warning Button Link</a>
 
 ```
-<a href="#" class="a-btn__link">Button Link</a>
-<a href="#" class="a-btn__link a-btn__secondary">Secondary Button Link</a>
-<a href="#" class="a-btn__link a-btn__warning">Warning Button Link</a>
+<a href="#" class="a-btn a-btn__link">Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__warning">Warning Button Link</a>
 ```
 
 #### Hovered state
-<a href="#" class="a-btn__link hover">Button Link</a>
-<a href="#" class="a-btn__link a-btn__secondary hover">Secondary Button Link</a>
-<a href="#" class="a-btn__link a-btn__warning hover">Warning Button Link</a>
+<a href="#" class="a-btn a-btn__link hover">Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary hover">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__warning hover">Warning Button Link</a>
 
 ```
-<a href="#" class="a-btn__link hover">Button Link</a>
-<a href="#" class="a-btn__link a-btn__secondary hover">Secondary Button Link</a>
-<a href="#" class="a-btn__link a-btn__warning hover">Warning Button Link</a>
+<a href="#" class="a-btn a-btn__link hover">Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary hover">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__warning hover">Warning Button Link</a>
 ```
 
 #### Focus state
-<a href="#" class="a-btn__link focus">Button Link</a>
-<a href="#" class="a-btn__link a-btn__secondary focus">Secondary Button Link</a>
-<a href="#" class="a-btn__link a-btn__warning focus">Warning Button Link</a>
+<a href="#" class="a-btn a-btn__link focus">Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary focus">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__warning focus">Warning Button Link</a>
 
 ```
-<a href="#" class="a-btn__link focus">Button Link</a>
-<a href="#" class="a-btn__link a-btn__secondary focus">Secondary Button Link</a>
-<a href="#" class="a-btn__link a-btn__warning focus">Warning Button Link</a>
+<a href="#" class="a-btn a-btn__link focus">Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary focus">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__warning focus">Warning Button Link</a>
 ```
 
 #### Active state
-<a href="#" class="a-btn__link active">Button Link</a>
-<a href="#" class="a-btn__link a-btn__secondary active">Secondary Button Link</a>
-<a href="#" class="a-btn__link a-btn__warning active">Warning Button Link</a>
+<a href="#" class="a-btn a-btn__link active">Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary active">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__warning active">Warning Button Link</a>
 
 ```
-<a href="#" class="a-btn__link active">Button Link</a>
-<a href="#" class="a-btn__link a-btn__secondary active">Secondary Button Link</a>
-<a href="#" class="a-btn__link a-btn__warning active">Warning Button Link</a>
+<a href="#" class="a-btn a-btn__link active">Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary active">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__warning active">Warning Button Link</a>
 ```
 
 ### Icon Buttons
 
 #### Button with Icon on the left
 
-<button class="a-btn">
-  <span class="a-btn_icon__left cf-icon cf-icon-delete"></span>
+<button class="a-btn a-btn_icon__left cf-icon cf-icon-delete">
   Close
 </button>
 
-<button class="a-btn a-btn__secondary">
-  <span class="a-btn_icon__left cf-icon cf-icon-delete"></span>
+<button class="a-btn a-btn__secondary a-btn_icon__left cf-icon cf-icon-delete">
   Close
 </button> - Secondary button
 
-<button class="a-btn a-btn__warning">
-  <span class="a-btn_icon__left cf-icon cf-icon-delete"></span>
+<button class="a-btn a-btn__warning a-btn_icon__left cf-icon cf-icon-delete">
   Close
 </button> - Warning button
 
-<button class="a-btn a-btn__disabled">
-  <span class="a-btn_icon__left cf-icon cf-icon-delete"></span>
+<button class="a-btn a-btn__disabled a-btn_icon__left cf-icon cf-icon-delete">
   Close
 </button> - Disabled button
 
 ```
-<button class="a-btn">
-  <span class="a-btn_icon__left cf-icon cf-icon-delete"></span>
+<button class="a-btn a-btn_icon__left cf-icon cf-icon-delete">
   Close
 </button>
 
-<button class="a-btn a-btn__secondary">
-  <span class="a-btn_icon__left cf-icon cf-icon-delete"></span>
+<button class="a-btn a-btn__secondary a-btn_icon__left cf-icon cf-icon-delete">
   Close
 </button> - Secondary button
 
-<button class="a-btn a-btn__warning">
-  <span class="a-btn_icon__left cf-icon cf-icon-delete"></span>
+<button class="a-btn a-btn__warning a-btn_icon__left cf-icon cf-icon-delete">
   Close
 </button> - Warning button
 
-<button class="a-btn a-btn__disabled">
-  <span class="a-btn_icon__left cf-icon cf-icon-delete"></span>
+<button class="a-btn a-btn__disabled a-btn_icon__left cf-icon cf-icon-delete">
   Close
 </button> - Disabled button
 ```
 
 #### Button with Icon on the right
 
-<button class="a-btn">
+<button class="a-btn a-btn_icon__right cf-icon cf-icon-delete">
   Close
-  <span class="a-btn_icon__right cf-icon cf-icon-delete"></span>
 </button>
 
-<button class="a-btn a-btn__secondary">
+<button class="a-btn a-btn__secondary a-btn_icon__right cf-icon cf-icon-delete">
   Close
-  <span class="a-btn_icon__right cf-icon cf-icon-delete"></span>
 </button> - Secondary button
 
-<button class="a-btn a-btn__warning">
+<button class="a-btn a-btn__warning a-btn_icon__right cf-icon cf-icon-delete">
   Close
-  <span class="a-btn_icon__right cf-icon cf-icon-delete"></span>
 </button> - Warning button
 
-<button class="a-btn a-btn__disabled">
+<button class="a-btn a-btn__disabled a-btn_icon__right cf-icon cf-icon-delete">
   Close
-  <span class="a-btn_icon__right cf-icon cf-icon-delete"></span>
 </button> - Disabled button
 
 ```
-<button class="a-btn">
+<button class="a-btn a-btn_icon__right cf-icon cf-icon-delete">
   Close
-  <span class="a-btn_icon__right cf-icon cf-icon-delete"></span>
 </button>
 
-<button class="a-btn a-btn__secondary">
+<button class="a-btn a-btn__secondary a-btn_icon__right cf-icon cf-icon-delete">
   Close
-  <span class="a-btn_icon__right cf-icon cf-icon-delete"></span>
 </button> - Secondary button
 
-<button class="a-btn a-btn__warning">
+<button class="a-btn a-btn__warning a-btn_icon__right cf-icon cf-icon-delete">
   Close
-  <span class="a-btn_icon__right cf-icon cf-icon-delete"></span>
 </button> - Warning button
 
-<button class="a-btn a-btn__disabled">
+<button class="a-btn a-btn__disabled a-btn_icon__right cf-icon cf-icon-delete">
   Close
-  <span class="a-btn_icon__right cf-icon cf-icon-delete"></span>
 </button> - Disabled button
 ```
 


### PR DESCRIPTION
While working on how to word/organize the atomic documentation, I realized there are some minor inconsistencies and inefficiencies in the code base. This is an attempt to clean those up within cf-buttons.

## Removals

- Removed duplicate rules where possible (mainly in the icons)
- Removed old margin alignment (not needed in testing)

## Changes

- Bundled modifiers with their parent.
- Fixed `a-btn__link` examples in usage doc.
- Changed `fade` function to `mix` function in button icons to reduce usage of alpha transparency (minor performance enhancement)

## Testing

- checkout this branch
- checkout `examples/buttons-cleanup` in the sandbox repo
- run `npm run build && npm start`
- navigate to `http://localhost:3000/components/cf-buttons/`

## Review

- @KimberlyMunoz 
- @mistergone 
- @Scotchester 

## Screenshots

Everything should look exactly the same.

__Example of button and button link vertically aligned with each other without the extra margin__

![screen shot 2016-09-19 at 2 30 10 pm](https://cloud.githubusercontent.com/assets/1280430/18646102/adf94df2-7e75-11e6-9a46-fba4ebc8bafd.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)