### PR TITLE
Atomic/typography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-buttons** [PATCH] Standardized and optimized less code
 - **cf-forms** [MINOR] Updated large target radios/checkboxes to use field molecule
 - **cf-tables:** [MAJOR] Atomized cf-tables.
+- **cf-typography:** [MAJOR] Update to atomic naming conventions:
+  - Broke links apart to create less repetitive code.
+  - Broke headings and headers apart to create a better parent/child relationship and handle layout according to our best practices.
+  - Broke lists apart to create less repetitive code.
+  - Comma separated selectors that share styles rather than list each required class in the markup or turning the required class into a mixin.
 
 ### Removed
 - **cf-core:** [MAJOR] Removed deprecated items:
@@ -45,6 +50,12 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   - `@cf-forms_input-icon-class`
   - `@input-icon__warning`
   - `@input-icon__success`
+- **cf-typography**: [MAJOR] Removed unused items:
+  - custom bullet mixin
+  - fancy slug because
+  - short-desc
+  - padded heading
+  - icon lists (for the time being to be addressed later when we can look at existing implementations).
 
 ### Fixed
 - **cf-typography:** [PATCH] Fixed old variables removed from cf-core

--- a/src/cf-typography/src/atoms/date.less
+++ b/src/cf-typography/src/atoms/date.less
@@ -1,0 +1,6 @@
+.a-date {
+    .heading-5();
+
+    color: @date;
+    white-space: nowrap;
+}

--- a/src/cf-typography/src/atoms/headings.less
+++ b/src/cf-typography/src/atoms/headings.less
@@ -1,0 +1,15 @@
+.a-heading__icon {
+    .heading-4();
+
+    color: @heading__icon;
+
+    a& {
+        .u-link__colors( @heading__icon, @heading__icon__hover );
+
+        border-width: 0;
+    }
+
+    .cf-icon {
+        margin-right: unit( 2px / @font-size, em );
+    }
+}

--- a/src/cf-typography/src/atoms/links.less
+++ b/src/cf-typography/src/atoms/links.less
@@ -1,0 +1,178 @@
+//
+// Links with icons
+// Required for jump link modifier
+//
+
+.a-link__icon,
+.a-link__jump {
+    border-bottom-width: 0;
+
+    .a-link_text {
+        border-bottom-width: 1px;
+        border-bottom-style: inherit;
+    }
+
+    &:before,
+    &:after {
+        .cf-icon();
+
+        margin-right: 1px;
+        margin-left: 1px;
+    }
+
+    &.a-link__download:after,
+    &.a-link__download&.a-link__before:before {
+        // Inserts the cf-icon-download glyph.
+        content: "\e406";
+    }
+
+    &.a-link__email:after,
+    &.a-link__email&.a-link__before:before {
+        // Inserts the cf-icon-email glyph.
+        content: "\e302";
+    }
+
+    &.a-link__external-link:after,
+    &.a-link__external-link&.a-link__before:before {
+        // Inserts the cf-icon-external-link glyph.
+        content: "\e610";
+    }
+
+    &.a-link__fax:after,
+    &.a-link__fax&.a-link__before:before {
+        // Inserts the cf-icon-fax glyph.
+        content: "\e310";
+    }
+
+    &.a-link__left:after,
+    &.a-link__left&.a-link__before:before {
+        // Inserts the cf-icon-left glyph.
+        content: "\e000";
+    }
+
+    &.a-link__mail:after,
+    &.a-link__mail&.a-link__before:before {
+        // Inserts the cf-icon-mail glyph.
+        content: "\e304";
+    }
+
+    &.a-link__pdf:after,
+    &.a-link__pdf&.a-link__before:before {
+        // Inserts the cf-icon-pdf glyph.
+        content: "\e402";
+    }
+
+    &.a-link__pdf:after,
+    &.a-link__pdf&.a-link__before:before {
+        // Inserts the cf-icon-pdf glyph.
+        content: "\e402";
+    }
+
+    &.a-link__phone:after,
+    &.a-link__phone&.a-link__before:before {
+        // Inserts the cf-icon-phone glyph.
+        content: "\e306";
+    }
+
+    &.a-link__right:after,
+    &.a-link__right&.a-link__before:before {
+        // Inserts the cf-icon-right glyph.
+        content: "\e002";
+    }
+
+    // New icon modifiers must be added ABOVE this line.
+
+    &.a-link__before {
+        &:after {
+            content: '';
+        }
+    }
+
+    &.a-link__no-wrap {
+        white-space: nowrap;
+    }
+}
+
+//
+// Jump link
+//
+
+.a-link__jump {
+    .webfont-medium();
+
+    &.a-link__large {
+        font-size: unit( @size-iv / @base-font-size-px, em );
+    }
+
+    .respond-to-max( @bp-xs-max, {
+        .a-link__block();
+
+        position: relative;
+
+        padding-right: 1.25em;
+
+        &:after,
+        &:before {
+            position: absolute;
+            margin-bottom: -0.6em;
+            bottom: 50%;
+        }
+
+        &:after {
+            right: 0;
+        }
+
+        &:before {
+            left: 0;
+        }
+
+        &.a-link__before {
+            padding-right: 0;
+            padding-left: 1.25em;
+        }
+
+        &.a-link__bg {
+            border: solid @jump-link_border;
+            border-width: 1px 0;
+            padding-left: 1em;
+            padding-right: 2.25em;
+
+            background: @jump-link_bg;
+
+            &:after {
+                right: 1em;
+            }
+
+            &:before {
+                left: 1em;
+            }
+
+            &.a-link__before {
+                padding-left: 2.25em;
+                padding-right: 1em;
+            }
+        }
+    } );
+}
+
+//
+// Block link
+//
+
+.a-link__block {
+    box-sizing: border-box;
+    display: block;
+
+    padding-top: unit( 10px / @base-font-size-px, em );
+    padding-bottom: unit( 10px / @base-font-size-px, em );
+    border-top-width: 1px;
+    border-bottom-width: 1px;
+    // 100% width is needed when block or jump link are applied to a <button>
+    width: 100%;
+
+    text-align: left;
+
+    .a-link_text {
+        border-bottom-width: 0;
+    }
+}

--- a/src/cf-typography/src/atoms/micro-copy.less
+++ b/src/cf-typography/src/atoms/micro-copy.less
@@ -1,0 +1,4 @@
+.a-micro-copy {
+    color: @micro-copy;
+    font-size: unit( @size-v / @base-font-size-px, em );
+}

--- a/src/cf-typography/src/cf-typography.less
+++ b/src/cf-typography/src/cf-typography.less
@@ -3,11 +3,6 @@
    Advanced Typography
    ========================================================================== */
 
-// Import external dependencies
-
-@import (less) '../../cf-core/src/cf-core.less';
-@import (less) '../../cf-icons/src/cf-icons.less';
-
 //
 // Theme variables
 //
@@ -16,599 +11,64 @@
 // $color- variables are from 18F's US Web Design Standards
 // https://github.com/18F/web-design-standards/blob/18f-pages-staging/src/stylesheets/core/_variables.scss
 
-// .pull-quote
-@pull-quote_body:               #494440; // $color-gray-warm-dark
-@pull-quote_citation:           #205493; // $color-cool-blue
+// Running text elements
 
