### PR TITLE
Remove box-sizing polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "wcag": "^0.2.2"
   },
   "dependencies": {
-    "box-sizing-polyfill": "0.1.0",
     "jquery": "~1.11.0",
     "jquery.easing": "~1.3.0",
     "normalize-css": "^2.0.0",

--- a/src/cf-core/package.json
+++ b/src/cf-core/package.json
@@ -12,7 +12,6 @@
     "test": "case $(pwd) in */capital-framework/src/*) cd ../.. && npm test;; esac"
   },
   "dependencies": {
-    "box-sizing-polyfill": "0.1.0",
     "normalize-css": "^2.0.0",
     "normalize-legacy-addon": "0.1.0"
   }

--- a/src/cf-grid/package.json
+++ b/src/cf-grid/package.json
@@ -12,7 +12,6 @@
     "test": "case $(pwd) in */cf/src/*) cd ../.. && npm test;; esac"
   },
   "dependencies": {
-    "box-sizing-polyfill": "0.1.0",
     "normalize-css": "^2.0.0",
     "normalize-legacy-addon": "0.1.0"
   },

--- a/src/cf-grid/src-generated/cf-grid-generated.less
+++ b/src/cf-grid/src-generated/cf-grid-generated.less
@@ -58,7 +58,7 @@
 
 
 .prefixX ( @index, @indexP ) when (@indexP > 0) {
-  
+
   .col-@{index}.prefix-@{indexP} {
     .grid_column( @columns: @index; @prefix: @indexP; );
   }
@@ -70,7 +70,7 @@
 
 
 .suffixX ( @index, @indexS ) when (@indexS > 0) {
-  
+
   .col-@{index}.suffix-@{indexS} {
     .grid_column( @columns: @index; @suffix: @indexS; );
   }
@@ -94,4 +94,3 @@
 .columnX ( 0 ) {}
 
 .columnX ( @grid_total-columns );
-

--- a/src/cf-grid/src/cf-grid.less
+++ b/src/cf-grid/src/cf-grid.less
@@ -12,7 +12,6 @@
 // Less variables
 //
 
-@grid_box-sizing-polyfill-path: '../../box-sizing-polyfill';
 @grid_wrapper-width:            1200px;
 @grid_gutter-width:             30px;
 @grid_total-columns:            12;
@@ -60,14 +59,6 @@
   .lt-ie8 & {
     // Hack inline-block into submission
     display: inline;
-    // Mixing negative margins and the box-sizing hack can be dangerous.
-    // This is a temporary fix for: https://github.com/cfpb/cf-grid/issues/17
-    margin-right: 0;
-
-    // Clearfix hack for IE 6/7 only
-    zoom: 1;
-    // Box-sizing polyfill
-    behavior: url('@{grid_box-sizing-polyfill-path}/boxsizing.htc');
   }
 
   // Modifying standard width and padding for prefixed/suffixed columns, if necessary:

--- a/src/cf-grid/usage.md
+++ b/src/cf-grid/usage.md
@@ -42,16 +42,6 @@ The following Less variables are exposed,
 allowing you to easily override them before compiling.
 
 ```
-@grid_box-sizing-polyfill-path: '../../box-sizing-polyfill';
-```
-
-For full IE 6/7 support, ensure that the path to boxsizing.htc is set
-using the `@grid_box-sizing-polyfill-path` Less variable.
-This path **must** be overridden in your project and set to a root-relative URL.
-
-Read more about the polyfill: https://github.com/Schepp/box-sizing-polyfill.
-
-```
 @grid_wrapper-width: 1200px;
 ```
 


### PR DESCRIPTION
The box-sizing polyfill is only for IE6/7 and hasn't been updated in three years. I think it's time to remove it and free ourselves of it as a dependent setting.

## Removals

- Remove references to the box-sizing polyfill.

## Testing
- Run `npm run build` and check that IE8+ works in the CF sandbox.

## Notes

- Updates to cf-form are purely to allow the build step to pass.