### PR TITLE
Bugfix - btn-inside-input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Fixed
 - **cf-typography:** [PATCH] Fixed old variables removed from cf-core
+- **cf-forms:** [PATCH] Fixed a layout bug in btn-inside-input
 
 ## 3.6.1 - 2016-08-12
 

--- a/src/cf-forms/src/molecules/btn-inside-input.less
+++ b/src/cf-forms/src/molecules/btn-inside-input.less
@@ -9,8 +9,10 @@
 
     .a-btn {
         .u-link__no-border();
+
         position: absolute;
-        right: unit( 15px / @btn-font-size, em );
-        top: 0;
+        // Set the right and top distances to match typical button padding
+        right: unit( @btn-h-padding / @btn-font-size, em );
+        top: unit( @btn-v-padding / @btn-font-size, em );
     }
 }


### PR DESCRIPTION
Fixed a bug with clear button alignment

## Changes

- Updated the top and right spacing to match button padding dimensions

## Testing

- checkout branch and run `npm run cf-link`
- checkout `example/btn-inside-input` in the sandbox
- run `npm run cf-link && npm run build && npm start`
- check button inside input example on cf-forms page

## Review

- @mistergone 
- @Scotchester 

## Screenshots

__Before__

![screen shot 2016-10-05 at 3 22 58 pm](https://cloud.githubusercontent.com/assets/1280430/19130140/9deae60e-8b0f-11e6-97e1-db393d05e60a.png)

__After__

![screen shot 2016-10-05 at 3 22 10 pm](https://cloud.githubusercontent.com/assets/1280430/19130108/81f8d46a-8b0f-11e6-95a4-f4735ae53dac.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