-// .micro-copy
-@micro-copy-text:               #112e51; // $color-primary-darkest
+// .a-micro-copy
+@micro-copy:                #112e51; // $color-primary-darkest
 
-// .date
-@date-text:                     #112e51; // $color-primary-darkest
+// .a-date
+@date:                      #112e51; // $color-primary-darkest
 
-// .category-slug
-@category-slug-text:            #112e51; // $color-primary-darkest
-@category-slug-hover:           #205493; // $color-primary-darker
+// .m-pull-quote
+@pull-quote_body:           #494440; // $color-gray-warm-dark
+@pull-quote_citation:       #205493; // $color-cool-blue
 
-// .header-slug
-@header-slug-thin-border:       #323a45; // $color-gray-dark
-@header-slug-thick-border:      #02bfe7; // $color-primary-alt
+// Headings
 
-// .padded-header
-@padded-header-text:            #046b99; // $color-primary-alt-darkest
-@padded-header-bg:              #dce4ef; // color-gray-cool-light
-@padded-header-border:          #046b99; // $color-primary-alt-darkest
+// .a-heading__icon
+@heading__icon:             #112e51; // $color-primary-darkest
+@heading__icon__hover:      #205493; // $color-primary-darker
 
-// .fancy-slug
-@fancy-slug-text:               #046b99; // $color-primary-alt-darkest
-@fancy-slug-bg:                 #dce4ef; // color-gray-cool-light
-@fancy-slug-border:             #046b99; // $color-primary-alt-darkest
+// .a-heading__padded
+@heading__padded:           #046b99; // $color-primary-alt-darkest
+@heading__padded_bg:        #dce4ef; // color-gray-cool-light
+@heading__padded_border:    #046b99; // $color-primary-alt-darkest
 
-// .meta-header
-@meta-header-border:            #323a45; // $color-gray-dark
+// Headers
 
-// .jump-link
-@jump-link__bg:                 #f1f1f1; // $color-gray-lightest
-@jump-link__bg-border:          #323a45; // $color-gray-dark
+// .m-slug-header
+@slug-header_border__thin:  #323a45; // $color-gray-dark
+@slug-header_border__thick: #02bfe7; // $color-primary-alt
+
+// .m-meta-header
+@meta-header_border:        #323a45; // $color-gray-dark
+
+// Links
+
+// .a-link__jump
+@jump-link_bg:              #f1f1f1; // $color-gray-lightest
+@jump-link_border:          #323a45; // $color-gray-dark
 
 
-//
-// Pull quote
-//
+// Import external dependencies
 
-/* TODO: Re-organize orders to follow FEWD guidelines */
-/* TODO: Standardize line breaks and spacing throughout */
-
-.pull-quote {
-
-    &_body {
-        .heading-3();
-
-        color: @pull-quote_body;
-
-        .respond-to-max(@bp-xs-max, {
-            .heading-4();
-        });
-    }
-
-    &_citation {
-        .heading-5();
-
-        color: @pull-quote_citation;
-    }
-
-    &__large .pull-qote_body {
-        .heading-2();
-
-        .respond-to-max(@bp-xs-max, {
-            .heading-3();
-        });
-    }
-}
-//
-// Micro copy
-//
-
-.micro-copy {
-    @font-size: 14px;
-    color: @micro-copy-text;
-    font-size: unit(@font-size / @base-font-size-px, em);
-    .webfont-regular();
-
-    &__large {
-        @font-size: 16px;
-        font-size: unit(@font-size / @base-font-size-px, em);
-    }
-}
+@import (less) '../../cf-core/src/cf-core.less';
+@import (less) '../../cf-icons/src/cf-icons.less';
 
 //
-// Short description
+// Import atoms
 //
 
-.short-desc {
-    .webfont-regular();
-
-    &__large {
-        @font-size: 18px;
-        font-size: unit(@font-size / @base-font-size-px, em);
-    }
-}
+@import (less) 'atoms/date.less';
+@import (less) 'atoms/headings.less';
+@import (less) 'atoms/links.less';
+@import (less) 'atoms/micro-copy.less';
 
 //
-// Date
+// Import molecules
 //
 
