### PR TITLE
Remove bottom margin from horizontal list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-pagination:** [MINOR] Standardized the usage doc
 - **cf-tables:** [MINOR] Standardized the usage doc
 - **cf-typography:** [MINOR] Standardized the usage doc
+- **cf-typography:** [PATCH] Removed default bottom margin from horizontal list items
 
 ### Removed
 - **cf-core:** [MAJOR] Removed deprecated items:

--- a/src/cf-typography/src/molecules/list.less
+++ b/src/cf-typography/src/molecules/list.less
@@ -38,6 +38,7 @@
         // Assuming a natural space of 4px between inline block items
         // then the space between would be 8px (4px natural + 4px added).
         margin-right: unit( 4px / @base-font-size-px, em );
+        margin-bottom: 0;
     }
 }
 


### PR DESCRIPTION
Horizontal lists are rarely meant to wrap, and the one notable example where they currently do (tags) already specifies bottom margin for its list items. Removing the standard `li` bottom margin so as not to create unwanted vertical space.

## Additions

- Rule to remove bottom margin from horizontal list items.

## Review

- @jimmynotjim 


## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