-.date {
-    .heading-5();
-
-    color: @date-text;
-    white-space: nowrap;
-}
-
-//
-// Category slug
-//
-
-.category-slug {
-    .heading-4();
-
-    display: inline-block;
-
-    color: @category-slug-text;
-
-    a& {
-        .u-link__colors(@category-slug-text, @category-slug-hover);
-    }
-
-    &_icon {
-        margin-right: unit(2px / @font-size, em);
-    }
-}
-
-//
-// Header slug
-//
-
-.header-slug {
-    .heading-5();
-
-    margin-bottom: unit(17px / @font-size, em);
-    border-top: 1px solid @header-slug-thin-border;
-
-    &_inner {
-        display: inline-block;
-        padding-top: unit(4px / @font-size, em);
-        margin-top: -3px;
-        border-top: 5px solid @header-slug-thick-border;
-    }
-}
-
-//
-// Padded header
-//
-
-.padded-header {
-    .heading-5();
-    // 8px top padding to account for line-height.
-    padding: unit(8px / @font-size, em)
-             unit(10px / @font-size, em);
-    margin-bottom: 0;
-    border-bottom: 1px solid @padded-header-border;
-    background: @padded-header-bg;
-    color: @padded-header-text;
-}
-//
-// Fancy slug
-//
-
-.fancy-slug {
-    @v-padding: 8px;
-    @ribbon-width: 17px;
-    @ribbon-angle: 33deg;
-
-    .heading-5();
-    position: relative;
-    // Cut the height in half since we will be adding it back with margin.
-    height: unit(((@font-size / 2) + @v-padding + 1) / @font-size, em);
-    padding: 0 unit(@ribbon-width / @font-size, em);
-    // Add back half of the height to create a space for the text to pull
-    // itself up into.
-    margin-top: unit(((@font-size / 2) + @v-padding + 1) / @font-size, em);
-    // Bottom margin is eyeballed to 15px when considering baseline and line-height.
-    margin-bottom: unit(8px / @font-size, em);
-    border-top: 1px solid @fancy-slug-border;
-    line-height: 1;
-    text-align: center;
-
-    &_text {
-        display: inline-block;
-        position: relative;
-        // Pull the text up by half of its height so that it is vertically
-        // centered with .fancy-slugs top border. "Height" means half the
-        // font-size plus half the total padding and half the borders.
-        top: unit(((@font-size / 2) + @v-padding + 1) * -1 / @font-size, em);
-        padding: unit(@v-padding / @font-size, em) unit(20px / @font-size, em);
-        border: 1px solid @fancy-slug-border;
-        background: @fancy-slug-bg;
-    }
-
-    // Use :before as the top corner and :after as the bottom corner.
-    &_ribbon-left,
-    &_ribbon-right {
-        display: block;
-        position: absolute;
-        top: -1px;
-        width: unit(@ribbon-width / @font-size, em);
-        height: 100%;
-        border-top: 1px solid @fancy-slug-border;
-        border-bottom: 1px solid @fancy-slug-border;
-
-        .lt-ie9 & {
-            display: none;
-        }
-
-        &:before,
-        &:after {
-            display: block;
-            content: "";
-            position: absolute;
-            z-index: 3;
-            width: unit(@ribbon-width / @font-size, em);
-            height: 50%;
-            background: @fancy-slug-bg;
-            border: 0 solid @fancy-slug-border;
-        }
-    }
-
-    &_ribbon-left {
-        left: unit(-@ribbon-width / @font-size, em);
-        &:before {
-            top: 0;
-            border-left-width: 1px;
-            transform-origin: 0 0;
-            transform: skewX(@ribbon-angle);
-        }
-        &:after {
-            bottom: 0;
-            border-left-width: 1px;
-            transform-origin: 0 100%;
-            transform: skewX(-@ribbon-angle);
-        }
-    }
-
-    &_ribbon-right {
-        right: unit(-@ribbon-width / @font-size, em);
-        &:before {
-            top: 0;
-            right: 0;
-            border-right-width: 1px;
-            transform-origin: 100% 0;
-            transform:  skewX(-@ribbon-angle);
-        }
-        &:after {
-            right: 0;
-            bottom: 0;
-            border-right-width: 1px;
-            transform-origin: 100% 100%;
-            transform:  skewX(@ribbon-angle);
-        }
-    }
-}
-//
-// Meta header
-//
-
-.meta-header {
-    padding-bottom: unit(8px / @base-font-size-px, em);
-    margin-bottom: unit(10px / @base-font-size-px, em);
-    border-bottom: 1px solid @meta-header-border;
-}
-
-.meta-header_left {
-    margin-bottom: 0;
-}
-
-.meta-header_right {
-    display: block;
-    margin-bottom: 0;
-    .respond-to-min(600px, {
-        .u-right();
-        display: inline-block;
-    });
-}
-
-//
-// Links with icons
-//
-
-.icon-link {
-    border-bottom-width: 0;
-    position: relative;
-
-    &_text {
-        border-bottom-width: 1px;
-        border-bottom-style: inherit;
-    }
-
-    &:before,
-    &:after {
-        .cf-icon();
-        margin-right: 1px;
-        margin-left: 1px;
-    }
-
-    &__download:after,
-    &__download&__before:before {
-        // Inserts the cf-icon-download glyph.
-        content: "\e406";
-    }
-
-    &__email:after,
-    &__email&__before:before {
-        // Inserts the cf-icon-email glyph.
-        content: "\e302";
-    }
-
-    &__external-link:after,
-    &__external-link&__before:before {
-        // Inserts the cf-icon-external-link glyph.
-        content: "\e610";
-    }
-
-    &__fax:after,
-    &__fax&__before:before {
-        // Inserts the cf-icon-fax glyph.
-        content: "\e310";
-    }
-
-    &__left:after,
-    &__left&__before:before {
-          // Inserts the cf-icon-left glyph.
-          content: "\e000";
-      }
-
-    &__mail:after,
-    &__mail&__before:before {
-        // Inserts the cf-icon-mail glyph.
-        content: "\e304";
-    }
-
-    &__pdf:after,
-    &__pdf&__before:before {
-        // Inserts the cf-icon-pdf glyph.
-        content: "\e402";
-    }
-
-    &__pdf:after,
-    &__pdf&__before:before {
-        // Inserts the cf-icon-pdf glyph.
-        content: "\e402";
-    }
-
-    &__phone:after,
-    &__phone&__before:before {
-        // Inserts the cf-icon-phone glyph.
-        content: "\e306";
-    }
-
-    &__right:after,
-    &__right&__before:before {
-        // Inserts the cf-icon-right glyph.
-        content: "\e002";
-    }
-
-    // New icon modifiers must be added ABOVE this line.
-
-    &__before {
-        &:after {
-            content: '';
-        }
-    }
-
-    &__no-wrap {
-        white-space: nowrap;
-    }
-}
-//
-// Styled link
-//
-
-.styled-link {
-    /* TODO: Why set this? It's the base size */
-    @font-size: 16px;
-
-    border-bottom-width: 1px;
-    .webfont-medium();
-    font-size: unit(@font-size / @base-font-size-px, em);
-}
-
-//
-// Jump link
-//
-
-.jump-link {
-    .webfont-medium();
-    /* TODO: Why set this one it's the default size */
-    @font-size: 16px;
-
-    font-size: unit(@font-size / @base-font-size-px, em);
-
-    .icon-link();
-
-    &__large {
-        @font-size: 18px;
-
-        font-size: unit(@font-size / @base-font-size-px, em);
-    }
-
-    .respond-to-max( @bp-xs-max, {
-        .block-link();
-
-        &:after {
-            position: absolute;
-            margin-bottom: -0.625em;
-            right: 0;
-            bottom: 50%;
-            text-align: right;
-        }
-
-        &__before {
-            padding-left: 1.25em;
-
-            &:before {
-                position: absolute;
-                margin-bottom: -0.625em;
-                bottom: 50%;
-                left: 0;
-            }
-        }
-
-        &_text {
-            border-bottom-width: 0;
-        }
-
-        &__bg {
-            background: @jump-link__bg;
-            border: solid @jump-link__bg-border;
-            border-width: 1px 0;
-            padding: unit(10px / @base-font-size-px, em) 1.25em unit(10px / @base-font-size-px, em) 1em;
-            &:after {
-                right: 1em;
-            }
-            &:before {
-                left: unit(10px / @base-font-size-px, em);
-            }
-        }
-    });
-}
-
-//
-// Block link
-//
-
-.block-link {
-    box-sizing: border-box;
-    display: block;
-    padding: unit(10px / @base-font-size-px, em) 1.25em unit(10px / @base-font-size-px, em) 0;
-    border: dotted @link-text;
-    border-width: 1px 0;
-    margin-right: 0;
-    // 100% width is needed when .jump-link is applied to a <button>.
-    width: 100%;
-    text-align: left;
-}
-
-//
-// Unstyled list modifier
-//
-
-.list__unstyled {
-    padding-left: 0;
-    list-style-type: none;
-
-    // This is needed for dd elements.
-    .list_item {
-        margin-left: 0;
-    }
-}
-
-//
-// Spaced list modifier
-//
-
-.list__spaced {
-    .list_item + .list_item {
-        margin-top: unit(24px / @base-font-size-px, em);
-    }
-}
-
-//
-// Spaced list item modifier
-//
-
-.list_item__spaced {
-    margin-top: unit(24px / @base-font-size-px, em);
-}
-
-//
-// Horizontal list modifier
-//
-
-.list__horizontal {
-    padding-left: 0;
-
-    .list_item {
-        .u-inline-block();
-    }
-
-    .list_item {
-        // Assuming a natural space of 4px between inline block items
-        // then the space between would be 8px (4px natural + 4px added).
-        margin-right: unit(4px / @base-font-size-px, em);
-        margin-left: 0;
-    }
-}
-
-//
-// Icon list modifier
-//
-
-.list__icons {
-    .list__unstyled();
-
-    .list_icon {
-        width: 1.5em;
-        text-align: center;
-    }
-}
-
-//
-// Link list modifier
-//
-
-.list__links {
-    .list__unstyled();
-
-    .list_item {
-        margin-bottom: unit(10px / @base-font-size-px, em);
-
-        .respond-to-max(599px, {
-            margin-bottom: -1px;
-        });
-    }
-
-    &.list__spaced .list_item + .list_item {
-        margin-top: 0;
-    }
-
-    .list_link {
-        .respond-to-max(599px, {
-            .block-link();
-
-            &.icon-link:after {
-                position: absolute;
-                margin-bottom: -0.625em;
-                right: 0;
-                bottom: 50%;
-                text-align: right;
-            }
-
-            .icon-link_text {
-                border-bottom-width: 0;
-            }
-        });
-    }
-
-    &.list__icons {
-        .list_link {
-            position: relative;
-            // Adjust for optical alignment of icons.
-            left: -0.125em;
-        }
-
-        .icon-link:before,
-        .icon-link:after {
-            width: 1.125em;
-            text-align: center;
-        }
-    }
-}
-
-//
-// Custom bullet mixin
-//
-
-.custom-bullet(@text, @color, @offset, @size, @font:inherit) {
-    list-style-type: none;
-    position: relative;
-
-  &:before {
-    content: @text;
-    font-family: @font;
-    font-size: @size;
-    color: @color;
-    line-height: 1;
-    position: absolute;
-    left: -@offset;
-  }
-}
+@import (less) 'molecules/list.less';
+@import (less) 'molecules/meta-header.less';
+@import (less) 'molecules/pull-quote.less';
+@import (less) 'molecules/slug-header.less';

--- a/src/cf-typography/src/molecules/list.less
+++ b/src/cf-typography/src/molecules/list.less
@@ -1,0 +1,64 @@
+//
+// Unstyled list modifier
+// Required for horizontal, icon, and link list modifiers
+//
+
+.m-list__unstyled,
+.m-list__horizontal,
+.m-list__links {
+    padding-left: 0;
+
+    list-style-type: none;
+
+    // This is needed for dd elements.
+    .m-list_item {
+        margin-left: 0;
+    }
+}
+
+//
+// Spaced list modifier
+//
+
+.m-list__spaced {
+    .m-list__spaced,
+    .m-list_item + .m-list_item {
+        margin-top: unit( 24px / @base-font-size-px, em );
+    }
+}
+
+//
+// Horizontal list modifier
+//
+
+.m-list__horizontal {
+    .m-list_item {
+        display: inline-block;
+
+        // Assuming a natural space of 4px between inline block items
+        // then the space between would be 8px (4px natural + 4px added).
+        margin-right: unit( 4px / @base-font-size-px, em );
+    }
+}
+
+//
+// Link list modifier
+//
+
+.m-list__links {
+    .m-list_item {
+        .respond-to-max( @bp-xs-max, {
+            margin-bottom: 0;
+
+            &:nth-child(n+2) .m-list_link {
+                border-top-width: 0;
+            }
+        } );
+    }
+
+    .m-list_link {
+        .respond-to-max( @bp-xs-max, {
+            .a-link__block();
+        } );
+    }
+}

--- a/src/cf-typography/src/molecules/meta-header.less
+++ b/src/cf-typography/src/molecules/meta-header.less
@@ -1,0 +1,22 @@
+.m-meta-header {
+    padding-bottom: unit( 8px / @base-font-size-px, em );
+    border-bottom: 1px solid @meta-header_border;
+    // TODO: Move margin to o-post-preview and other parent containers
+    margin-bottom: unit( 10px / @base-font-size-px, em );
+
+    .respond-to-min( @bp-sm-min, {
+        .u-clearfix();
+
+        &_left {
+            float: left;
+        }
+
+        &_right {
+            float: right;
+        }
+    } );
+
+    .a-heading {
+        margin-bottom: 0;
+    }
+}

--- a/src/cf-typography/src/molecules/pull-quote.less
+++ b/src/cf-typography/src/molecules/pull-quote.less
@@ -1,0 +1,26 @@
+.m-pull-quote {
+
+    &_body {
+        .heading-3();
+
+        color: @pull-quote_body;
+
+        .respond-to-max( @bp-xs-max, {
+            .heading-4();
+        } );
+    }
+
+    &_citation {
+        .heading-5();
+
+        color: @pull-quote_citation;
+    }
+
+    &__large .m-pull-quote_body {
+        .heading-2();
+
+        .respond-to-max( @bp-xs-max, {
+            .heading-3();
+        } );
+    }
+}

--- a/src/cf-typography/src/molecules/slug-header.less
+++ b/src/cf-typography/src/molecules/slug-header.less
@@ -1,0 +1,14 @@
+.m-slug-header {
+    margin-bottom: unit( 17px / @base-font-size-px, em );
+    border-top: 1px solid @slug-header_border__thin;
+
+    .a-heading {
+        .heading-5();
+
+        display: inline-block;
+
+        padding-top: unit( 4px / @font-size, em) ;
+        border-top: 5px solid @slug-header_border__thick;
+        margin-top: -3px;
+    }
+}

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -49,62 +49,91 @@ Default color variables are from 18F's
 [U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages-staging/src/stylesheets/core/_variables.scss).
 
 ```
-// .pull-quote
-@pull-quote_body:               #494440; // $color-gray-warm-dark
-@pull-quote_citation:           #205493; // $color-cool-blue
+// Running text elements
 
-// .micro-copy
-@micro-copy-text:               #112e51; // $color-primary-darkest
+// .a-micro-copy
+@micro-copy:                #112e51; // $color-primary-darkest
 
-// .date
-@date-text:                     #112e51; // $color-primary-darkest
+// .a-date
+@date:                      #112e51; // $color-primary-darkest
 
-// .category-slug
-@category-slug-text:            #112e51; // $color-primary-darkest
-@category-slug-hover:           #205493; // $color-primary-darker
+// .m-pull-quote
+@pull-quote_body:           #494440; // $color-gray-warm-dark
+@pull-quote_citation:       #205493; // $color-cool-blue
 
-// .header-slug
-@header-slug-thin-border:       #323a45; // $color-gray-dark
-@header-slug-thick-border:      #02bfe7; // $color-primary-alt
+// Headings
 
-// .padded-header
-@padded-header-text:            #046b99; // $color-primary-alt-darkest
-@padded-header-bg:              #dce4ef; // color-gray-cool-light
-@padded-header-border:          #046b99; // $color-primary-alt-darkest
+// .a-heading__icon
+@heading__icon:             #112e51; // $color-primary-darkest
+@heading__icon__hover:      #205493; // $color-primary-darker
 
-// .fancy-slug
-@fancy-slug-text:               #046b99; // $color-primary-alt-darkest
-@fancy-slug-bg:                 #dce4ef; // color-gray-cool-light
-@fancy-slug-border:             #046b99; // $color-primary-alt-darkest
+// .a-heading__padded
+@heading__padded:           #046b99; // $color-primary-alt-darkest
+@heading__padded_bg:        #dce4ef; // color-gray-cool-light
+@heading__padded_border:    #046b99; // $color-primary-alt-darkest
 
-// .meta-header
-@meta-header-border:            #323a45; // $color-gray-dark
+// Headers
 
-// .jump-link
-@jump-link__bg:                 #f1f1f1; // $color-gray-lightest
-@jump-link__bg-border:          #323a45; // $color-gray-dark
+// .m-slug-header
+@slug-header_border__thin:  #323a45; // $color-gray-dark
+@slug-header_border__thick: #02bfe7; // $color-primary-alt
 
-// .list__branded
-@list__branded-bullet:          #02bfe7; // $color-primary-alt
+// .m-meta-header
+@meta-header_border:        #323a45; // $color-gray-dark
+
+// Links
+
+// .a-link__jump
+@jump-link_bg:              #f1f1f1; // $color-gray-lightest
+@jump-link_border:          #323a45; // $color-gray-dark
 ```
 
-## Pull quote
+## Running Text
+
+### Micro copy
+
+The `.a-micro-copy` class is good for highlighting small pieces of text, typically
+legal copy.
+
+<p class="a-micro-copy">
+    Lorem ipsum dolor sit amet
+</p>
+
+```
+<p class="a-micro-copy">
+    Lorem ipsum dolor sit amet
+</p>
+```
+
+### Date
+
+<span class="a-date">
+    Nov 4, 2013
+</span>
+
+```
+<span class="a-date">
+    Nov 4, 2013
+</span>
+```
+
+### Pull quote
 
 Use a pull quote to highlight excerpts from the current work.
 This is not to be confused with `blockquote` which quotes from an external work.
 Since a pull quote is an excerpt and repeats content from the article
 you should use the `aside` element.
 
-### Default pull quote
+#### Default pull quote
 
-<aside class="pull-quote">
-    <div class="pull-quote_body">
+<aside class="m-pull-quote">
+    <p class="m-pull-quote_body">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.
         Cum corrupti tempora nam nihil qui mollitia consectetur
         corporis nemo culpa dolorum!
-    </div>
+    </p>
     <footer>
-        <cite class="pull-quote_citation">
+        <cite class="m-pull-quote_citation">
             - Author Name
         </cite>
     </footer>
@@ -112,271 +141,123 @@ you should use the `aside` element.
 
 
 ```
-<aside class="pull-quote">
-    <div class="pull-quote_body">
+<aside class="m-pull-quote">
+    <p class="m-pull-quote_body">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.
         Cum corrupti tempora nam nihil qui mollitia consectetur
         corporis nemo culpa dolorum!
-    </div>
+    </p>
     <footer>
-        <cite class="pull-quote_citation">
+        <cite class="m-pull-quote_citation">
             - Author Name
         </cite>
     </footer>
 </aside>
 ```
 
-### Large pull quote
+#### Large pull quote
 
-<aside class="pull-quote pull-quote__large">
-    <div class="pull-quote_body">
+<aside class="m-pull-quote m-pull-quote__large">
+    <div class="m-pull-quote_body">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.
         Cum corrupti tempora nam nihil qui mollitia consectetur
         corporis nemo culpa dolorum!
     </div>
     <footer>
-        <cite class="pull-quote_citation">
+        <cite class="m-pull-quote_citation">
             - Author Name
         </cite>
     </footer>
 </aside>
 
 ```
-<aside class="pull-quote pull-quote__large">
-    <div class="pull-quote_body">
+<aside class="m-pull-quote m-pull-quote__large">
+    <div class="m-pull-quote_body">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit.
         Cum corrupti tempora nam nihil qui mollitia consectetur
         corporis nemo culpa dolorum!
     </div>
     <footer>
-        <cite class="pull-quote_citation">
+        <cite class="m-pull-quote_citation">
             - Author Name
         </cite>
     </footer>
 </aside>
 ```
 
+## Headings
 
-## Micro copy
+### Padded heading
 
-The `.micro-copy` class is good for highlighting small pieces of text.
+<h2 class="a-heading a-heading__padded">
+    Heading
+</h2>
 
-### Standard micro copy
 
-<p class="micro-copy">
-    Lorem ipsum dolor sit amet
-</p>
+### Heading with icon
 
-```
-<p class="micro-copy">
-    Lorem ipsum dolor sit amet
-</p>
-```
+The heading with icon is typically used for listing categories in a meta header.
+Since categories can be repetitive, we suggest placing a label with `.u-visually-hidden`
+prior to the headings to add more context for screen readers (see Meta Header below).
 
-### Large micro copy
-
-<p class="micro-copy__large">
-    Lorem ipsum dolor sit amet
-</p>
+<a href="#" class="a-heading a-heading__icon">
+    <span class="cf-icon cf-icon-dialogue"></span>
+    Consumer finance
+</a>
 
 ```
-<p class="micro-copy__large">
-    Lorem ipsum dolor sit amet
-</p>
+<a href="#" class="a-heading a-heading__icon">
+    <span class="cf-icon cf-icon-dialogue"></span>
+    Consumer finance
+</a>
 ```
-
-## Short description
-
-The `.short-desc` class is about a line or two of text underneath a headline.
-
-### Short description
-
-<p class="short-desc">I am short description.</p>
-
-```
-<p class="short-desc">
-    I am short description.
-</p>
-```
-
-### Large short description
-
-<p class="short-desc short-desc__large">I am large short description.</p>
-
-```
-<p class="short-desc short-desc__large">
-    I am large short description.
-</p>
-```
-
-
-## Date
-
-### Default date
-
-<span class="date">
-    Nov 4, 2013
-</span>
-
-```
-<span class="date">
-    Nov 4, 2013
-</span>
-```
-
 
 ## Headers
 
-### Category slug
+### Slug header
 
-The category slug is used on top of a section.
-Since categories can be repetitive,
-we suggest using a `.u-visually-hidden` element to add more context for screen readers.
-
-#### Default category slug
-
-<a href="#" class="category-slug">
-    <span class="category-slug_icon cf-icon cf-icon-dialogue"></span>
-    <span class="u-visually-hidden">Category:</span>
-    Consumer finance
-</a>
-
-```
-<a href="#" class="category-slug">
-    <span class="category-slug_icon cf-icon cf-icon-dialogue"></span>
-    <span class="u-visually-hidden">Category:</span>
-    Consumer finance
-</a>
-```
-
-### Header slug
-
-#### Default header slug
-
-<h2 class="header-slug">
-    <span class="header-slug_inner">
+<header class="m-slug-header">
+    <h2 class="a-heading">
         Blog summary
-    </span>
-</h2>
+    </h2>
+</header>
 
 ```
-<h2 class="header-slug">
-    <span class="header-slug_inner">
+<header class="m-slug-header">
+    <h2 class="a-heading">
         Blog summary
-    </span>
-</h2>
-```
-
-### Padded header
-
-#### Default padded header
-
-<h2 class="padded-header">
-    Header
-</h2>
-
-```
-<h2 class="padded-header">
-    Header
-</h2>
-```
-
-
-### Fancy slug
-
-#### Default fancy slug
-
-<h2 class="fancy-slug">
-    <span class="fancy-slug_text">
-        <span class="fancy-slug_ribbon-left"></span>
-        Watchroom
-        <span class="fancy-slug_ribbon-right"></span>
-    </span>
-</h2>
-
-```
-<h2 class="fancy-slug">
-    <span class="fancy-slug_text">
-        <span class="fancy-slug_ribbon-left"></span>
-        Watchroom
-        <span class="fancy-slug_ribbon-right"></span>
-    </span>
-</h2>
+    </h2>
+</header>
 ```
 
 ### Meta header
 
-`.meta-header_right` should come first in the markup so that
-when it floats to the right it will appear on the same line as `.meta-header_left`.
-
-Note that the example shows `.meta-header_left` using the `.category-slug` pattern
-and `.meta-header_right` using the `.date` pattern but you could use other patterns in place of them.
+Note that the example shows `.m-meta-header_left` using the `.a-heading__icon` pattern
+and `.meta-header_right` using the `.a-date` pattern but you could use other patterns in place of them.
 Or you can even swap them so that date is
 attached to `.meta-header_left` and `.category-slug` is attached to `.meta-header_right`.
 
 #### Default meta header
 
-<div class="meta-header">
-    <span class="meta-header_right date">
-        Nov 4, 2013
-    </span>
-    <a href="#" class="meta-header_left category-slug">
-        <span class="cf-icon cf-icon-credit-card"></span>
-        Consumer finance
-    </a>
-</div>
-
-```
-<div class="meta-header">
-    <span class="meta-header_right date">
-        Nov 4, 2013
-    </span>
-    <a href="#" class="meta-header_left category-slug">
-        <span class="cf-icon cf-icon-credit-card"></span>
-        Consumer finance
-    </a>
-</div>
-```
-
-#### Alternate meta header arrangements
-
-This is just another set of variations to show off what you could do.
-
-<div class="meta-header">
-    <a href="#" class="meta-header_right category-slug">
-        <span class="cf-icon cf-icon-credit-card"></span>
-    </a>
-    <span class="meta-header_left date">
-        Nov 4, 2013
-    </span>
-</div>
-<br>
-<div class="meta-header">
-    <a href="#" class="meta-header_left category-slug">
-        <span class="cf-icon cf-icon-credit-card"></span>
-        Consumer finance
-    </a>
-</div>
-
-
-```
-<div class="meta-header">
-    <a href="#" class="meta-header_right category-slug">
-        <span class="cf-icon cf-icon-credit-card"></span>
-    </a>
-    <span class="meta-header_left date">
-        Nov 4, 2013
-    </span>
-</div>
-<br>
-<div class="meta-header">
-    <a href="#" class="meta-header_left category-slug">
-        <span class="cf-icon cf-icon-credit-card"></span>
-        Consumer finance
-    </a>
-</div>
-```
-
+<header class="m-meta-header">
+    <div class="m-meta-header_right">
+        <span class="a-date">
+            Nov 4, 2013
+        </span>
+    </div>
+    <div class="m-meta-header_left">
+        <span class="u-visually-hidden">Categories: </span>
+        <a href="#" class="a-heading a-heading__icon">
+            <span class="cf-icon cf-icon-credit-card"></span>
+            Consumer finance
+        </a>
+        |
+        <a href="#" class="a-heading a-heading__icon">
+            <span class="cf-icon cf-icon-credit-card"></span>
+            Consumer finance
+        </a>
+    </div>
+</header>
 
 ## Link patterns
 
@@ -392,41 +273,35 @@ This is just another set of variations to show off what you could do.
 
 <p>
     For more information, email
-    <a class="icon-link icon-link__mail" href="#">
-        <span class="icon-link_text">john.smith@cfpb.gov</span>
+    <a class="a-link a-link__icon a-link__mail" href="#">
+        <span class="a-link_text">john.smith@cfpb.gov</span>
     </a>.
     Alternatively, you can
-    <a class="icon-link icon-link__download" href="#">
-        <span class="icon-link_text">download the info sheet</span>
+    <a class="a-link a-link__icon a-link__download" href="#">
+        <span class="a-link_text">download the info sheet</span>
     </a>.
     Oh, you might also want to visit this
-    <a class="icon-link icon-link__external-link" href="#">
-        <span class="icon-link_text">other organization's website</span>
+    <a class="a-link a-link__icon a-link__external-link" href="#">
+        <span class="a-link_text">other organization's website</span>
     </a> for further details.
 </p>
-<a class="icon-link icon-link__right" href="#">
-    Visit another section of our site
-</a>
 
 
 ```
 <p>
     For more information, email
-    <a class="icon-link icon-link__mail" href="#">
-        <span class="icon-link_text">john.smith@cfpb.gov</span>
+    <a class="a-link a-link__icon a-link__mail" href="#">
+        <span class="a-link_text">john.smith@cfpb.gov</span>
     </a>.
     Alternatively, you can
-    <a class="icon-link icon-link__download" href="#">
-        <span class="icon-link_text">download the info sheet</span>
+    <a class="a-link a-link__icon a-link__download" href="#">
+        <span class="a-link_text">download the info sheet</span>
     </a>.
     Oh, you might also want to visit this
-    <a class="icon-link icon-link__external-link" href="#">
-        <span class="icon-link_text">other organization's website</span>
+    <a class="a-link a-link__icon a-link__external-link" href="#">
+        <span class="a-link_text">other organization's website</span>
     </a> for further details.
 </p>
-<a class="icon-link icon-link__right" href="#">
-    Visit another section of our site
-</a>
 ```
 
 #### Links with icons on the left
@@ -434,19 +309,19 @@ This is just another set of variations to show off what you could do.
 - Simply add the `.icon-link__before` modifier to place the icon before the link text.
 - You can omit the `span.icon-link_text` wrapper if you do not need an underline on a particular link.
 
-<a class="icon-link icon-link__mail icon-link__before" href="#">
-    <span class="icon-link_text">john.smith@cfpb.gov</span>
+<a class="a-link a-link__icon a-link__mail a-link__before" href="#">
+    <span class="a-link_text">john.smith@cfpb.gov</span>
 </a><br>
-<a class="icon-link icon-link__phone icon-link__before" href="#">
-    (123) 456-7890
+<a class="a-link a-link__icon a-link__phone a-link__before" href="#">
+    <span class="a-link_text">(123) 456-7890</span>
 </a>
 
 ```
-<a class="icon-link icon-link__mail icon-link__before" href="#">
-    <span class="icon-link_text">john.smith@cfpb.gov</span>
+<a class="a-link a-link__icon a-link__mail a-link__before" href="#">
+    <span class="a-link_text">john.smith@cfpb.gov</span>
 </a><br>
-<a class="icon-link icon-link__phone icon-link__before" href="#">
-    (123) 456-7890
+<a class="a-link a-link__icon a-link__phone a-link__before" href="#">
+    <span class="a-link_text">(123) 456-7890</span>
 </a>
 ```
 
@@ -456,103 +331,92 @@ This is just another set of variations to show off what you could do.
 
 <p>
     For more information, email
-    <a class="icon-link icon-link__mail icon-link__no-wrap" href="#">
-        <span class="icon-link_text">john.smith@cfpb.gov</span>
+    <a class="a-link a-link__icon a-link__mail a-link__no-wrap" href="#">
+        <span class="a-link_text">john.smith@cfpb.gov</span>
     </a>.
 </p>
 
 ```
 <p>
     For more information, email
-    <a class="icon-link icon-link__mail icon-link__no-wrap" href="#">
-        <span class="icon-link_text">john.smith@cfpb.gov</span>
+    <a class="a-link a-link__icon a-link__mail a-link__no-wrap" href="#">
+        <span class="a-link_text">john.smith@cfpb.gov</span>
     </a>.
 </p>
 ```
 
-
-### Styled link
-
-#### Default pattern
-
-<a class="styled-link" href="#">
-    Default styled link
-</a>
-
-```
-<a class="styled-link" href="#">
-    Default styled link
-</a>
-```
-
 ### Jump link
 
-#### Default pattern
-
-<a class="jump-link" href="#">
-    <span class="jump-link_text">Default jump link</span>
+<a class="a-link
+          a-link__jump
+          a-link__right" href="#">
+    <span class="a-link_text">Default jump link</span>
 </a>
 
 ```
-<a class="jump-link" href="#">
-    <span class="jump-link_text">Default jump link</span>
+<a class="a-link
+          a-link__jump
+          a-link__right" href="#">
+    <span class="a-link_text">Default jump link</span>
 </a>
 ```
 
-#### Large jump link
+#### Jump link with large link modifier
 
 The large jump link has an 18px font-size, compared to the default of 16px.
 
-<a class="jump-link jump-link__large" href="#">
-    <span class="jump-link_text">Large jump link</span>
+<a class="a-link
+          a-link__jump
+          a-link__large
+          a-link__right" href="#">
+    <span class="a-link_text">Large jump link</span>
 </a>
 
 ```
-<a class="jump-link jump-link__large" href="#">
-    <span class="jump-link_text">Large jump link</span>
+<a class="a-link
+          a-link__jump
+          a-link__large
+          a-link__right" href="#">
+    <span class="a-link_text">Large jump link</span>
 </a>
 ```
 
-#### Jump link with icon
-
-- `.jump-link` extends `.icon-link`, so all that is needed to add an icon to a jump link is to add a modifier with the icon's name.
-- In this example, `.jump-link__right` is a taken from the `cf-icon__right` icon in [cf-icons](../cf-icons).
-
-<a class="jump-link jump-link__right" href="#">
-    <span class="jump-link_text">Jump link using the right icon from cf-icons</span>
-</a>
-
-```
-<a class="jump-link jump-link__right" href="#">
-    <span class="jump-link_text">Jump link using the right icon from cf-icons</span>
-</a>
-```
-
-
-#### Jump link with icon on left
+#### Jump link with before link modifier
 
 Jump links can also have icons before the text, like icon links.
 
-<a class="jump-link jump-link__left jump-link__before" href="#">
-    <span class="jump-link_text">Jump link with icon on left</span>
+<a class="a-link
+          a-link__jump
+          a-link__before
+          a-link__left" href="#">
+    <span class="a-link_text">Jump link with icon on left</span>
 </a>
 
 ```
-<a class="jump-link jump-link__left jump-link__before" href="#">
-    <span class="jump-link_text">Jump link with icon on left</span>
+<a class="a-link
+          a-link__jump
+          a-link__before
+          a-link__left" href="#">
+    <span class="a-link_text">Jump link with icon on left</span>
 </a>
 ```
 
-#### Jump link with background
+#### Jump link with bg link modifier (only visible on small screens)
 
-<a class="jump-link jump-link__bg" href="#">
-    <span class="jump-link_text">Jump link with grey background and
+<a class="a-link
+          a-link__jump
+          a-link__bg
+          a-link__right" href="#">
+    <span class="a-link_text">Jump link with grey background and
         solid borders on small screens</span>
 </a>
 
 ```
-<a class="jump-link jump-link__bg" href="#">
-    <span class="jump-link_text">Jump link with grey background and
+<a class="a-link
+          a-link__jump
+          a-link__bg
+          a-link__right" href="#">
+    <span class="a-link_text">Jump link with grey background and
         solid borders on small screens</span>
 </a>
 ```
@@ -562,16 +426,15 @@ Jump links can also have icons before the text, like icon links.
 The block link class converts a standard inline link
 to a block-level element with padding, background, and borders.
 
-It is primarily used within a max-width 599px media query (see `.jump-link` and `.list__links`).
+It is primarily used within a max-width `@bp-xs-max` media query
+(see `.link__jump` and `.list__links`).
 
-#### Default example
-
-<a class="block-link" href="#">
+<a class="a-link__block" href="#">
     Default block link
 </a>
 
 ```
-<a class="block-link" href="#">
+<a class="a-link__block" href="#">
     Default block link
 </a>
 ```
@@ -579,266 +442,119 @@ It is primarily used within a max-width 599px media query (see `.jump-link` and 
 
 ## Lists
 
-### Unstyled list
+### Unstyled list modifier
 
 Unstyled list removes bullets and other styling from a list.
 
-<ul class="list list__unstyled">
-    <li class="list_item">
-        <a class="list_link">List item 1</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 2</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 3</a>
-    </li>
+<ul class="m-list m-list__unstyled">
+    <li class="m-list_item">List item 1</li>
+    <li class="m-list_item">List item 2</li>
+    <li class="m-list_item">List item 3</li>
 </ul>
 
 ```
-<ul class="list list__unstyled">
-    <li class="list_item">
-        <a class="list_link">List item 1</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 2</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 3</a>
-    </li>
+<ul class="m-list m-list__unstyled">
+    <li class="m-list_item">List item 1</li>
+    <li class="m-list_item">List item 2</li>
+    <li class="m-list_item">List item 3</li>
 </ul>
 ```
 
-### Spaced list
+### Spaced list modifier
 
 Spaced list adds extra padding to every element in a list.
 
-<ul class="list list__spaced">
-    <li class="list_item">
-        <a class="list_link">List item 1</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 2</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 3</a>
-    </li>
+#### Default spaced list
+
+<ul class="m-list m-list__spaced">
+    <li class="m-list_item">List item 1</li>
+    <li class="m-list_item">List item 2</li>
+    <li class="m-list_item">List item 3</li>
 </ul>
 
 ```
-<ul class="list list__spaced">
-    <li class="list_item">
-        <a class="list_link">List item 1</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 2</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 3</a>
-    </li>
+<ul class="m-list m-list__spaced">
+    <li class="m-list_item">List item 1</li>
+    <li class="m-list_item">List item 2</li>
+    <li class="m-list_item">List item 3</li>
 </ul>
 ```
 
-### Spaced list item
+#### Nested list example
 
-The spaced list item class will space one item in an otherwise standard list.
-
-<ul class="list">
-    <li class="list_item">
-        <a class="list_link">List item 1</a>
+<ul class="m-list m-list__spaced">
+    <li class="m-list_item">List item 1</li>
+    <li class="m-list_item">
+        List item 2
+        <ul class="m-list m-list__spaced">
+            <li class="m-list_item">List item 2a</li>
+            <li class="m-list_item">List item 2b</li>
+            <li class="m-list_item">List item 2c</li>
+        </ul>
     </li>
-    <li class="list_item">
-        <a class="list_link">List item 2</a>
-    </li>
-    <li class="list_item list_item__spaced">
-        <a class="list_link">List item 3 (Spaced)</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 4</a>
-    </li>
+    <li class="m-list_item">List item 3</li>
 </ul>
 
 ```
-<ul class="list">
-    <li class="list_item">
-        <a class="list_link">List item 1</a>
+<ul class="m-list m-list__spaced">
+    <li class="m-list_item">List item 1</li>
+    <li class="m-list_item">
+        List item 2
+        <ul class="m-list m-list__spaced">
+            <li class="m-list_item">List item 2a</li>
+            <li class="m-list_item">List item 2b</li>
+            <li class="m-list_item">List item 2c</li>
+        </ul>
     </li>
-    <li class="list_item">
-        <a class="list_link">List item 2</a>
-    </li>
-    <li class="list_item list_item__spaced">
-        <a class="list_link">List item 3 (Spaced)</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 4</a>
-    </li>
+    <li class="m-list_item">List item 3</li>
 </ul>
 ```
 
-### Horizontal list
+### Horizontal list modifier
 
 A modifier for the list to make it show items horizontally.
 
-<ul class="list list__horizontal">
-    <li class="list_item">
-        <a class="list_link">List item 1</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 2</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 3</a>
-    </li>
+<ul class="m-list m-list__horizontal">
+    <li class="m-list_item">List item 1</li>
+    <li class="m-list_item">List item 2</li>
+    <li class="m-list_item">List item 3</li>
 </ul>
 
 ```
-<ul class="list list__horizontal">
-    <li class="list_item">
-        <a class="list_link">List item 1</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 2</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link">List item 3</a>
-    </li>
+<ul class="m-list m-list__horizontal">
+    <li class="m-list_item">List item 1</li>
+    <li class="m-list_item">List item 2</li>
+    <li class="m-list_item">List item 3</li>
 </ul>
 ```
 
-### Icon list
-
-The icon list will set up a list with icons on the left, in place of bullets.
-Will need some more work to allow lines to wrap.
-
-<ul class="list list__icons">
-    <li class="list_item">
-        <span class="cf-icon cf-icon-email list_icon"></span>
-        List item 1
-    </li>
-    <li class="list_item">
-        <span class="cf-icon cf-icon-phone list_icon"></span>
-        List item 1
-    </li>
-    <li class="list_item">
-        <span class="cf-icon cf-icon-fax list_icon"></span>
-        List item 1
-    </li>
-</ul>
-
-```
-<ul class="list list__icons">
-    <li class="list_item">
-        <span class="cf-icon cf-icon-email list_icon"></span>
-        List item 1
-    </li>
-    <li class="list_item">
-        <span class="cf-icon cf-icon-phone list_icon"></span>
-        List item 1
-    </li>
-    <li class="list_item">
-        <span class="cf-icon cf-icon-fax list_icon"></span>
-        List item 1
-    </li>
-</ul>
-```
-
-### Link list
+### Link list modifier
 
 The link list modifier is intended to be used for lists where each item is a link.
 It converts to a finger-friendly link with a large tap area on smaller screens.
 
-<ul class="list list__links">
-    <li class="list_item">
-        <a class="list_link" href="#">List item 1</a>
+<ul class="m-list m-list__links">
+    <li class="m-list_item">
+        <a class="m-list_link" href="#">List item 1</a>
     </li>
-    <li class="list_item">
-        <a class="list_link" href="#">List item 2</a>
+    <li class="m-list_item">
+        <a class="m-list_link" href="#">List item 2</a>
     </li>
-    <li class="list_item">
-        <a class="list_link" href="#">List item 3</a>
-    </li>
-</ul>
-
-```
-<ul class="list list__links">
-    <li class="list_item">
-        <a class="list_link" href="#">List item 1</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link" href="#">List item 2</a>
-    </li>
-    <li class="list_item">
-        <a class="list_link" href="#">List item 3</a>
-    </li>
-</ul>
-```
-
-### Link list with icons
-
-Used when you have a list of links that you would like to include icons as bullets.
-It converts to a finger-friendly link with a large tap area on smaller screens.
-For accessibility reasons, always include a text label accessible to screenreaders
-with `.u-visually-hidden` when using icon bullets.
-
-<ul class="list list__links list__icons">
-    <li class="list_item">
-        <a class="list_link icon-link icon-link__before icon-link__email"
-           href="#">
-            <span class="u-visually-hidden">Email: </span>
-            <span class="icon-link_text">List item 1</span>
-        </a>
-    </li>
-    <li class="list_item">
-        <a class="list_link icon-link icon-link__before icon-link__phone"
-           href="#">
-            <span class="u-visually-hidden">Phone: </span>
-            <span class="icon-link_text">List item 2</span>
-        </a>
-    </li>
-    <li class="list_item">
-        <a class="list_link icon-link icon-link__before icon-link__fax"
-           href="#">
-            <span class="u-visually-hidden">Fax: </span>
-            <span class="icon-link_text">List item 3</span>
-        </a>
+    <li class="m-list_item">
+        <a class="m-list_link" href="#">List item 3</a>
     </li>
 </ul>
 
 ```
-<ul class="list list__links list__icons">
-    <li class="list_item">
-        <a class="list_link icon-link icon-link__before icon-link__email"
-           href="#">
-            <span class="u-visually-hidden">Email: </span>
-            <span class="icon-link_text">List item 1</span>
-        </a>
+<ul class="m-list m-list__links">
+    <li class="m-list_item">
+        <a class="m-list_link" href="#">List item 1</a>
     </li>
-    <li class="list_item">
-        <a class="list_link icon-link icon-link__before icon-link__phone"
-           href="#">
-            <span class="u-visually-hidden">Phone: </span>
-            <span class="icon-link_text">List item 2</span>
-        </a>
+    <li class="m-list_item">
+        <a class="m-list_link" href="#">List item 2</a>
     </li>
-    <li class="list_item">
-        <a class="list_link icon-link icon-link__before icon-link__fax"
-           href="#">
-            <span class="u-visually-hidden">Fax: </span>
-            <span class="icon-link_text">List item 3</span>
-        </a>
+    <li class="m-list_item">
+        <a class="m-list_link" href="#">List item 3</a>
     </li>
 </ul>
 ```
-
-
-### Custom bullet mixin
-
-- Displays custom bullets to the left of specified elements as :before pseudo elements.
-
-- To use, pass this mixin values for the bullet to be displayed: text, color, font size, and offset (distance away from the parent element the bullet should appear). Font family parameter is optional and defaults to inherited.
-
-- Bullets are absolutely positioned outside of their parent's flow, so they will not receive certain properties applied to the parent (borders, text-decoration, etc).
-
-- By default, custom bullets hang outside of their parent's content box (in the margin or padding if there is any). If you want the bullets to align with the left boundary of the parent's content box, give the parent a left margin value equal to the offset.
-
-`.custom-bullet(@text, @color, @offset, @size, @font, @type)`


### PR DESCRIPTION
Converted cf-typography to atomic standards

## Removals

- Removed custom bullet mixin because it is no longer used
- Removed fancy slug because it is no longer used
- Removed short-desc because we are now using Avenir as our standard body font
- Removed padded heading because it's no longer used.
- Removed icon lists for the time being to be addressed later when we can look at existing implementations.

## Changes

- Broke links apart to create less repetitive code
- Broke headings and headers apart to create a better parent/child relationship and handle layout according to our best practices.

## Testing

- check out `example/cf-typography ` sandbox branch and run `npm run build && npm start`
- navigate to `http://localhost:3000/components/cf-typography/`

## Review

- @Scotchester 

## Screenshots

Too many to list, but everything should really look the same as the examples at `https://cfpb.github.io/capital-framework/components/cf-typography/#pull-quote` 

## Notes

- `a-heading` is a placeholder much like `a-list`. There are no uniform styles between the headings, but it makes the most sense, especially when controlling the layout/margin of stylized headings nested inside headers.
- __Reduces output by 4kb__. Small gains but still a positive impact.

## Todos

- Clean up the way we're handling icons. There's a ton of repetitive code due to icons and I have an idea of how it could be better implemented.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
