### PR TITLE
Doc corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **all components:** [PATCH] Standardized all the usage docs for v4
 
 ### Removed
 -

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -1,3 +1,16 @@
+The cf-buttons component provides extensions to the basic button styles for
+Capital Framework.
+
+[`cf-core`](../cf-core) and [`cf-icons`](../cf-icons) components are all
+dependencies of this component.
+
+> NOTE: If you use `cf-buttons.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
+
+## Table of contents
 
 - [Variables](#variables)
     - [Color variables](#color-variables)
@@ -12,13 +25,6 @@
     - [Icon buttons](#icon-buttons)
 - [Molecules](#molecules)
     - [Button group](#button-group)
-
-> NOTE: If you use `cf-buttons.less` directly,
-  be sure to run the file through
-  [Autoprefixer](https://github.com/postcss/autoprefixer),
-  or your compiled Capital Framework CSS will
-  not work perfectly in older browsers.
-
 
 ## Variables
 
@@ -63,7 +69,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 ### Default Button
 
 The default button is an atom in our atomic design standards.
-You can apply the a-btn class to a link, button and submit input field
+You can apply the `a-btn` class to a link, button and submit input field
 to receive the atomic button styles.
 
 For accessibility reasons, use the semantic `<button>` instead of a link when possible.
@@ -133,36 +139,48 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 #### Hovered state
 
 <a href="#" class="a-btn a-btn__secondary hover">Anchor Tag</a>
-<button class="a-btn a-btn__secondary hover" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__secondary hover" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__secondary hover">
 
 ```
 <a href="#" class="a-btn a-btn__secondary hover">Anchor Tag</a>
-<button class="a-btn a-btn__secondary hover" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__secondary hover" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__secondary hover">
 ```
 
 #### Focused state
 
 <a href="#" class="a-btn a-btn__secondary focus">Anchor Tag</a>
-<button class="a-btn a-btn__secondary focus" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__secondary focus" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__secondary focus">
 
 ```
 <a href="#" class="a-btn a-btn__secondary focus">Anchor Tag</a>
-<button class="a-btn a-btn__secondary focus" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__secondary focus" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__secondary focus">
 ```
 
 #### Active state
 
 <a href="#" class="a-btn a-btn__secondary active">Anchor Tag</a>
-<button class="a-btn a-btn__secondary active" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__secondary active" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__secondary active">
 
 ```
 <a href="#" class="a-btn a-btn__secondary active">Anchor Tag</a>
-<button class="a-btn a-btn__secondary active" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__secondary active" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__secondary active">
 ```
 
@@ -171,48 +189,64 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 #### Default state
 
 <a href="#" class="a-btn a-btn__warning">Anchor Tag</a>
-<button class="a-btn a-btn__warning" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__warning" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__warning">
 
 ```
 <a href="#" class="a-btn a-btn__warning">Anchor Tag</a>
-<button class="a-btn a-btn__warning" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__warning" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__warning">
 ```
 
 #### Hovered state
 
 <a href="#" class="a-btn a-btn__warning hover">Anchor Tag</a>
-<button class="a-btn a-btn__warning hover" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__warning hover" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__warning hover">
 
 ```
 <a href="#" class="a-btn a-btn__warning hover">Anchor Tag</a>
-<button class="a-btn a-btn__warning hover" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__warning hover" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__warning hover">
 ```
 
 #### Focused state
 
 <a href="#" class="a-btn a-btn__warning focus">Anchor Tag</a>
-<button class="a-btn a-btn__warning focus" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__warning focus" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__warning focus">
 
 ```
 <a href="#" class="a-btn a-btn__warning focus">Anchor Tag</a>
-<button class="a-btn a-btn__warning focus" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__warning focus" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__warning focus">
 ```
 
 #### Active state
 
 <a href="#" class="a-btn a-btn__warning active">Anchor Tag</a>
-<button class="a-btn a-btn__warning active" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__warning active" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__warning active">
 
 ```
 <a href="#" class="a-btn a-btn__warning active">Anchor Tag</a>
-<button class="a-btn a-btn__warning active" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__warning active" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__warning active">
 ```
 
@@ -223,13 +257,17 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 <a href="#" class="a-btn a-btn__disabled">Anchor Tag</a>
 <button class="a-btn a-btn__disabled" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__disabled">
-<button class="a-btn" disabled title="Test button">Button Tag w/ disabled attr</button>
+<button class="a-btn" disabled title="Test button">
+    Button Tag w/ disabled attr
+</button>
 
 ```
 <a href="#" class="a-btn a-btn__disabled">Anchor Tag</a>
 <button class="a-btn a-btn__disabled" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__disabled">
-<button class="a-btn" disabled title="Test button">Button Tag w/ disabled attr</button>
+<button class="a-btn" disabled title="Test button">
+    Button Tag w/ disabled attr
+</button>
 ```
 
 #### Focused state
@@ -237,13 +275,17 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 <a href="#" class="a-btn a-btn__disabled focus">Anchor Tag</a>
 <button class="a-btn a-btn__disabled focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__disabled focus">
-<button class="a-btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
+<button class="a-btn focus" disabled title="Test button">
+    Button Tag w/ disabled attr
+</button>
 
 ```
 <a href="#" class="a-btn a-btn__disabled focus">Anchor Tag</a>
 <button class="a-btn a-btn__disabled focus" title="Test button">Button Tag</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__disabled focus">
-<button class="a-btn focus" disabled title="Test button">Button Tag w/ disabled attr</button>
+<button class="a-btn focus" disabled title="Test button">
+    Button Tag w/ disabled attr
+</button>
 ```
 
 ### Super button
@@ -263,36 +305,48 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 #### Hovered state
 
 <a href="#" class="a-btn a-btn__super hover">Anchor Tag</a>
-<button class="a-btn a-btn__super hover" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__super hover" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__super hover">
 
 ```
 <a href="#" class="a-btn a-btn__super hover">Anchor Tag</a>
-<button class="a-btn a-btn__super hover" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__super hover" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__super hover">
 ```
 
 #### Focused state
 
 <a href="#" class="a-btn a-btn__super focus">Anchor Tag</a>
-<button class="a-btn a-btn__super focus" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__super focus" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__super focus">
 
 ```
 <a href="#" class="a-btn a-btn__super focus">Anchor Tag</a>
-<button class="a-btn a-btn__super focus" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__super focus" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__super focus">
 ```
 
 #### Active state
 
 <a href="#" class="a-btn a-btn__super active">Anchor Tag</a>
-<button class="a-btn a-btn__super active" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__super active" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__super active">
 
 ```
 <a href="#" class="a-btn a-btn__super active">Anchor Tag</a>
-<button class="a-btn a-btn__super active" title="Test button">Button Tag</button>
+<button class="a-btn a-btn__super active" title="Test button">
+    Button Tag
+</button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__super active">
 ```
 
@@ -301,48 +355,64 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 #### Default state
 
 <a href="#" class="a-btn a-btn__link">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary">
+    Secondary Button Link
+</a>
 <a href="#" class="a-btn a-btn__link a-btn__warning">Warning Button Link</a>
 
 ```
 <a href="#" class="a-btn a-btn__link">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary">
+    Secondary Button Link
+</a>
 <a href="#" class="a-btn a-btn__link a-btn__warning">Warning Button Link</a>
 ```
 
 #### Hovered state
 
 <a href="#" class="a-btn a-btn__link hover">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary hover">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary hover">
+    Secondary Button Link
+</a>
 <a href="#" class="a-btn a-btn__link a-btn__warning hover">Warning Button Link</a>
 
 ```
 <a href="#" class="a-btn a-btn__link hover">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary hover">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary hover">
+    Secondary Button Link
+</a>
 <a href="#" class="a-btn a-btn__link a-btn__warning hover">Warning Button Link</a>
 ```
 
 #### Focus state
 
 <a href="#" class="a-btn a-btn__link focus">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary focus">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary focus">
+    Secondary Button Link
+</a>
 <a href="#" class="a-btn a-btn__link a-btn__warning focus">Warning Button Link</a>
 
 ```
 <a href="#" class="a-btn a-btn__link focus">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary focus">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary focus">
+    Secondary Button Link
+</a>
 <a href="#" class="a-btn a-btn__link a-btn__warning focus">Warning Button Link</a>
 ```
 
 #### Active state
 
 <a href="#" class="a-btn a-btn__link active">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary active">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary active">
+    Secondary Button Link
+</a>
 <a href="#" class="a-btn a-btn__link a-btn__warning active">Warning Button Link</a>
 
 ```
 <a href="#" class="a-btn a-btn__link active">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary active">Secondary Button Link</a>
+<a href="#" class="a-btn a-btn__link a-btn__secondary active">
+    Secondary Button Link
+</a>
 <a href="#" class="a-btn a-btn__link a-btn__warning active">Warning Button Link</a>
 ```
 

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -33,8 +33,8 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables are from 18F's
-[US Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss)
+`$color-` variables referenced in comments are from 18F's
+[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 ```
 @btn-text

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -8,6 +8,7 @@ It's made up of four child components `cf-vars`, `cf-media-queries`,
   or your compiled Capital Framework CSS will
   not work perfectly in older browsers.
 
+[//]: # (NOTE: The markdown adds a `p` element inside the `blockquote`, we need to explore a style fix so this is more obviously a `blockquote`.)
 
 ## Table of contents
 
@@ -93,11 +94,13 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ## Media queries
 
-Mixins for consistent media queries that take `px` values and convert them to `em`s.
+Mixins for consistent media queries that take `px` values and convert them
+to `em`s.
 
 ### Respond to min and max width mixins
 
-These mixins take a `px` value breakpoint and set of style rules and converts them to the corresponding min or max width media query.
+These mixins take a `px` value breakpoint and set of style rules and converts
+them to the corresponding min or max width media query.
 
 ```
 .respond-to-min(@bp, @rules);
@@ -124,7 +127,8 @@ Ex.
 
 ### Respond to range mixin
 
-This mixin takes both min and max `px` values and a set of style rules and converts them to the corresponding min and max media query.
+This mixin takes both min and max `px` values and a set of style rules and
+converts them to the corresponding min and max media query.
 
 ```
 .respond-to-range(@bp1, @bp2, @rules);
@@ -208,17 +212,18 @@ This mixin allows us to easily write styles that target both
 
 #### JS only
 
-Hide an element when JavaScript isn't available. Requires a small script in the HEAD of your HTML document that removes a `.no-js` class.
+Hide an element when JavaScript isn't available. Requires a small script in the
+`<head>` of your `<html>` document that removes a `.no-js` class.
 
 1. Add a `no-js` class added to the `html`
   ```
   <html class="no-js">
   ```
 
-2. Add a script to remove the `no-js` class after confirming JS is available
+2. Add a script to remove the `no-js` class after confirming JavaScript is available
   ```
   <script>
-      // Confirm availability of JS and remove no-js class from html
+      // Confirm availability of JavaScript and remove no-js class from html
       var docElement = document.documentElement;
       docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
   </script>
@@ -231,9 +236,11 @@ Hide an element when JavaScript isn't available. Requires a small script in the 
 
 #### Clearfix
 
-Clear floated elements to avoid following elements from flowing into the previous one.
+Clear floated elements to avoid following elements from flowing into the
+previous one.
 
-For example, to float an element to the left, but prevent the following text from flowing into it.
+For example, to float an element to the left, but prevent the following text
+from flowing into it.
 
 _More information see: <http://css-tricks.com/snippets/css/clear-fix>_
 
@@ -248,7 +255,9 @@ _More information see: <http://css-tricks.com/snippets/css/clear-fix>_
 
 Hide an element from view while keeping it accessible to screen readers.
 
-For example, to create a link with a social network icon, but allow non-sighted users to understand the context, add descriptive text with the `u-visually-hidden` class.
+For example, to create a link with a social network icon, but allow non-sighted
+users to understand the context, add descriptive text with the
+`u-visually-hidden` class.
 
 ```
 <h1>
@@ -261,7 +270,7 @@ For example, to create a link with a social network icon, but allow non-sighted 
 
 #### Inline block
 
-Adds a `.lt-ie8` fallback to hack inline block for IE 7 and below.
+Adds a `.lt-ie8` fallback to hack inline block for Internet Explorer 7 and below.
 
 ```
 <div class="u-inline-block"></div>
@@ -275,18 +284,24 @@ Adds a `.lt-ie8` fallback to hack inline block for IE 7 and below.
 
 #### Break word
 
-Force word breaks within an element. Useful for small containers where text may over-run the width of the container.
+Force word breaks within an element. Useful for small containers where text may
+over-run the width of the container.
 
-_This only works in IE8 when the element with the `.u-break-word` class has layout. See <http://stackoverflow.com/questions/3997223/word-wrapbreak-word-not-working-in-ie8> for more information._
+_This only works in Internet Explorer 8 when the element with the
+`.u-break-word` class has layout. See
+<http://stackoverflow.com/questions/3997223/word-wrapbreak-word-not-working-in-ie8>
+for more information._
 
-<div class="u-break-word u-mb30" style="width: 100px; padding: 0.5em; border: 1px solid silver;">
+<div class="u-break-word u-mb30"
+     style="width: 100px; padding: 0.5em; border: 1px solid silver;">
     This link should break:
     <a href="#">
         something@something.com
     </a>
 </div>
 
-<div class="u-mb30" style="width: 100px; padding: 0.5em; border: 1px solid silver;">
+<div class="u-mb30"
+     style="width: 100px; padding: 0.5em; border: 1px solid silver;">
     This link should not:
     <a href="#">
         something@something.com
@@ -311,11 +326,12 @@ _This only works in IE8 when the element with the `.u-break-word` class has layo
 
 #### Margin utilities
 
-Force a margin top or bottom on an element in pixels.
+Force a `margin` top or bottom on an element in pixels.
 
 `.u-m[p][#]`
 
-_`[p]` is the position, use `t` for top or `b` for bottom. `[#]` is the pixel value, available options are 0, 5, 10, 15, 20, 30, 45, 60_
+_`[p]` is the position, use `t` for top or `b` for bottom. `[#]` is the pixel
+value, available options are 0, 5, 10, 15, 20, 30, 45, 60_
 
 ```
 <h1 class="u-mb0">Heading with zero bottom margin</h1>
@@ -323,7 +339,7 @@ _`[p]` is the position, use `t` for top or `b` for bottom. `[#]` is the pixel va
 
 #### Width utilities
 
-Set the width of an element in percentages.
+Set the `width` of an element in percentages.
 
 **NOTE: Inline style properties for demonstration only.**
 
@@ -423,7 +439,7 @@ __NOTE: Inline style properties for demonstration only__
 
 ##### Show on mobile
 
-Displays content on screen widths under 601px.
+Displays content on screen widths under `601px`.
 
 <div style="border: 1px solid black; height: 22px; padding: 5px;">
     <p class="u-show-on-mobile">Visible on mobile</p>
@@ -437,7 +453,7 @@ Displays content on screen widths under 601px.
 
 ##### Hide on mobile
 
-Hides content on screens widths under 601px.
+Hides content on screens widths under `601px`.
 
 <div style="border: 1px solid black; height: 22px; padding: 5px;">
     <p class="u-hide-on-mobile">Hidden on mobile</p>
@@ -453,9 +469,11 @@ Hides content on screens widths under 601px.
 
 #### Align with button
 
-Align an element vertically with the text within a button that may be to either side.
+Align an element vertically with the text within a button that may be to either
+side.
 
-_Pass font-size as the argument for calculating spacing, default value is `@base-font-size-px`._
+_Pass `font-size` as the argument for calculating spacing, default value is
+`@base-font-size-px`._
 
 ```
 .u-align-with-btn(@font-size: @base-font-size-px);
@@ -463,23 +481,30 @@ _Pass font-size as the argument for calculating spacing, default value is `@base
 
 #### Flexible proportional containers
 
-Utilize intrinsic ratios to create a flexible container that retains an aspect ratio. When image tags scale they retain their aspect ratio, but if you need a flexible video you will need to use this mixin.
+Utilize intrinsic ratios to create a flexible container that retains an aspect
+ratio. When `<img>` tags scale they retain their aspect ratio, but if you need
+a flexible video you will need to use this mixin.
 
-_Read more about intrinsic rations: <http://alistapart.com/article/creating-intrinsic-ratios-for-video>_
+_Read more about intrinsic rations:
+<http://alistapart.com/article/creating-intrinsic-ratios-for-video>_
 
 ```
 .u-flexible-container-mixin(@width: 16, @height: 9);
 ```
 
-In addition to the mixin, there are two default classes available for building 16:9 and 4:3 containers.
+In addition to the mixin, there are two default classes available for building
+16:9 and 4:3 containers.
 
-_When using the mixin, pass the width as the first argument, and the height as the second argument, default values are `16, 9`._
+_When using the mixin, pass the `width` as the first argument, and the `height`
+as the second argument, default values are `16, 9`._
 
 _Original mixin credit: <https://gist.github.com/craigmdennis/6655047>_
 
 __NOTE: Inline style properties for demonstration only__
 
-To create a 16:9 flexible video player, wrap the video element in an element with `u-flexible-container` and add the `u-flexible-container_inner` to the video element.
+To create a 16:9 flexible video player, wrap the video element in an element
+with `u-flexible-container` and add the `u-flexible-container_inner` to the
+video element.
 
 <div class="u-flexible-container">
     <video class="u-flexible-container_inner"
@@ -497,7 +522,8 @@ To create a 16:9 flexible video player, wrap the video element in an element wit
 </div>
 ```
 
-To create a flexible container with only a background (no inner video or object element), ommit the inner container.
+To create a flexible container with only a background (no inner video or object
+element), ommit the inner container.
 
 <div class="u-flexible-container"
      style="background-image: url(http://placekitten.com/700/394);
@@ -535,49 +561,66 @@ Modify link properties using the following mixins.
 
 ##### Link colors
 
-Calling the mixin without arguments will set the following states - default(pacific), :hover(pacific-50), :focus:(pacific), :visited teal, :active navy.
+Calling the mixin without arguments will set the following states:
+`default` - `@pacific`, `:hover` - `@pacific-50`, `focus:` - `@pacific`,
+`:visited` - `@teal`, `:active` - `@navy`.
+
+[//]: # (NOTE: These aren't the default colors within this project, only once the brand theme has been applied.)
 
 `u-link__colors()`
 
-Passing a single argument into the mixin will set the color for the default, :visited, :hover, :focus, :active states.
+Passing a single argument into the mixin will set the color for the
+`default`, `:visited`, `:hover`, `:focus`, `:active` states.
 
 `u-link__colors(@c)`
 
-Passing two arguments into the mixin will set the color for the default, :visited, and :active states as the first argument, and :hover and :focus as the second argument.
+Passing two arguments into the mixin will set the color for the `default`,
+`:visited`, and `:active` states as the first argument, and `:hover` and
+`:focus` as the second argument.
 
 `u-link__colors(@c, @h)`
 
-Passing five arguments will set the color for the default, :visited, :hover, :focus, and :active states respectively.
+Passing five arguments will set the color for the `default`, `:visited`,
+`:hover`, `:focus`, and `:active` states respectively.
 
 `u-link__colors(@c, @v, @h, @f, @a)`
 
-Passing ten arguments will set the text (default, :visited, :hover, :focus, and :active states in the first five arguments) and border colors (default, :visited, :hover, :focus, and :active states in the following five arguments) separately.
+Passing ten arguments will set the text (`default`, `:visited`, `:hover`,
+`:focus`, and `:active` states in the first five arguments) and border colors
+(`default`, `:visited`, `:hover`, `:focus`, and `:active` states in the
+following five arguments) separately.
 
 `u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba)`
 
-__A base mixin of `u-link__colors-base()` exists, but please refrain from using this mixin directly in order to promote consistent naming throughout this project. If you need to set colors for all states of a link, use `.u-link__colors(@c, @v, @h, @f, @a)`.__
+__A base mixin of `u-link__colors-base()` exists, but please refrain from
+using this mixin directly in order to promote consistent naming throughout
+this project. If you need to set colors for all states of a link, use
+`.u-link__colors(@c, @v, @h, @f, @a)`.__
 
 ##### Link borders
 
-Force the default bottom border on the default and :hover states.
+Force the default bottom `border` on the `default` and `:hover` states.
 
 `.u-link__border()`
 
-Turn off the default bottom border on the default and :hover states.
+Turn off the default bottom `border` on the `default` and `:hover` states.
 
 `.u-link__no-border()`
 
-Turn off the default bottom border on the default state but force a bottom border on the :hover state.
+Turn off the default bottom `border` on the `default` state but force a bottom
+`border` on the `:hover` state.
 
 `.u-link__hover-border()`
 
 ##### Link children
 
-Calling this mixin without arguments will set the default color for the hover state of a child within a link, without affecting the link itself.
+Calling this mixin without arguments will set the default color for the
+`:hover` state of a child within a link, without affecting the link itself.
 
 `.u-link__hover-child()`
 
-Passing a single argument into the mixin will set a custom color for the hover state of a child within a link, without affecting the link itself.
+Passing a single argument into the mixin will set a custom color for the
+`:hover` state of a child within a link, without affecting the link itself.
 
 `.u-link__hover-child(@c)`
 
@@ -585,15 +628,17 @@ Passing a single argument into the mixin will set a custom color for the hover s
 
 ##### Class
 
-Sets the element to 14px (in ems).
+Sets the element to `14px` (in `em`s).
 
-_To be used on default 16px text only. To use on text set to another size, use the mixin below._
+_To be used on default `16px` text only. To use on text set to another size,
+use the mixin below._
 
 `.u-small-text`
 
 ##### Mixin
 
-Sets the element to 14px (in ems) based on the text size passed as `@context`.
+Sets the element to `14px` (in `em`s) based on the text size passed as
+`@context`.
 
 `.u-small-text(@context)`
 
@@ -631,18 +676,31 @@ Sets the font-stack, weight, and style of an element.
 .u-webfont-demi();
 ```
 
-To use your own fonts in the webfont mixins, set your own font with the `@webfont-regular/italic/medium/demi` variables in your `theme-overrides.less` file.
+To use your own fonts in the webfont mixins, set your own font with the
+`@webfont-regular/italic/medium/demi` variables in your `theme-overrides.less`
+file.
 
-_These mixins also add the appropriate .lt-ie9 overrides. .lt-ie9 overrides are necessary to override font-style and font-weight each time the webfont is used. These overrides are built into the webfont mixins so you get them automatically. Note that this requires you to use conditional classes on the <html> element: <https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md#conditional-html-classes.>_
+_These mixins also add the appropriate `.lt-ie9` overrides. `.lt-ie9`
+overrides are necessary to override `font-style` and `font-weight` each time
+the webfont is used. These overrides are built into the webfont mixins so you
+get them automatically. Note that this requires you to use conditional
+classes on the `<html>` element:
+<https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md#conditional-html-classes.>_
 
 ### Type hierarchy
 
 #### Default body type
 
-<p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+<p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do
+eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat.</p>
 
 ```
-<p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+<p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do
+eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat.</p>
 ```
 
 #### Heading level 1
@@ -719,12 +777,15 @@ _Not a responsive heading._
 
 #### Lead paragraph
 
-_Responsive text. Displays as a Heading 3 on large screens; displays at Heading 4 size (but still Regular weight) on small screens._
+_Responsive text. Displays as a Heading 3 on large screens; displays at Heading
+4 size (but still Regular weight) on small screens._
 
-<p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+<p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 
 ```
-<p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+<p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 ```
 
 #### Display heading (aka "superheading")
@@ -737,10 +798,13 @@ _Responsive text. Displays as a Heading 3 on large screens; displays at Heading 
 
 ### Body copy vertical margins
 
-- _Applies 15px bottom margin to all `p`, `ul`, `ol`, `dl`, `figure`, `table`, and `blockquote` elements._
-- _Applies -5px top margin to lists following paragraphs to reduce margin between them to 10px._
-- _Applies 8px bottom margin to list items that are not within a nav element._
-- _Assumes that the font size of each of these items remains the default._
+- Applies `15px` bottom `margin` to all `p`, `ul`, `ol`, `dl`, `figure`,
+  `table`, and `blockquote` elements.
+- Applies `-5px` top `margin` to lists following paragraphs to reduce `margin`
+  between them to `10px`.
+- Applies `8px` bottom `margin` to list items that are not within a `nav`
+  element.
+- Assumes that the font size of each of these items remains the default.
 
 <p>Paragraph margin example</p>
 <p>Paragraph margin example</p>
@@ -763,6 +827,9 @@ _Responsive text. Displays as a Heading 3 on large screens; displays at Heading 
 ```
 
 ### Default links
+
+_Note that the `.visited`, `.hover`, `.focus`, `.active` classes are for
+demonstration purposes only and should not be used in production._
 
 #### Default state
 
@@ -798,8 +865,6 @@ _Responsive text. Displays as a Heading 3 on large screens; displays at Heading 
 
 #### Active state
 
-_Note that the `.visited`, `.hover`, `.focus`, `.active` classes are for demonstration purposes only and should not be used in production._
-
 <a href="#" class="active">Visited link style</a>
 
 ```
@@ -808,11 +873,13 @@ _Note that the `.visited`, `.hover`, `.focus`, `.active` classes are for demonst
 
 ### Underlined links
 
-Links are automatically underlined when they are a child of a `p`, `li`, or `dd`. To enable them elsewhere, simply add a bottom-border-width to the link.
+Links are automatically underlined when they are a child of a `p`, `li`, or
+`dd`. To enable them elsewhere, simply add a bottom-border-width to the link.
+
+_Note that the `.visited`, `.hover`, `.focus`, `.active` classes are for
+demonstration purposes only and should not be used in production._
 
 #### States
-
-_Note that the `.visited`, `.hover`, `.focus`, `.active` classes are for demonstration purposes only and should not be used in production._
 
 <p>
     <a href="#">Default</a>,
@@ -872,7 +939,7 @@ _Note that the `.visited`, `.hover`, `.focus`, `.active` classes are for demonst
 
 #### Exceptions for underlined links
 
-Links within a nav element are not underlined.
+Links within a `nav` element are not underlined.
 
 <nav>
     <p>
@@ -937,24 +1004,24 @@ Links within a nav element are not underlined.
 #### Ordered list
 
 <p>Paragraph example for visual reference</p>
-<ul>
+<ol>
     <li>List item 1</li>
     <li>List item 2</li>
     <li>List item 3</li>
-</ul>
+</ol>
 
 ```
 <p>Paragraph example for visual reference</p>
-<ul>
+<ol>
     <li>List item 1</li>
     <li>List item 2</li>
     <li>List item 3</li>
-</ul>
+</ol>
 ```
 
 ### Tables
 
-#### Standard label
+#### Standard table
 
 <table>
     <thead>
@@ -1014,8 +1081,11 @@ Links within a nav element are not underlined.
 
 ### Block quote
 
-_Note that the use of a block quote is to quote an external work. See `.pull-quote` if you need to highlight an excerpt from the current work._
-_Note that it is best practice to document the URL of a quoted work using the cite attribute._
+_Note that the use of a `blockquote` is to quote an external work. See
+`.pull-quote` if you need to highlight an excerpt from the current work._
+
+_Note that it is best practice to document the URL of a quoted work using
+the `cite` attribute._
 
 <blockquote cite="link-to-source">
     Lorem ipsum dolor sit amet, consectetur adipisicing elit. Culpa
@@ -1048,7 +1118,7 @@ _Note that it is best practice to document the URL of a quoted work using the ci
 
 ### Full-width images
 
-Gives all images a default max-width of 100% of their container.
+Gives all images a default `max-width` of `100%` of their container.
 
 <img src="http://placekitten.com/800/40" alt="">
 
@@ -1058,7 +1128,7 @@ Gives all images a default max-width of 100% of their container.
 
 ### Figure
 
-Resets browser default side margins for `figure` to 0,
+Resets browser default side `margins` for `figure` to `0`,
 and removes bottom inline spacing from `img` elements within.
 
 <figure>

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -44,8 +44,8 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables are from 18F's
-[US Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss)
+`$color-` variables referenced in comments are from 18F's
+[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 ```
 // body
@@ -485,7 +485,7 @@ Utilize intrinsic ratios to create a flexible container that retains an aspect
 ratio. When `<img>` tags scale they retain their aspect ratio, but if you need
 a flexible video you will need to use this mixin.
 
-_Read more about intrinsic rations:
+_Read more about intrinsic ratios:
 <http://alistapart.com/article/creating-intrinsic-ratios-for-video>_
 
 ```
@@ -496,7 +496,7 @@ In addition to the mixin, there are two default classes available for building
 16:9 and 4:3 containers.
 
 _When using the mixin, pass the `width` as the first argument, and the `height`
-as the second argument, default values are `16, 9`._
+as the second argument. Default values are `16, 9`._
 
 _Original mixin credit: <https://gist.github.com/craigmdennis/6655047>_
 
@@ -562,32 +562,32 @@ Modify link properties using the following mixins.
 ##### Link colors
 
 Calling the mixin without arguments will set the following states:
-`default` - `@pacific`, `:hover` - `@pacific-50`, `focus:` - `@pacific`,
-`:visited` - `@teal`, `:active` - `@navy`.
+default - `#0071bc`, `:hover` - `#205493`, `focus:` - `#0071bc`,
+`:visited` - `#4c2c92`, `:active` - `#046b99`.
 
 [//]: # (NOTE: These aren't the default colors within this project, only once the brand theme has been applied.)
 
 `u-link__colors()`
 
 Passing a single argument into the mixin will set the color for the
-`default`, `:visited`, `:hover`, `:focus`, `:active` states.
+default, `:visited`, `:hover`, `:focus`, `:active` states.
 
 `u-link__colors(@c)`
 
-Passing two arguments into the mixin will set the color for the `default`,
+Passing two arguments into the mixin will set the color for the default,
 `:visited`, and `:active` states as the first argument, and `:hover` and
 `:focus` as the second argument.
 
 `u-link__colors(@c, @h)`
 
-Passing five arguments will set the color for the `default`, `:visited`,
+Passing five arguments will set the color for the default, `:visited`,
 `:hover`, `:focus`, and `:active` states respectively.
 
 `u-link__colors(@c, @v, @h, @f, @a)`
 
-Passing ten arguments will set the text (`default`, `:visited`, `:hover`,
+Passing ten arguments will set the text (default, `:visited`, `:hover`,
 `:focus`, and `:active` states in the first five arguments) and border colors
-(`default`, `:visited`, `:hover`, `:focus`, and `:active` states in the
+(default, `:visited`, `:hover`, `:focus`, and `:active` states in the
 following five arguments) separately.
 
 `u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba)`
@@ -599,15 +599,15 @@ this project. If you need to set colors for all states of a link, use
 
 ##### Link borders
 
-Force the default bottom `border` on the `default` and `:hover` states.
+Force the default bottom `border` on the default and `:hover` states.
 
 `.u-link__border()`
 
-Turn off the default bottom `border` on the `default` and `:hover` states.
+Turn off the default bottom `border` on the default and `:hover` states.
 
 `.u-link__no-border()`
 
-Turn off the default bottom `border` on the `default` state but force a bottom
+Turn off the default bottom `border` on the default state but force a bottom
 `border` on the `:hover` state.
 
 `.u-link__hover-border()`
@@ -677,14 +677,14 @@ Sets the font-stack, weight, and style of an element.
 ```
 
 To use your own fonts in the webfont mixins, set your own font with the
-`@webfont-regular/italic/medium/demi` variables in your `theme-overrides.less`
+`@webfont-regular/italic/medium/demi` variables in your `cf-theme-overrides.less`
 file.
 
 _These mixins also add the appropriate `.lt-ie9` overrides. `.lt-ie9`
 overrides are necessary to override `font-style` and `font-weight` each time
 the webfont is used. These overrides are built into the webfont mixins so you
 get them automatically. Note that this requires you to use conditional
-classes on the `<html>` element:
+classes on the `html` element:
 <https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md#conditional-html-classes.>_
 
 ### Type hierarchy
@@ -874,7 +874,8 @@ demonstration purposes only and should not be used in production._
 ### Underlined links
 
 Links are automatically underlined when they are a child of a `p`, `li`, or
-`dd`. To enable them elsewhere, simply add a bottom-border-width to the link.
+`dd`. To enable them elsewhere, simply add a `border-bottom-width: 1px;` to
+the link.
 
 _Note that the `.visited`, `.hover`, `.focus`, `.active` classes are for
 demonstration purposes only and should not be used in production._

--- a/src/cf-expandables/usage.md
+++ b/src/cf-expandables/usage.md
@@ -78,9 +78,9 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Expanded
 
-Sometimes you may want the expandable to be open by default. This is as easy
-as adding the `.o-expandable_content__onload-open` modifier to the
-`.o-expandable_content` block.
+Sometimes you may want the expandable to be open by default.
+This is as easy as adding the `.o-expandable_content__onload-open` modifier
+to the `.o-expandable_content` block.
 
 ```
 .o-expandable_content__onload-open
@@ -169,8 +169,8 @@ Allows you to float information left and right.
 ## Recommended expandable pattern
 
 Expandables can be built by combining the basic barebones structure described
-in the next section along with more specialized expandable elements and
-modifiers described throughout.
+in the next section along with more specialized expandable elements
+and modifiers described throughout.
 
 ### Default state
 
@@ -518,9 +518,9 @@ In this barebones example there are no visual styles.
 
 ### Accordion-style group
 
-Accordions can only show one open expandable at a time. Add the
-`data-accordion="true"` attribute to the expandable group to activate the
-accordion mode.
+Accordions can only show one open expandable at a time.
+Add the `data-accordion="true"` attribute to the expandable group to activate
+the accordion mode.
 
 <div class="o-expandable-group o-expandable-group__accordion" >
     <div class="o-expandable o-expandable__padded">

--- a/src/cf-expandables/usage.md
+++ b/src/cf-expandables/usage.md
@@ -19,7 +19,7 @@ dependencies of this component.
   - [Sizing variables](#sizing-variables)
   - [Timing variables](#timing-variables)
 - [Modifiers](#modifiers)
-  - [Expanded](#expandables)
+  - [Expanded](#expanded)
   - [Padded](#padded)
   - [Spaced header](#spaced-header)
 - [Elements](#elements)
@@ -40,8 +40,8 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables are from 18F's
-[US Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss)
+`$color-` variables referenced in comments are from 18F's
+[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 ```
 // Single expandable
@@ -91,7 +91,7 @@ as adding the `.o-expandable_content__onload-open` modifier to the
 Adds `padding` and a `background` color to `.o-expandable_header` and
 `.o-expandable_content`.
 
-In addition to using the `.o-expandable__padded` modifier you alsoneed to make
+In addition to using the `.o-expandable__padded` modifier you also need to make
 sure you are using `.o-expandable_header`.
 
 ```

--- a/src/cf-expandables/usage.md
+++ b/src/cf-expandables/usage.md
@@ -1,6 +1,6 @@
 Expandables are components that have additional content that can be
 opened (expanded) and closed (collapsed). They can appear on their own
-or can appear in groups.
+or in groups.
 
 [`cf-core`](../cf-core) and [`cf-icons`](../cf-icons) components are
 dependencies of this component.
@@ -78,8 +78,9 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Expanded
 
-Sometimes you may want the expandable to be open by default.
-This is as easy as adding the `.o-expandable_content__onload-open` modifier to the `.o-expandable_content` block.
+Sometimes you may want the expandable to be open by default. This is as easy
+as adding the `.o-expandable_content__onload-open` modifier to the
+`.o-expandable_content` block.
 
 ```
 .o-expandable_content__onload-open
@@ -87,10 +88,11 @@ This is as easy as adding the `.o-expandable_content__onload-open` modifier to t
 
 ### Padded
 
-Adds padding and a background color to `.o-expandable_header` and `.o-expandable_content`.
+Adds `padding` and a `background` color to `.o-expandable_header` and
+`.o-expandable_content`.
 
-In addition to using the `.o-expandable__padded` modifier you also
-need to make sure you are using `.o-expandable_header`.
+In addition to using the `.o-expandable__padded` modifier you alsoneed to make
+sure you are using `.o-expandable_header`.
 
 ```
 .o-expandable__padded
@@ -98,7 +100,7 @@ need to make sure you are using `.o-expandable_header`.
 
 ### Spaced header
 
-Allows you to add space between .o-expandable_header and .o-expandable_content.
+Allows you to add space between `.o-expandable_header` and `.o-expandable_content`.
 
 ```
 .o-expandable_header__spaced
@@ -124,7 +126,9 @@ Allows you to add some styled text.
 
 #### Link
 
-Allows you to add some styled text with a link-like look.
+Allows you to add some styled text to look like a link.
+
+_Note: only use this in the expandable header_
 
 <span class="o-expandable_link">
     Lorem ipsum
@@ -138,14 +142,15 @@ Allows you to add some styled text with a link-like look.
 
 ### Header elements
 
-These additional elements are useful for more complicated expandables
-that need to convey more information than just 'Show/Hide' before the user expands it.
+These additional elements are useful for more complicated expandables that need
+to convey more information than just 'Show/Hide' before the user expands it.
 
 #### Header
 
 Creates a full-width container to house information that is always visible.
 
-Combine `.o-expandable_header` with `.o-expandable_target` for a full-width trigger.
+Combine `.o-expandable_header` with `.o-expandable_target` for a full-width
+trigger.
 
 ```
 .o-expandable_header
@@ -164,15 +169,16 @@ Allows you to float information left and right.
 ## Recommended expandable pattern
 
 Expandables can be built by combining the basic barebones structure described
-in the next section along with more specialized expandable elements
-and modifiers described throughout.
+in the next section along with more specialized expandable elements and
+modifiers described throughout.
 
 ### Default state
 
 The following combination is our recommended go-to expandable pattern.
 
 <div class="o-expandable o-expandable__padded">
-    <button class="o-expandable_header o-expandable_target" title="Expand content">
+    <button class="o-expandable_header o-expandable_target"
+            title="Expand content">
         <span class="o-expandable_header-left o-expandable_label">
             Expandable Header
         </span>
@@ -197,9 +203,11 @@ The following combination is our recommended go-to expandable pattern.
         </p>
     </div>
 </div>
+
 ```
 <div class="o-expandable o-expandable__padded">
-    <button class="o-expandable_header o-expandable_target" title="Expand content">
+    <button class="o-expandable_header o-expandable_target"
+            title="Expand content">
         <span class="o-expandable_header-left o-expandable_label">
             Expandable Header
         </span>
@@ -229,7 +237,8 @@ The following combination is our recommended go-to expandable pattern.
 ### Default state (open on load)
 
 <div class="o-expandable o-expandable__padded">
-    <button class="o-expandable_header o-expandable_target" title="Expand content">
+    <button class="o-expandable_header o-expandable_target"
+            title="Expand content">
         <span class="o-expandable_header-left o-expandable_label">
             Expandable Header
         </span>
@@ -254,9 +263,11 @@ The following combination is our recommended go-to expandable pattern.
         </p>
     </div>
 </div>
+
 ```
 <div class="o-expandable o-expandable__padded">
-    <button class="o-expandable_header o-expandable_target" title="Expand content">
+    <button class="o-expandable_header o-expandable_target"
+            title="Expand content">
         <span class="o-expandable_header-left o-expandable_label">
             Expandable Header
         </span>
@@ -285,8 +296,8 @@ The following combination is our recommended go-to expandable pattern.
 
 ### Barebones expandable
 
-This is the barebones structure for expandables that can be used
-(along with other expanable elements and modifiers) to create custom expandable patterns.
+This is the barebones structure for expandables that can be used (along with
+other expanable elements and modifiers) to create custom expandable patterns.
 
 In this barebones example there are no visual styles.
 
@@ -337,7 +348,8 @@ In this barebones example there are no visual styles.
 
 <div class="o-expandable-group">
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 1
             </span>
@@ -363,7 +375,8 @@ In this barebones example there are no visual styles.
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 2
             </span>
@@ -389,7 +402,8 @@ In this barebones example there are no visual styles.
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 3
             </span>
@@ -419,7 +433,8 @@ In this barebones example there are no visual styles.
 ```
 <div class="o-expandable-group">
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 1
             </span>
@@ -445,7 +460,8 @@ In this barebones example there are no visual styles.
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 2
             </span>
@@ -471,7 +487,8 @@ In this barebones example there are no visual styles.
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 3
             </span>
@@ -501,12 +518,14 @@ In this barebones example there are no visual styles.
 
 ### Accordion-style group
 
-Accordions can only show one open expandable at a time.
-Add the `data-accordion="true"` attribute to the expandable group to activate the accordion mode.
+Accordions can only show one open expandable at a time. Add the
+`data-accordion="true"` attribute to the expandable group to activate the
+accordion mode.
 
 <div class="o-expandable-group o-expandable-group__accordion" >
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 1
             </span>
@@ -532,7 +551,8 @@ Add the `data-accordion="true"` attribute to the expandable group to activate th
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 2
             </span>
@@ -558,7 +578,8 @@ Add the `data-accordion="true"` attribute to the expandable group to activate th
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 3
             </span>
@@ -588,7 +609,8 @@ Add the `data-accordion="true"` attribute to the expandable group to activate th
 ```
 <div class="o-expandable-group o-expandable-group__accordion" >
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 1
             </span>
@@ -614,7 +636,8 @@ Add the `data-accordion="true"` attribute to the expandable group to activate th
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 2
             </span>
@@ -640,7 +663,8 @@ Add the `data-accordion="true"` attribute to the expandable group to activate th
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target" title="Expand content">
+        <button class="o-expandable_header o-expandable_target"
+                title="Expand content">
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 3
             </span>

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -200,9 +200,6 @@ See the 'Form icons' section below for guidance on adding icons to states.
     </div>
 </div>
 
-##NOTE: Fix the button text size
-
-
 ```
 <div class="o-form__input-w-btn">
     <div class="o-form__input-w-btn_input-container">

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -38,8 +38,8 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables are from 18F's
-[US Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss)
+`$color-` variables referenced in comments are from 18F's
+[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 ```
 // .error

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -22,15 +22,13 @@ Capital Framework.
     - [Basic Text Inputs](#basic-text-inputs)
     - [Basic checkboxes](#basic-checkboxes)
     - [Basic radio buttons](#basic-radio-buttons)
-    - [Select box](#select-box)
     - [Input states](#input-states)
 - [Buttons](#buttons)
     - [Input and button](#input-and-button)
     - [Button inside input](#button-inside-input)
 - [Select dropdown](#select-dropdown)
-    - [Required select](#required-select)
+    - [Basic select](#basic-select)
     - [Disabled select](#disabled-select)
-    - [Optional select](#optional-select)
 
 
 ## Variables
@@ -87,21 +85,27 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ## Inputs
 
-Inputs should always be paired with a label for accessibility reasons.
+Inputs should always be paired with a `label` for accessibility reasons.
 
 ### Basic text inputs
 
-<label class="a-label" for="text-input-example"></label>
-<input class="a-text-input" type="text" id="text-input example" value="Lorem ipsum">
+<label class="a-label" for="text-input-example">A text input</label>
+<input class="a-text-input"
+       type="text"
+       id="text-input example"
+       value="Lorem ipsum">
 
-<label class="a-label a-label__heading" for="textarea-example"></label>
+<label class="a-label" for="textarea-example">A textarea input</label>
 <textarea class="a-text-input" id="textarea-example">Lorem Ipsum</textarea>
 
 ```
-<label class="a-label" for="text-input-example"></label>
-<input class="a-text-input" type="text" id="text-input example" value="Lorem ipsum">
+<label class="a-label" for="text-input-example">A text input</label>
+<input class="a-text-input"
+       type="text"
+       id="text-input example"
+       value="Lorem ipsum">
 
-<label class="a-label a-label__heading" for="textarea-example"></label>
+<label class="a-label" for="textarea-example">A textarea input</label>
 <textarea class="a-text-input" id="textarea-example">Lorem Ipsum</textarea>
 ```
 
@@ -133,59 +137,29 @@ Inputs should always be paired with a label for accessibility reasons.
 </div>
 ```
 
-### Select box
-
-<div class="m-form-field__select">
-    <label class="a-label" for="test_select">Label</label>
-    <div class="a-select">
-        <select id="test_select">
-            <option value="option1">Option 1</option>
-            <option value="option2">Option 2</option>
-            <option value="option3">Option 3</option>
-            <option value="option4">Option 4</option>
-        </select>
-    </div>
-</div>
-
-```
-<div class="m-form-field__select">
-    <label class="a-label" for="test_select">Label</label>
-    <div class="a-select">
-        <select id="test_select">
-            <option value="option1">Option 1</option>
-            <option value="option2">Option 2</option>
-            <option value="option3">Option 3</option>
-            <option value="option4">Option 4</option>
-        </select>
-    </div>
-</div>
-```
-
 ### Input states
 
 See the 'Form icons' section below for guidance on adding icons to states.
 
 #### Disabled state
 
-<input class="disabled"
+<input class="a-text-input disabled"
        disabled="true"
        autocomplete="off"
        type="text"
-       value="Validated input"
-       title="Test input">
+       value="Disabled input">
 
 ```
-<input class="disabled"
+<input class="a-text-input disabled"
        disabled="true"
        autocomplete="off"
        type="text"
-       value="Validated input"
-       title="Test input">
+       value="Disabled input">
 ```
 
 ### Inline Form Validation
 
-<div class="m-field m-field__error">
+<div class="m-form-field m-form-field__error">
     <label class="a-label__heading" for="form-input-error">Label</label>
     <input class="a-text-input a-text-input__error"
            type="text"
@@ -212,40 +186,6 @@ See the 'Form icons' section below for guidance on adding icons to states.
     </div>
 </div>
 ```
-
-#### Error icon
-
-- The icon must be placed directly after the form input in the markup and the input must use the 'error' class.
-- For invalid fields only use the alert role to call attention to fields that need immediate attention: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
-
-<input class="error" type="text" value="Invalid input" title="Test input">
-<span class="cf-form_input-icon cf-icon cf-icon-delete-round" role="alert"></span>
-
-```
-<input class="error" type="text" value="Invalid input" title="Test input">
-<span class="cf-form_input-icon cf-icon cf-icon-delete-round" role="alert"></span>
-```
-
-#### Warning icon
-
-<input class="warning" type="text" value="Invalid input" title="Test input">
-<span class="cf-form_input-icon cf-icon cf-icon-error-round" role="alert"></span>
-
-```
-<input class="warning" type="text" value="Invalid input" title="Test input">
-<span class="cf-form_input-icon cf-icon cf-icon-error-round" role="alert"></span>
-```
-
-#### Success icon
-
-<input class="success" type="text" value="Validated input" title="Test input">
-<span class="cf-form_input-icon cf-icon cf-icon-approved-round"></span>
-
-```
-<input class="success" type="text" value="Validated input" title="Test input">
-<span class="cf-form_input-icon cf-icon cf-icon-approved-round"></span>
-```
-
 
 ## Buttons
 
@@ -253,17 +193,20 @@ See the 'Form icons' section below for guidance on adding icons to states.
 
 <div class="o-form__input-w-btn">
     <div class="o-form__input-w-btn_input-container">
-        <input type="text" title="Test input">
+        <input class="a-text-input" type="text" title="Test input">
     </div>
     <div class="o-form__input-w-btn_btn-container">
         <button class="a-btn">Search</button>
     </div>
 </div>
 
+##NOTE: Fix the button text size
+
+
 ```
 <div class="o-form__input-w-btn">
     <div class="o-form__input-w-btn_input-container">
-        <input type="text" title="Test input">
+        <input class="a-text-input" type="text" title="Test input">
     </div>
     <div class="o-form__input-w-btn_btn-container">
         <button class="a-btn">Search</button>
@@ -277,7 +220,9 @@ See the 'Form icons' section below for guidance on adding icons to states.
 
 <div class="m-btn-inside-input">
     <input type="text"
-        value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable."
+        value="This is some really long text to make sure that the button
+               doesn't overlap the content in such a way that this input
+               becomes unusable."
         title="Test input"
         class="a-text-input">
     <button class="a-btn a-btn__link">
@@ -292,7 +237,9 @@ See the 'Form icons' section below for guidance on adding icons to states.
     <div class="o-form__input-w-btn_input-container">
         <div class="m-btn-inside-input">
             <input type="text"
-                value="This is some really long text to make sure that the button doesn't overlap the content in such a way that this input becomes unusable."
+                value="This is some really long text to make sure that the
+                       button doesn't overlap the content in such a way
+                       that this input becomes unusable."
                 title="Test input"
                 class="a-text-input">
             <button class="a-btn a-btn__link">
@@ -309,15 +256,12 @@ See the 'Form icons' section below for guidance on adding icons to states.
 
 ## Select dropdown
 
-### Required select
+### Basic select
 
-<div class="form-l_col form-l_col-1">
-    <label class="form-label-header"
-           for="select_example">
-            Required select example
-    </label>
-    <div class="m-select">
-        <select id="select_example" required>
+<div class="m-form-field__select">
+    <label class="a-label" for="test_select">Label</label>
+    <div class="a-select">
+        <select id="test_select">
             <option value="option1">Option 1</option>
             <option value="option2">Option 2</option>
             <option value="option3">Option 3</option>
@@ -327,13 +271,10 @@ See the 'Form icons' section below for guidance on adding icons to states.
 </div>
 
 ```
-<div class="form-l_col form-l_col-1">
-    <label class="form-label-header"
-           for="select_example">
-            Required select example
-    </label>
-    <div class="m-select">
-        <select id="select_example" required>
+<div class="m-form-field__select">
+    <label class="a-label" for="test_select">Label</label>
+    <div class="a-select">
+        <select id="test_select">
             <option value="option1">Option 1</option>
             <option value="option2">Option 2</option>
             <option value="option3">Option 3</option>
@@ -345,13 +286,10 @@ See the 'Form icons' section below for guidance on adding icons to states.
 
 ### Disabled select
 
-<div class="form-l_col form-l_col-1">
-    <label class="form-label-header"
-           for="select_example__disabled">
-            Disabled select example
-    </label>
-    <div class="m-select">
-        <select id="select_example__disabled" disabled>
+<div class="m-form-field__select">
+    <label class="a-label" for="test_select__disabled">Label</label>
+    <div class="a-select">
+        <select id="test_select__disabled" disabled>
             <option value="option1">Option 1</option>
             <option value="option2">Option 2</option>
             <option value="option3">Option 3</option>
@@ -361,51 +299,10 @@ See the 'Form icons' section below for guidance on adding icons to states.
 </div>
 
 ```
-<div class="form-l_col form-l_col-1">
-    <label class="form-label-header"
-           for="select_example__disabled">
-            Disabled select example
-    </label>
-    <div class="m-select">
-        <select id="select_example__disabled" disabled>
-            <option value="option1">Option 1</option>
-            <option value="option2">Option 2</option>
-            <option value="option3">Option 3</option>
-            <option value="option4">Option 4</option>
-        </select>
-    </div>
-</div>
-```
-
-### Optional select
-
-<div class="form-l_col form-l_col-1">
-    <label class="form-label-header"
-           for="select_example__optional">
-            Optional select example
-            <span class="micro-copy">&nbsp;(Optional)</span>
-    </label>
-    <div class="m-select">
-        <select id="select_example__optional">
-            <option value="" disabled selected>Please select</option>
-            <option value="option1">Option 1</option>
-            <option value="option2">Option 2</option>
-            <option value="option3">Option 3</option>
-            <option value="option4">Option 4</option>
-        </select>
-    </div>
-</div>
-
-```
-<div class="form-l_col form-l_col-1">
-    <label class="form-label-header"
-           for="select_example__optional">
-            Optional select example
-            <span class="micro-copy">&nbsp;(Optional)</span>
-    </label>
-    <div class="m-select">
-        <select id="select_example__optional">
-            <option value="" disabled selected>Please select</option>
+<div class="m-form-field__select">
+    <label class="a-label" for="test_select__disabled">Label</label>
+    <div class="a-select">
+        <select id="test_select__disabled" disabled>
             <option value="option1">Option 1</option>
             <option value="option2">Option 2</option>
             <option value="option3">Option 3</option>

--- a/src/cf-icons/usage.md
+++ b/src/cf-icons/usage.md
@@ -1,5 +1,6 @@
 The cf-icon component provides the custom icon font for Capital Framework.
-This component can be used by itself, but is designed to work with Capital Framework.
+This component can be used by itself, but is designed to work with Capital
+Framework.
 
 > NOTE: If you use `cf-icons.less` directly,
   be sure to run the file through
@@ -43,10 +44,11 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ## The basics
 
-The cf-icon-prefix class applies all shared icon styles including the font family.
-By default, this class will be named `cf-icon` but it can be changed in the settings.
-All icons must use three classes, one for the base class, one to select the
-desired icon, and one for the chosen pseudo-element. For example:
+The cf-icon-prefix class applies all shared icon styles including the font
+family. By default, this class will be named `cf-icon` but it can be changed
+in the settings. All icons must use three classes, one for the base class,
+one to select the desired icon, and one for the chosen pseudo-element.
+For example:
 
 ```
 <span class="cf-icon
@@ -54,11 +56,11 @@ desired icon, and one for the chosen pseudo-element. For example:
              cf-icon__before"></span>
 ```
 
-It's preferred to combine the icon classes with an existing element, but if it's
-necessary to use an empty element, please use the `span` element instead of the `i`
-element. This avoids font family cascading conflicts when using an italic webfont
-on `i` elements and then another font for the icons.
-Note that this issue only pops up in older versions of Internet Explorer.
+It's preferred to combine the icon classes with an existing element, but if
+it's necessary to use an empty element, please use the `span` element instead
+of the `i` element. This avoids font family cascading conflicts when using an
+italic webfont on `i` elements and then another font for the icons.
+_Note that this issue only pops up in older versions of Internet Explorer._
 
 
 ## Helpers
@@ -146,8 +148,8 @@ MIT Licensed by Font Awesome
 .@{cf-icon-prefix}__rotate-90  { .cf-icon__rotate(90deg, 1);  }
 ```
 
-First parameter is `@degrees`.
-Second parameter is `@rotation`.
+- First parameter is `@degrees`.
+- Second parameter is `@rotation`.
 
 #### Icon flip mixin
 
@@ -156,9 +158,9 @@ Second parameter is `@rotation`.
 .@{cf-icon-prefix}__flip-vertical   { .cf-icon__flip(1, -1, 2); }
 ```
 
-First parameter is for number of horizontal flips
-Second parameter is for number of vertical flips
-Third parameter is for rotation
+- First parameter is for number of horizontal flips.
+- Second parameter is for number of vertical flips
+- Third parameter is for rotation.
 
 ### Modified icons
 
@@ -174,7 +176,8 @@ MIT Licensed by Font Awesome
 <span class="cf-icon
              cf-icon-update
              cf-icon__before
-             cf-icon__border"></span>```
+             cf-icon__border"></span>
+```
 
 Border color set by `@cf-icon-border-color`
 
@@ -204,7 +207,8 @@ Border color set by `@cf-icon-border-color`
 <span class="cf-icon
              cf-icon-update
              cf-icon__before
-             cf-icon__rotate-270"></span>```
+             cf-icon__rotate-270"></span>
+```
 
 #### Flipped icons
 
@@ -260,27 +264,6 @@ MIT Licensed by Font Awesome
              cf-icon-update
              cf-icon__before
              cf-icon__pulse"></span>
-```
-
-#### Flipped icons
-
-<span class="cf-icon
-             cf-icon-phone
-             cf-icon__before
-             cf-icon__flip-horizontal"></span>
-<span class="cf-icon
-             cf-icon-phone
-             cf-icon__before
-             cf-icon__flip-vertical"></span>
-```
-<span class="cf-icon
-             cf-icon-phone
-             cf-icon__before
-             cf-icon__flip-horizontal"></span>
-<span class="cf-icon
-             cf-icon-phone
-             cf-icon__before
-             cf-icon__flip-vertical"></span>
 ```
 
 

--- a/src/cf-icons/usage.md
+++ b/src/cf-icons/usage.md
@@ -44,11 +44,11 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ## The basics
 
-The cf-icon-prefix class applies all shared icon styles including the font
-family. By default, this class will be named `cf-icon` but it can be changed
-in the settings. All icons must use three classes, one for the base class,
-one to select the desired icon, and one for the chosen pseudo-element.
-For example:
+The class defined by the @cf-icon-prefix variable applies all shared icon
+styles including the font family. By default, this class will be named
+`cf-icon` but it can be changed in the settings. All icons must use three
+classes, one for the base class, one to select the desired icon, and one
+for the chosen pseudo-element. For example:
 
 ```
 <span class="cf-icon
@@ -159,7 +159,7 @@ MIT Licensed by Font Awesome
 ```
 
 - First parameter is for number of horizontal flips.
-- Second parameter is for number of vertical flips
+- Second parameter is for number of vertical flips.
 - Third parameter is for rotation.
 
 ### Modified icons

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -1548,7 +1548,7 @@ as it's unlikely that the Pacific Blue will have accessible contrast
 with a non-white (or light gray) background.
 
 <section class="m-hero m-hero__overlay"
-         style="background-image: url('http://files.consumerfinance.gov/f/images/PC_hero.original.jpg')">
+         style="background-image: url('https://s3.amazonaws.com/files.consumerfinance.gov/f/images/PC_hero.original.jpg')">
     <div class="m-hero_wrapper wrapper">
         <div class="m-hero_text">
             <h1 class="m-hero_heading">Hero title</h1>
@@ -1560,7 +1560,7 @@ with a non-white (or light gray) background.
         </div>
         <div class="m-hero_image-wrapper">
             <div class="m-hero_image"
-                 style="background-image: url('http://files.consumerfinance.gov/f/images/pc_mobile_1.original.jpg')">
+                 style="background-image: url('https://s3.amazonaws.com/files.consumerfinance.gov/f/images/pc_mobile_1.original.jpg')">
             </div>
         </div>
     </div>
@@ -1568,7 +1568,7 @@ with a non-white (or light gray) background.
 
 ```
 <section class="m-hero m-hero__overlay"
-         style="background-image: url('http://files.consumerfinance.gov/f/images/PC_hero.original.jpg')">
+         style="background-image: url('https://s3.amazonaws.com/files.consumerfinance.gov/f/images/PC_hero.original.jpg')">
     <div class="m-hero_wrapper wrapper">
         <div class="m-hero_text">
             <h1 class="m-hero_heading">Hero title</h1>
@@ -1580,7 +1580,7 @@ with a non-white (or light gray) background.
         </div>
         <div class="m-hero_image-wrapper">
             <div class="m-hero_image"
-                 style="background-image: url('http://files.consumerfinance.gov/f/images/pc_mobile_1.original.jpg')">
+                 style="background-image: url('https://s3.amazonaws.com/files.consumerfinance.gov/f/images/pc_mobile_1.original.jpg')">
             </div>
         </div>
     </div>

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -335,12 +335,12 @@ For example `.content-l_col-1-2` has different divider needs than
 `.content-l_col-1-3` because they may break to single columns at different
 breakpoints.
 
-Dividers use absolute positioning relative to the `.content-l` element and
-depend on `.content-l` using `position: relative;`. This allows vertical
-dividers to span the height of the tallest column. Just be aware that if you
-have more than one row of columns, and each row has columns of different
-widths, the borders will cause unwanted overlapping since they will span the
-height of the entire `.content-l` element.
+Dividers use absolute positioning relative to the `.content-l` element
+and depend on `.content-l` using `position: relative;`.
+This allows vertical dividers to span the height of the tallest column.
+Just be aware that if you have more than one row of columns,
+and each row has columns of different widths, the borders will cause unwanted
+overlapping since they will span the height of the entire `.content-l` element.
 
 <div class="content-l content-l__large-gutters">
     <div class="content-l_col content-l_col-1-2">
@@ -413,9 +413,10 @@ A 1 pixel edge to edge bar that can divide content.
 
 Standard layout for the main content area and sidebar.
 
-By default `.content_main` and `.content_sidebar` stack vertically. When using
-the modifiers described below to create columns, the columns will remain
-stacked for smaller screens and then convert to to columns at `801px`.
+By default `.content_main` and `.content_sidebar` stack vertically.
+When using the modifiers described below to create columns,
+the columns will remain stacked for smaller screens and then convert to to
+columns at `801px`.
 
 `.content_bar` must come after `.content_hero` (if it exists) but before
 `.content_wrapper`.
@@ -1505,7 +1506,7 @@ height. The image should be `195px` in height to conform to this standard.
         </div>
         <div class="m-hero_image-wrapper">
             <div class="m-hero_image"
-                 style="background-image: url('http://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')">
+                 style="background-image: url('https://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')">
             </div>
         </div>
     </div>
@@ -1527,7 +1528,7 @@ height. The image should be `195px` in height to conform to this standard.
         </div>
         <div class="m-hero_image-wrapper">
             <div class="m-hero_image"
-                 style="background-image: url('http://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')">
+                 style="background-image: url('https://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')">
             </div>
         </div>
     </div>
@@ -1541,9 +1542,10 @@ so they don't have to be included in this repo._
 
 ### Hero with photograph
 
-The text overlays the photograph at larger screen sizes. It's best to avoid a
-non-button call to action in these, as it's unlikely that the Pacific Blue will
-have accessible contrast with a non-white (or light gray) background.
+The text overlays the photograph at larger screen sizes.
+It's best to avoid a non-button call to action in these,
+as it's unlikely that the Pacific Blue will have accessible contrast
+with a non-white (or light gray) background.
 
 <section class="m-hero m-hero__overlay"
          style="background-image: url('http://files.consumerfinance.gov/f/images/PC_hero.original.jpg')">

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -64,8 +64,8 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables are from 18F's
-[US Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss)
+`$color-` variables referenced in comments are from 18F's
+[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 ```
 // .block

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -331,15 +331,16 @@ Adds dividers between specified `.content-l_col-X-X` classes.
 
 Layout dividers work in conjunction with `.content-l_col-X-X` elements and have
 specific needs depending on which column element variant they are attached to.
-For example `.content-l_col-1-2` has different divider needs than `.content-l_col-1-3`
-because they may break to single columns at different breakpoints.
+For example `.content-l_col-1-2` has different divider needs than
+`.content-l_col-1-3` because they may break to single columns at different
+breakpoints.
 
-Dividers use absolute positioning relative to the .content-l element and depend
-on `.content-l` using `position: relative;`.
-This allows vertical dividers to span the height of the tallest column.
-Just be aware that if you have more than one row of columns,
-and each row has columns of different widths, the borders will cause unwanted
-overlapping since they will span the height of the entire .content-l element.
+Dividers use absolute positioning relative to the `.content-l` element and
+depend on `.content-l` using `position: relative;`. This allows vertical
+dividers to span the height of the tallest column. Just be aware that if you
+have more than one row of columns, and each row has columns of different
+widths, the borders will cause unwanted overlapping since they will span the
+height of the entire `.content-l` element.
 
 <div class="content-l content-l__large-gutters">
     <div class="content-l_col content-l_col-1-2">
@@ -412,12 +413,15 @@ A 1 pixel edge to edge bar that can divide content.
 
 Standard layout for the main content area and sidebar.
 
-By default `.content_main` and `.content_sidebar` stack vertically.
-When using the modifiers described below to create columns,
-the columns will remain stacked for smaller screens and then convert to to columns at 801px.
+By default `.content_main` and `.content_sidebar` stack vertically. When using
+the modifiers described below to create columns, the columns will remain
+stacked for smaller screens and then convert to to columns at `801px`.
 
-`.content_bar` must come after `.content_hero` (if it exists) but before `.content_wrapper`.
-Inline styling is for demonstration purposes only; do not include it in your markup.
+`.content_bar` must come after `.content_hero` (if it exists) but before
+`.content_wrapper`.
+
+_Inline styling is for demonstration purposes only; do not include it in your
+markup._
 
 <main class="content" role="main">
     <section class="content_hero" style="background: #E3E4E5">
@@ -454,10 +458,11 @@ Inline styling is for demonstration purposes only; do not include it in your mar
 
 ## Left-hand navigation layout
 
-Add a class of `.content__L-R` to `main.content` to determine the width ratio of `.content_main` and `.content_sidebar`,
-where 'L' is the left-hand item and 'R' is the right-hand item.
-The two common configurations are 1-3 (sidebar on the left, content on the right, in a ratio of 1:3)
-and 2-1 (content on the left, sidebar on the right, in a ratio of 2:1).
+Add a class of `.content__L-R` to `main.content` to determine the width ratio
+of `.content_main` and `.content_sidebar`, where 'L' is the left-hand item and
+'R' is the right-hand item. The two common configurations are `1-3` (sidebar on
+the left, content on the right, in a ratio of 1:3) and `2-1` (content on the
+left, sidebar on the right, in a ratio of 2:1).
 
 It is assumed that the content is wider than the sidebar.
 
@@ -512,13 +517,16 @@ It is assumed that the content is wider than the sidebar.
 
 ## Right-hand sidebar layout
 
-Add a class of `.content__L-R` to `main.content` to determine the width ratio of `.content_main` and `.content_sidebar`,
-where 'L' is the left-hand item and 'R' is the right-hand item.
-The two common configurations are 1-3 (sidebar on the left, content on the right, in a ratio of 1:3)
-and 2-1 (content on the left, sidebar on the right, in a ratio of 2:1).
+Add a class of `.content__L-R` to `main.content` to determine the width ratio
+of `.content_main` and `.content_sidebar`, where 'L' is the left-hand item and
+'R' is the right-hand item. The two common configurations are `1-3` (sidebar
+on the left, content on the right, in a ratio of 1:3) and `2-1` (content on the
+left, sidebar on the right, in a ratio of 2:1).
+
 It is assumed that the content is wider than the sidebar.
 
-Inline styling is for demonstration purposes only; do not include it in your markup.
+_Inline styling is for demonstration purposes only; do not include it in your
+markup._
 
 <main class="content content__2-1" role="main">
     <div class="content_bar"></div>
@@ -574,7 +582,8 @@ Inline styling is for demonstration purposes only; do not include it in your mar
 Add a class of `.content_main__narrow` to `.content_main` to get a one-column
 (in a 12-column grid) gutter on the right side.
 
-Inline styling is for demonstration purposes only; do not include it in your markup.
+_Inline styling is for demonstration purposes only; do not include it in your
+markup._
 
 <main class="content content__2-1" role="main">
     <div class="content_bar"></div>
@@ -627,7 +636,8 @@ Inline styling is for demonstration purposes only; do not include it in your mar
 
 ## Flush bottom modifier
 
-Add a class of `.content__flush-bottom` to `.content_main` or content_sidebar to remove bottom padding.
+Add a class of `.content__flush-bottom` to `.content_main` or
+`.content_sidebar` to remove bottom padding.
 
 <main class="content content__1-3" role="main">
     <div class="content_bar"></div>
@@ -684,9 +694,9 @@ Add a class of `.content__flush-bottom` to `.content_main` or content_sidebar to
 
 ## Flush top modifier (only on small screens)
 
-Add a class of `.content__flush-top-on-small` to `.content_main` or `.content_sidebar`
-to remove top padding on small screens only.
-'Small' screens in this case refers to the breakpoint where `.content_main` and
+Add a class of `.content__flush-top-on-small` to `.content_main` or
+`.content_sidebar` to remove top `padding` on small screens only. 'Small'
+screens in this case refers to the breakpoint where `.content_main` and
 `.content_sidebar` single column layout.
 
 <main class="content content__1-3" role="main">
@@ -728,9 +738,10 @@ to remove top padding on small screens only.
 
 ## Flush all modifier (only on small screens)
 
-Add a class of `.content__flush-all-on-small` to `.content_main` or `.content_sidebar`
-to remove all padding and border-based gutters on small screens only.
-'Small' screens in this case refers to the breakpoint where `.content_main` and `.content_sidebar` single column layout.
+Add a class of `.content__flush-all-on-small` to `.content_main` or
+`.content_sidebar` to remove all `padding` and border-based gutters on small
+screens only. 'Small' screens in this case refers to the breakpoint where
+`.content_main` and `.content_sidebar` single column layout.
 
 <main class="content content__1-3" role="main">
     <div class="content_bar"></div>
@@ -771,12 +782,13 @@ to remove all padding and border-based gutters on small screens only.
 
 ## Block
 
-`.block` is a base class with several modifiers that help you separate chunks of
-content via margins, padding, borders, and backgrounds.
+`.block` is a base class with several modifiers that help you separate chunks
+of content via `margin`, `padding`, `border`, and `background`.
 
 ### Standard block example
 
-The standard `.block` class by itself simply adds a margin of twice the gutter width to the top and bottom.
+The standard `.block` class by itself simply adds a `margin` of twice the
+gutter width to the top and bottom.
 
 Main content...
 <div class="block">
@@ -804,7 +816,7 @@ Main content...
 
 ### Border-top modifier
 
-Adds top border to `.block`.
+Adds top `border` to `.block`.
 
 Main content...
 <div class="block block__border-top">
@@ -820,7 +832,7 @@ Main content...
 
 ### Border-right modifier
 
-Adds right border to `.block`.
+Adds right `border` to `.block`.
 
 Main content...
 <div class="block block__border-right">
@@ -836,7 +848,7 @@ Main content...
 
 ### Border-bottom modifier
 
-Adds bottom border to `.block`.
+Adds bottom `border` to `.block`.
 
 Main content...
 <div class="block block__border-bottom">
@@ -852,7 +864,7 @@ Main content...
 
 ### Border-left modifier
 
-Adds left border to `.block`.
+Adds left `border` to `.block`.
 
 Main content...
 <div class="block block__border-left">
@@ -868,7 +880,7 @@ Main content...
 
 ### Border modifier
 
-Adds border on all sides to `.block`.
+Adds `border` on all sides to `.block`.
 
 Main content...
 <div class="block block__border">
@@ -884,7 +896,7 @@ Main content...
 
 ### Flush-top modifier
 
-Removes the top margin from `.block`.
+Removes the top `margin` from `.block`.
 
 Main content...
 <div class="block block__flush-top">
@@ -906,7 +918,7 @@ Main content...
 
 ### Flush-bottom modifier
 
-Removes the bottom margin from `.block`.
+Removes the bottom `margin` from `.block`.
 
 Main content...
 <div class="block block__flush-bottom">
@@ -928,9 +940,9 @@ Main content...
 
 ### Flush-sides modifier
 
-Removes the side margin from `.block`.
+Removes the side `margin` from `.block`.
 Typically used in conjunction with `.block__bg` to create a 'well' whose
-background extends into the left and right gutters. (See below.)
+`background` extends into the left and right gutters. (See below.)
 
 <main class="content content__1-3" role="main">
     <div class="content_wrapper">
@@ -964,7 +976,7 @@ background extends into the left and right gutters. (See below.)
 
 ### Flush modifier
 
-Removes the side, top, and bottom margin from `.block`.
+Removes the side, top, and bottom `margin` from `.block`.
 
 <main class="content content__1-3" role="main">
     <div class="content_wrapper">
@@ -998,8 +1010,8 @@ Removes the side, top, and bottom margin from `.block`.
 
 ### Background modifier
 
-Adds a background color and padding to `.block`.
-Setup for (ems-equivalent) 30px padding on top and 60px on bottom.
+Adds a `background` color and padding to `.block`.
+Setup for (ems-equivalent) `30px` `padding` on top and `60px` on bottom.
 
 Main content...
 <div class="block block__bg">
@@ -1015,7 +1027,8 @@ Main content...
 
 ### Background and flush-sides modifier combo example
 
-This is an example of combining modifiers to get a flush padded bg with a `.block`.
+This is an example of combining modifiers to get a flush `padding` and
+`background` with a `.block`.
 
 <main class="content content__1-3" role="main">
     <div class="content_wrapper">
@@ -1049,8 +1062,8 @@ This is an example of combining modifiers to get a flush padded bg with a `.bloc
 
 ### Padded-top modifier
 
-Breaks top margin into margin & padding. Useful in combination with
-`block__border-top` to add padding between block contents & border.
+Breaks top `margin` into `margin` & `padding`. Useful in combination with
+`block__border-top` to add `padding` between `.block` contents and `border`.
 
 Main content...
 <div class="block block__padded-top block__border-top">
@@ -1068,8 +1081,8 @@ Main content...
 
 ### Padded-bottom modifier
 
-Breaks bottom margin into margin & padding. Useful in combination with
-`block__border-bottom` to add padding between block contents & border.
+Breaks bottom `margin` into `margin` & `padding`. Useful in combination with
+`block__border-bottom` to add `padding` between `.block` contents and `border`.
 
 Main content...
 <div class="block block__padded-bottom block__border-bottom">
@@ -1087,8 +1100,11 @@ Main content...
 
 ### Sub blocks
 
-Useful for when you need some consistent margins between blocks that are nested within other blocks.
-Note that the divs with inline styles are for demonstration purposes only and should not be used in production.
+Useful for when you need some consistent `margin` between `.blocks` that are
+nested within other `.blocks`.
+
+_Note that the `div`s with inline styles are for demonstration purposes only
+and should not be used in production._
 
 <div class="block block__sub">
     <div style="background: #F1F2F2; padding: 8px;">
@@ -1127,8 +1143,11 @@ Note that the divs with inline styles are for demonstration purposes only and sh
 ### Mixing content blocks with content layouts
 
 You can safely combine `.block` with `.content-l_col` to achieve a column-based
-layout at larger screens with no top margins and a vertical layout at smaller screens that do have margins.
-Note that the divs with inline styles are for demonstration purposes only and should not be used in production.
+layout at larger screens with no top `margin` and a vertical layout at smaller
+screens that do have `margins`.
+
+_Note that the `div`s with inline styles are for demonstration purposes only
+and should not be used in production._
 
 <div class="content-l">
     <div class="block content-l_col content-l_col-1-2">
@@ -1169,9 +1188,11 @@ Note that the divs with inline styles are for demonstration purposes only and sh
 
 ## Bleedbar sidebar styling
 
-Simply add class `.content__bleedbar` to `main.content`.
-Only supports sidebars on the right, for now.
-Inline styling is for demonstration purposes only; do not include it in your markup.
+Simply add class `.content__bleedbar` to `main.content`. Only supports
+sidebars on the right, for now.
+
+_Note that inline styling is for demonstration purposes only; do not include
+it in your markup._
 
 <main class="content content__2-1 content__bleedbar" role="main">
     <section class="content_hero" style="background: #E3E4E5">
@@ -1210,8 +1231,9 @@ Inline styling is for demonstration purposes only; do not include it in your mar
 
 ### .wrapper (base)
 
-Turns an element into a cf-grid wrapper at 801px and above.
-Includes some explicit declarations for IE8 due to the fact that it doesn't support media queries.
+Turns an element into a cf-grid wrapper at `801px` and above. Includes some
+explicit declarations for Internet Explorer 8 due to the fact that it doesn't
+support media queries.
 
 <div class="wrapper">
     Wrapper
@@ -1225,12 +1247,12 @@ Includes some explicit declarations for IE8 due to the fact that it doesn't supp
 
 ### Column divider modifiers
 
-cf-grid columns use left and right borders for fixed margins which means it's
+cf-grid columns use left and right `border` for fixed `margin` which means it's
 not possible to set visual left and right borders directly on them.
-Instead we can use the :before pseudo element and position it absolutely.
-The added benefit of doing it this way is that the border spans the entire
-height of the next parent using `position: relative;`.
-This means that the border will always match the height of the tallest column in the row.
+Instead we can use the `:before` pseudo element and position it absolutely.
+The added benefit of doing it this way is that the `border` spans the entire
+height of the next parent using `position: relative;`. This means that the
+`border` will always match the height of the tallest column in the row.
 
 ```less
 .my-column-1-2 {
@@ -1254,115 +1276,217 @@ This means that the border will always match the height of the tallest column in
 
 ## Featured content module
 
-Featured content module, like a hero, consists of headline/text/optional call to action along with a visual. It is intended to be used in a main content column next to a sidebar.
+Featured content module, like a hero, consists of headline/text/optional call
+to action along with a visual. It is intended to be used in a main content
+column next to a sidebar.
 
 Text is full width & displayed above the visual in the default/mobile view.
-At larger screen sizes, the text occupies a fixed portion of the screen (equal to the width of 5 of 12 columns at 701px & 3 of 12 columns at 901px for desktop).
-The visual occupies the remaining space.
-The visual should be 640x360 (16x9 ratio) and resize to fit the height of the FCM with a static width and is anchored left when it becomes too wide for the available space.
+At larger screen sizes, the text occupies a fixed portion of the screen (equal
+to the width of 5 of 12 columns at `701px` & 3 of 12 columns at `901px` for
+desktop). The visual occupies the remaining space. The visual should be
+`640x360` (16x9 ratio) and resize to fit the height of the Featured Content
+Module with a static width and is anchored left when it becomes too wide for
+the available space.
 
 <section class="block block__border block__flush o-featured-content-module">
     <div class="o-featured-content-module_text">
         <div class="category-slug">
-            <span class="o-featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured </div>
+            <span class="o-featured-content-module_icon
+                         cf-icon
+                         cf-icon-speech-bubble"></span>
+            Featured
+        </div>
         <h2>Feature title</h2>
-        <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
-        <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>
+        <p>
+            Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur
+            instructior ex pri. Cu pri inani constituto, cum aeque noster
+            commodo cu.
+        </p>
+        <a class="jump-link jump-link__underline">
+            <span class="jump-link_text">Read more about the feature</span>
+        </a>
     </div>
-    <div class="o-featured-content-module_visual"> <img class="o-featured-content-module_img" src="http://placekitten.com/g/540/270"> </div>
+    <div class="o-featured-content-module_visual">
+        <img class="o-featured-content-module_img"
+             src="http://placekitten.com/g/540/270">
+    </div>
 </section>
 
 ```
 <section class="block block__border block__flush o-featured-content-module">
     <div class="o-featured-content-module_text">
         <div class="category-slug">
-            <span class="o-featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured </div>
+            <span class="o-featured-content-module_icon
+                         cf-icon
+                         cf-icon-speech-bubble"></span>
+            Featured
+        </div>
         <h2>Feature title</h2>
-        <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
-        <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>
+        <p>
+            Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur
+            instructior ex pri. Cu pri inani constituto, cum aeque noster
+            commodo cu.
+        </p>
+        <a class="jump-link jump-link__underline">
+            <span class="jump-link_text">Read more about the feature</span>
+        </a>
     </div>
-    <div class="o-featured-content-module_visual"> <img class="o-featured-content-module_img" src="http://placekitten.com/g/540/270"> </div>
+    <div class="o-featured-content-module_visual">
+        <img class="o-featured-content-module_img"
+             src="http://placekitten.com/g/540/270">
+    </div>
 </section>
 ```
 
 ### Featured content module - Maps
 
-When the featured content module image is a map (or other right-aligned content), the `o-featured-content-module__right` modifier class is added to the `o-featured-content-module` organism. This anchors the image to the right side so that the copyright information is displayed.
+When the featured content module image is a map (or other right-aligned
+content), the `o-featured-content-module__right` modifier class is added to
+the `o-featured-content-module` organism. This anchors the image to the right
+side so that the copyright information is displayed.
 
-<section class="block block__border block__flush o-featured-content-module o-featured-content-module__right">
+<section class="block
+                block__border
+                block__flush
+                o-featured-content-module
+                o-featured-content-module__right">
     <div class="o-featured-content-module_text">
         <div class="category-slug">
-            <span class="o-featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured (Map)</div>
+            <span class="o-featured-content-module_icon
+                         cf-icon
+                         cf-icon-speech-bubble"></span>
+            Featured (Map)
+        </div>
         <h2>Feature title</h2>
-        <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
-        <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>
+        <p>
+            Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur
+            instructior ex pri. Cu pri inani constituto, cum aeque noster
+            commodo cu.
+        </p>
+        <a class="jump-link jump-link__underline">
+            <span class="jump-link_text">Read more about the feature</span>
+        </a>
     </div>
-    <div class="o-featured-content-module_visual"> <img class="o-featured-content-module_img" src="http://placekitten.com/g/540/270"> </div>
+    <div class="o-featured-content-module_visual">
+        <img class="o-featured-content-module_img"
+             src="http://placekitten.com/g/540/270">
+    </div>
 </section>
 
 ```
-<section class="block block__border block__flush o-featured-content-module o-featured-content-module__right">
+<section class="block
+                block__border
+                block__flush
+                o-featured-content-module
+                o-featured-content-module__right">
     <div class="o-featured-content-module_text">
         <div class="category-slug">
-            <span class="o-featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured (Map)</div>
+            <span class="o-featured-content-module_icon
+                         cf-icon
+                         cf-icon-speech-bubble"></span>
+            Featured (Map)
+        </div>
         <h2>Feature title</h2>
-        <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
-        <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>
+        <p>
+            Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur
+            instructior ex pri. Cu pri inani constituto, cum aeque noster
+            commodo cu.
+        </p>
+        <a class="jump-link jump-link__underline">
+            <span class="jump-link_text">Read more about the feature</span>
+        </a>
     </div>
-    <div class="o-featured-content-module_visual"> <img class="o-featured-content-module_img" src="http://placekitten.com/g/540/270"> </div>
+    <div class="o-featured-content-module_visual">
+        <img class="o-featured-content-module_img"
+             src="http://placekitten.com/g/540/270">
+    </div>
 </section>
 ```
 
 ### Featured content module - Videos
 
-When the featured content module image is a video (or other centered content), the `o-featured-content-module__center` modifier class is added to the `o-featured-content-module` organism. This anchors the center of the image to the center of the available space so that the focal point of the video generally remains centered.
+When the featured content module image is a video (or other centered content),
+the `o-featured-content-module__center` modifier class is added to the
+`o-featured-content-module` organism. This anchors the center of the image to
+the center of the available space so that the focal point of the video
+generally remains centered.
 
-<section class="block block__border block__flush o-featured-content-module o-featured-content-module__center">
+<section class="block
+                block__border
+                block__flush
+                o-featured-content-module
+                o-featured-content-module__center">
     <div class="o-featured-content-module_text">
         <div class="category-slug">
-            <span class="o-featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured (Video) </div>
+            <span class="o-featured-content-module_icon
+                         cf-icon
+                         cf-icon-speech-bubble"></span>
+            Featured (Video)
+        </div>
         <h2>Feature title</h2>
-        <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
-        <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>
+        <p>
+            Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur
+            instructior ex pri. Cu pri inani constituto, cum aeque noster
+            commodo cu.
+        </p>
+        <a class="jump-link jump-link__underline">
+            <span class="jump-link_text">Read more about the feature</span>
+        </a>
     </div>
-    <div class="o-featured-content-module_visual"> <img class="o-featured-content-module_img" src="http://placekitten.com/g/540/270"> </div>
+    <div class="o-featured-content-module_visual">
+        <img class="o-featured-content-module_img"
+             src="http://placekitten.com/g/540/270">
+    </div>
 </section>
 
 ```
-<section class="block block__border block__flush o-featured-content-module o-featured-content-module__center">
+<section class="block
+                block__border
+                block__flush
+                o-featured-content-module
+                o-featured-content-module__center">
     <div class="o-featured-content-module_text">
         <div class="category-slug">
-            <span class="o-featured-content-module_icon cf-icon cf-icon-speech-bubble">
-</span> Featured (Video) </div>
+            <span class="o-featured-content-module_icon
+                         cf-icon
+                         cf-icon-speech-bubble"></span>
+            Featured (Video)
+        </div>
         <h2>Feature title</h2>
-        <p>Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur instructior ex pri. Cu pri inani constituto, cum aeque noster commodo cu.</p>
-        <a class="jump-link jump-link__underline"> <span class="jump-link_text">Read more about the feature</span> </a>
+        <p>
+            Lorem ipsum dolor sit amet, ei ius adhuc inani iudico, labitur
+            instructior ex pri. Cu pri inani constituto, cum aeque noster
+            commodo cu.
+        </p>
+        <a class="jump-link jump-link__underline">
+            <span class="jump-link_text">Read more about the feature</span>
+        </a>
     </div>
-    <div class="o-featured-content-module_visual"> <img class="o-featured-content-module_img" src="http://placekitten.com/g/540/270"> </div>
+    <div class="o-featured-content-module_visual">
+        <img class="o-featured-content-module_img"
+             src="http://placekitten.com/g/540/270">
+    </div>
 </section>
 ```
 
 
 ## Heroes
 
-A hero consists of a headline, a small amount of additional text,
-an optional call to action, and an illustration.
-Its background color is flush with the sides of the screen, and the content is centered with wrapper classes.
+A hero consists of a headline, a small amount of additional text, an optional
+call to action, and an illustration. Its background color is flush with the
+sides of the screen, and the content is centered with wrapper classes.
 
-The illustration can be customized by setting the `background-image` property on the `.m-hero_image` element.
+The illustration can be customized by setting the `background-image` property
+on the `.m-hero_image` element.
 
-On small screens (or where media queries are not supported),
-the text spans the full width of the `.m-hero_wrapper` and the illustration is displayed underneath.
+On small screens (or where media queries are not supported), the text spans the
+full width of the `.m-hero_wrapper` and the illustration is displayed underneath.
 
-For larger screen sizes, media queries are used to position the illustration to the right of the text.
+For larger screen sizes, media queries are used to position the illustration to
+the right of the text.
 
-At the grid's maximum width and above, the hero should not exceed 285px in height.
-The image should be 195px in height to conform to this standard.
+At the grid's maximum width and above, the hero should not exceed `285px` in
+height. The image should be `195px` in height to conform to this standard.
 
 ### Standard hero with illustration
 
@@ -1371,15 +1495,18 @@ The image should be 195px in height to conform to this standard.
         <div class="m-hero_text">
             <h1 class="m-hero_heading">Hero title</h1>
             <p class="m-hero_subhead">
-                Hero text goes here. This paragraph has a recommended maximum length of 185 characters.
-                This paragraph has a recommended maximum length of 185 characters.
+                Hero text goes here. This paragraph has a recommended maximum
+                length of 185 characters. This paragraph has a recommended
+                maximum length of 185 characters.
             </p>
             <a class="m-hero_cta" href="#">
                 Call to action
             </a>
         </div>
         <div class="m-hero_image-wrapper">
-            <div class="m-hero_image" style="background-image: url('http://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')"></div>
+            <div class="m-hero_image"
+                 style="background-image: url('http://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')">
+            </div>
         </div>
     </div>
 </section>
@@ -1390,33 +1517,33 @@ The image should be 195px in height to conform to this standard.
         <div class="m-hero_text">
             <h1 class="m-hero_heading">Hero title</h1>
             <p class="m-hero_subhead">
-                Hero text goes here. This paragraph has a recommended maximum length of 185 characters.
-                This paragraph has a recommended maximum length of 185 characters.
+                Hero text goes here. This paragraph has a recommended maximum
+                length of 185 characters. This paragraph has a recommended
+                maximum length of 185 characters.
             </p>
             <a class="m-hero_cta" href="#">
                 Call to action
             </a>
         </div>
         <div class="m-hero_image-wrapper">
-            <div class="m-hero_image" style="background-image: url('http://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')"></div>
+            <div class="m-hero_image"
+                 style="background-image: url('http://www.consumerfinance.gov/static/fin-ed-resources/static/img/parents_hero_760x390.png')">
+            </div>
         </div>
     </div>
 </section>
 ```
 
 ### Hero with bleeding illustration
-{: class="u-mt30"}
 
 _Examples coming when we can hotlink to the images live on our server,
 so they don't have to be included in this repo._
 
 ### Hero with photograph
-{: class="u-mt30"}
 
-The text overlays the photograph at larger screen sizes.
-It's best to avoid a non-button call to action in these,
-as it's unlikely that the Pacific Blue will have accessible contrast with a
-non-white (or light gray) background.
+The text overlays the photograph at larger screen sizes. It's best to avoid a
+non-button call to action in these, as it's unlikely that the Pacific Blue will
+have accessible contrast with a non-white (or light gray) background.
 
 <section class="m-hero m-hero__overlay"
          style="background-image: url('http://files.consumerfinance.gov/f/images/PC_hero.original.jpg')">
@@ -1424,12 +1551,36 @@ non-white (or light gray) background.
         <div class="m-hero_text">
             <h1 class="m-hero_heading">Hero title</h1>
             <p class="m-hero_subhead">
-                Hero text goes here. This paragraph has a recommended maximum length of 185 characters.
-                This example paragraph is 151 characters long.
+                Hero text goes here. This paragraph has a recommended maximum
+                length of 185 characters. This example paragraph is 151
+                characters long.
             </p>
         </div>
         <div class="m-hero_image-wrapper">
-            <div class="m-hero_image" style="background-image: url('http://files.consumerfinance.gov/f/images/pc_mobile_1.original.jpg')"></div>
+            <div class="m-hero_image"
+                 style="background-image: url('http://files.consumerfinance.gov/f/images/pc_mobile_1.original.jpg')">
+            </div>
         </div>
     </div>
 </section>
+
+```
+<section class="m-hero m-hero__overlay"
+         style="background-image: url('http://files.consumerfinance.gov/f/images/PC_hero.original.jpg')">
+    <div class="m-hero_wrapper wrapper">
+        <div class="m-hero_text">
+            <h1 class="m-hero_heading">Hero title</h1>
+            <p class="m-hero_subhead">
+                Hero text goes here. This paragraph has a recommended maximum
+                length of 185 characters. This example paragraph is 151
+                characters long.
+            </p>
+        </div>
+        <div class="m-hero_image-wrapper">
+            <div class="m-hero_image"
+                 style="background-image: url('http://files.consumerfinance.gov/f/images/pc_mobile_1.original.jpg')">
+            </div>
+        </div>
+    </div>
+</section>
+```

--- a/src/cf-pagination/usage.md
+++ b/src/cf-pagination/usage.md
@@ -27,8 +27,8 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables are from 18F's
-[US Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss)
+`$color-` variables referenced in comments are from 18F's
+[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 ```
 // text color
@@ -149,4 +149,4 @@ To enable the component to jump directly to the paginated content, place
 ## Responsive behavior
 
 - `@bp-xs-max`: On small screens, the pagination links display next to each
-other, stacked on top of the form.
+  other, stacked on top of the form.

--- a/src/cf-pagination/usage.md
+++ b/src/cf-pagination/usage.md
@@ -1,6 +1,8 @@
-The cf-pagination component provides a responsive approach to multipage page navigation for Capital Framework.
+The cf-pagination component provides a responsive approach to multipage page
+navigation for Capital Framework.
 
-[`cf-core`](../cf-core), [`cf-buttons`](../cf-buttons), and [`cf-icons`](../cf-icons) components are all dependencies of this component."
+[`cf-core`](../cf-core), [`cf-buttons`](../cf-buttons), and
+[`cf-icons`](../cf-icons) components are all dependencies of this component.
 
 > NOTE: If you use `cf-pagination.less` directly,
   be sure to run the file through
@@ -20,52 +22,55 @@ The cf-pagination component provides a responsive approach to multipage page nav
 
 ## Variables
 
-Theme variables for setting the color and sizes throughout the project. Overwrite them in your own project by duplicating the variable `@key: value`.
+Theme variables for setting the color and sizes throughout the project.
+Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables are from 18F's [US Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss)
+`$color-` variables are from 18F's
+[US Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss)
 
-Pagination text color.
 ```
+// text color
 @pagination-text-color: #757575; // $color-gray-medium
-```
 
-Pagination form background color.
-```
-@pagination-bg-color: #f1f1f1; // $color-gray-lightest
+// form background color
+@pagination-bg-color:   #f1f1f1; // $color-gray-lightest
 ```
 
 ### Sizing variables
 
-The font size of pagination text.
 ```
-@pagination-font-size__px:          16px;
+// pagination text
+@pagination-font-size__px: 16px;
 ```
 
 
 ## Default pagination
 
-Default pagination consists of "Previous" and "Next" links, styled as buttons, and an inline form (input, submit button) that allows users to navigate to specific pages by number.
+Default pagination consists of "Previous" and "Next" links, styled as buttons,
+and an inline form (input, submit button) that allows users to navigate to
+specific pages by number.
 
-To enable the component to jump directly to the paginated content, place `#pagination_content` directly above your paginated content.
+To enable the component to jump directly to the paginated content, place
+`#pagination_content` directly above your paginated content.
 
 <div id="pagination_content"></div>
 
 <!-- Paginated content here -->
 
 <nav class="m-pagination" role="navigation" aria-label="Pagination">
-    <a class="btn
+    <a class="a-btn
               m-pagination_btn-prev"
        href="?page=1#pagination_content">
-        <span class="cf-icon cf-icon-left btn_icon__left "></span>
+        <span class="cf-icon cf-icon-left cf-icon__before"></span>
         Newer
     </a>
-    <a class="btn
-             m-pagination_btn-next"
+    <a class="a-btn
+              m-pagination_btn-next"
        href="?page=3#pagination_content">
         Older
-        <span class="cf-icon cf-icon-right btn_icon__right"></span>
+        <span class="cf-icon cf-icon-right cf-icon__after"></span>
     </a>
     <form class="m-pagination_form"
             action="#pagination_content">
@@ -86,9 +91,9 @@ To enable the component to jump directly to the paginated content, place `#pagin
                      value="2">
             of 149
         </label>
-        <button class="btn
-                         btn__link
-                         m-pagination_submit-btn"
+        <button class="a-btn
+                       a-btn__link
+                       m-pagination_submit-btn"
                   id="m-pagination_submit-btn"
                   type="submit">Go</button>
     </form>
@@ -100,17 +105,17 @@ To enable the component to jump directly to the paginated content, place `#pagin
 <!-- Paginated content here -->
 
 <nav class="m-pagination" role="navigation" aria-label="Pagination">
-    <a class="btn
+    <a class="a-btn
               m-pagination_btn-prev"
        href="?page=1#pagination_content">
-        <span class="cf-icon cf-icon-left btn_icon__left "></span>
+        <span class="cf-icon cf-icon-left cf-icon__before"></span>
         Newer
     </a>
-    <a class="btn
-             m-pagination_btn-next"
+    <a class="a-btn
+              m-pagination_btn-next"
        href="?page=3#pagination_content">
         Older
-        <span class="cf-icon cf-icon-right btn_icon__right"></span>
+        <span class="cf-icon cf-icon-right cf-icon__after"></span>
     </a>
     <form class="m-pagination_form"
             action="#pagination_content">
@@ -131,8 +136,8 @@ To enable the component to jump directly to the paginated content, place `#pagin
                      value="2">
             of 149
         </label>
-        <button class="btn
-                       btn__link
+        <button class="a-btn
+                       a-btn__link
                        m-pagination_submit-btn"
                   id="m-pagination_submit-btn"
                   type="submit">Go</button>
@@ -143,4 +148,5 @@ To enable the component to jump directly to the paginated content, place `#pagin
 
 ## Responsive behavior
 
-- `@bp-xs-max`: On small screens, the pagination links display next to each other, stacked on top of the form.
+- `@bp-xs-max`: On small screens, the pagination links display next to each
+other, stacked on top of the form.

--- a/src/cf-tables/usage.md
+++ b/src/cf-tables/usage.md
@@ -35,8 +35,8 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables are from 18F's
-[US Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages/assets/_scss/core/_variables.scss)
+`$color-` variables referenced in comments are from 18F's
+[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 ```
 @table-cell-bg:              #ffffff; // $color-white
@@ -119,8 +119,8 @@ not visible on small screens.
 
 ## Right-aligned cells
 
-The use of the `.o-table_cell__right-align` class on a `td` aligns the text right
-- see the third column above.
+The use of the `.o-table_cell__right-align` class on a `td` aligns the text
+right - see the third column above.
 
 <table class="o-table o-table__stack-on-small">
     <thead>
@@ -664,7 +664,7 @@ The `.o-table-wrapper__scrolling` class must be added to the parent element of
 the `table` (by adding a wrapping `div`, in most cases). The `table` element
 does not need additional markup in this case. The "Comparative with horizontal
 scroll" style also adds striped rows to the table contained within, and remains
-striped on small screens (unlike the `o-table__striped `class, below).
+striped on small screens (unlike the `o-table__striped` class, below).
 
 <div class="o-table o-table-wrapper__scrolling">
     <table>

--- a/src/cf-tables/usage.md
+++ b/src/cf-tables/usage.md
@@ -47,8 +47,8 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ## Striped tables
 
-The `.o-table__striped` class adds stripes to the table rows.
-This striping is not visible on small screens.
+The `.o-table__striped` class adds stripes to the `table` rows. This striping is
+not visible on small screens.
 
 <table class="o-table o-table__striped">
     <thead>
@@ -119,8 +119,8 @@ This striping is not visible on small screens.
 
 ## Right-aligned cells
 
-The use of the `.o-table_cell__right-align` class on a TD aligns the text right -
-see the third column above.
+The use of the `.o-table_cell__right-align` class on a `td` aligns the text right
+- see the third column above.
 
 <table class="o-table o-table__stack-on-small">
     <thead>
@@ -171,8 +171,8 @@ see the third column above.
 
 ## Tables with row links
 
-The `.o-table_cell__row-links` class is added to a table to enable highlighting and hyperlinking rows which
-contain links.
+The `.o-table_cell__row-links` class is added to a `table` to enable
+highlighting and hyperlinking rows which contain links.
 
 <table class="o-table o-table__row-links">
     <thead>
@@ -231,8 +231,8 @@ The cf-tables module also includes a sortable table utility.
 
 ### Making a table sortable
 
-By adding the `.o-table__sortable` class to a table, the table becomes sortable.
-To allow the table to be sorted by a column, add a button to the `th` of the
+By adding the `.o-table__sortable` class to a `table`, the `table` becomes sortable.
+To allow the `table` to be sorted by a column, add a `button` to the `th` of the
 column like so:
 
 ```
@@ -241,19 +241,18 @@ column like so:
 </button>
 ```
 
-The use of a button helps address certain accessibility concerns.
+The use of a `button` helps address certain accessibility concerns.
 
 ### Sorting type
 
-To sort properly, the type of the data can be specified.
-By default, the column's values will be sorted as string values.
-However, the column can be specifically sorted by number values
-(in which case, the cell's contents are stripped of non-numeric characters,
-then sorted by the resulting number).
-To see an example, the sample table later in this document sorts the "Distance"
-column by number value.
+To sort properly, the type of the `data` can be specified. By default, the
+column's values will be sorted as `string` values. However, the column can be
+specifically sorted by `number` values (in which case, the cell's contents are
+stripped of non-numeric characters, then sorted by the resulting number). To
+see an example, the sample table later in this document sorts the "Distance"
+column by `number` value.
 
-To sort by number value, add the `data-sort_type="number"` attribute
+To sort by `number` value, add the `data-sort_type="number"` attribute
 to the sorting button:
 
 ```
@@ -501,12 +500,15 @@ highest to lowest)
 
 ### Responsive stacked table
 
-The `.o-table__stack-on-small` class adds the "stacked" table style for small screens.
-_Please note that tables are not responsive without adding one of the small screen classes._
+The `.o-table__stack-on-small` class adds the "stacked" `table` style for small
+screens.
 
-Also note that the `data-label` attribute is used to label each entry in a table
-for small screen responsive views.
-Always include the `data-label` attribute for each cell.
+_Please note that tables are not responsive without adding one of the small
+screen classes._
+
+_Also note that the `data-label` attribute is used to label each entry in a `table`
+for small screen responsive views. Always include the `data-label` attribute for
+each cell._
 
 <table class="o-table o-table__stack-on-small">
     <thead>
@@ -576,13 +578,15 @@ Always include the `data-label` attribute for each cell.
 
 ### Responsive stacked table with header
 
-The `.o-table__entry-header-on-small` class in addition to `.o-table__stack-on-small` class
-changes the first column to be styled as an entry header.
-This style requires both classes be added.
-_Note that tables are not responsive without adding one of the small screen classes._
+The `.o-table__entry-header-on-small` class in addition to
+`.o-table__stack-on-small` class changes the first column to be styled as an
+entry header. This style requires both classes be added.
 
-Also note that the `data-label` attribute is used to label each entry.
-Always include the `data-label` attribute for each cell.
+_Note that tables are not responsive without adding one of the small screen
+classes._
+
+_Also note that the `data-label` attribute is used to label each entry.
+Always include the `data-label` attribute for each cell._
 
 <table class="o-table
               o-table__stack-on-small
@@ -657,11 +661,10 @@ Always include the `data-label` attribute for each cell.
 ### Responsive table - horizontal scroll variation
 
 The `.o-table-wrapper__scrolling` class must be added to the parent element of
-the table (by adding a wrapping `<div>`, in most cases).
-The `<table>` element does not need additional markup in this case.
-The "Comparative with horizontal scroll" style also adds striped rows
-to the table contained within, and
-remains striped on small screens (unlike the `o-table__striped `class, below).
+the `table` (by adding a wrapping `div`, in most cases). The `table` element
+does not need additional markup in this case. The "Comparative with horizontal
+scroll" style also adds striped rows to the table contained within, and remains
+striped on small screens (unlike the `o-table__striped `class, below).
 
 <div class="o-table o-table-wrapper__scrolling">
     <table>

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -5,7 +5,13 @@ The [`cf-core`](../core) component is a dependency of this component
 and has more basic typography patterns.
 
 
-## Contents
+> NOTE: If you use `cf-typography.less` directly,
+  be sure to run the file through
+  [Autoprefixer](https://github.com/postcss/autoprefixer),
+  or your compiled Capital Framework CSS will
+  not work perfectly in older browsers.
+
+## Table of cntents
 
 - [Variables](#variables)
     - [Color variables](#color-variables)
@@ -28,17 +34,11 @@ and has more basic typography patterns.
     - [Date](#date)
     - [Pull quote](#pull-quote)
 
-> NOTE: If you use `cf-typography.less` directly,
-  be sure to run the file through
-  [Autoprefixer](https://github.com/postcss/autoprefixer),
-  or your compiled Capital Framework CSS will
-  not work perfectly in older browsers.
-
 
 ## Variables
 
-Theme variables for setting the color and sizes.
-Overwrite them in your own project by duplicating the variable `@key: value`.
+Theme variables for setting the color and sizes. Overwrite them in your own
+project by duplicating the variable `@key: value`.
 
 ### Color variables
 
@@ -97,9 +97,10 @@ Default color variables are from 18F's
 
 ### Heading with icon
 
-The heading with icon is typically used for listing categories in a meta header.
-Since categories can be repetitive, we suggest placing a label with `.u-visually-hidden`
-prior to the headings to add more context for screen readers (see Meta Header below).
+The heading with icon is typically used for listing categories in a meta
+header. Since categories can be repetitive, we suggest placing a label with
+`.u-visually-hidden` prior to the headings to add more context for screen
+readers (see Meta Header below).
 
 <a href="#" class="a-heading a-heading__icon">
     <span class="cf-icon cf-icon-dialogue"></span>
@@ -134,10 +135,11 @@ prior to the headings to add more context for screen readers (see Meta Header be
 
 ### Meta header
 
-Note that the example shows `.m-meta-header_left` using the `.a-heading__icon` pattern
-and `.meta-header_right` using the `.a-date` pattern but you could use other patterns in place of them.
-Or you can even swap them so that date is
-attached to `.meta-header_left` and `.category-slug` is attached to `.meta-header_right`.
+Note that the example shows `.m-meta-header_left` using the `.a-heading__icon`
+pattern and `.meta-header_right` using the `.a-date` pattern but you could use
+other patterns in place of them. Or you can even swap them so that date is
+attached to `.meta-header_left` and `.category-slug` is attached to
+`.meta-header_right`.
 
 #### Default meta header
 
@@ -166,8 +168,11 @@ attached to `.meta-header_left` and `.category-slug` is attached to `.meta-heade
 
 ### Links with icons
 
-- Styles to enable adding an icon to a link and preventing the link's underline from extending under the icon.
-- For the underlined icon prevention to work, you must wrap the link text with a `span.icon-link_text`. There can be no whitespace between the text and the opening and closing span tags.
+- Styles to enable adding an icon to a link and preventing the link's underline
+  from extending under the icon.
+- For the underlined icon prevention to work, you must wrap the link text with
+  a `span.icon-link_text`. There can be no whitespace between the text and the
+  opening and closing `span` tags.
 
 #### Default pattern
 
@@ -239,8 +244,10 @@ attached to `.meta-header_left` and `.category-slug` is attached to `.meta-heade
 
 #### Links with icons on the left
 
-- Simply add the `.icon-link__before` modifier to place the icon before the link text.
-- You can omit the `span.icon-link_text` wrapper if you do not need an underline on a particular link.
+- Simply add the `.icon-link__before` modifier to place the icon before the
+  link text.
+- You can omit the `span.icon-link_text` wrapper if you do not need an
+  underline on a particular link.
 
 <a class="a-link a-link__icon
           cf-icon
@@ -278,7 +285,9 @@ attached to `.meta-header_left` and `.category-slug` is attached to `.meta-heade
 
 #### Non-wrapping icon links
 
-- Warning: Icons added to inline links can sometimes break onto the next line. If you want to prevent this, you can add the `__no-wrap` modifier to `.icon-link`.
+- Warning: Icons added to inline links can sometimes break onto the next line.
+  If you want to prevent this, you can add the `__no-wrap` modifier to
+  `.icon-link`.
 
 
 For more information, email
@@ -330,7 +339,7 @@ For more information, email
 
 #### Jump link with large link modifier
 
-The large jump link has an 18px font-size, compared to the default of 16px.
+The large jump link has an `18px` `font-size`, compared to the default of `16px`.
 
 <a class="a-link
           a-link__jump
@@ -406,8 +415,8 @@ Jump links can also have icons before the text, like icon links.
 
 ### Block link
 
-The block link class converts a standard inline link
-to a block-level element with padding, background, and borders.
+The block link class converts a standard inline link to a block-level element
+with `padding`, `background`, and `border`.
 
 It is primarily used within a max-width `@bp-xs-max` media query
 (see `.link__jump` and `.list__links`).
@@ -513,8 +522,9 @@ A modifier for the list to make it show items horizontally.
 
 ### Link list modifier
 
-The link list modifier is intended to be used for lists where each item is a link.
-It converts to a finger-friendly link with a large tap area on smaller screens.
+The link list modifier is intended to be used for lists where each item is a
+link. It converts to a finger-friendly link with a large tap area on smaller
+screens.
 
 <ul class="m-list m-list__links">
     <li class="m-list_item">
@@ -546,8 +556,8 @@ It converts to a finger-friendly link with a large tap area on smaller screens.
 
 ### Micro copy
 
-The `.a-micro-copy` class is good for highlighting small pieces of text, typically
-legal copy.
+The `.a-micro-copy` class is good for highlighting small pieces of text,
+typically legal copy.
 
 <p class="a-micro-copy">
     Lorem ipsum dolor sit amet
@@ -573,10 +583,10 @@ legal copy.
 
 ### Pull quote
 
-Use a pull quote to highlight excerpts from the current work.
-This is not to be confused with `blockquote` which quotes from an external work.
-Since a pull quote is an excerpt and repeats content from the article
-you should use the `aside` element.
+Use a pull quote to highlight excerpts from the current work. This is not to
+be confused with `blockquote` which quotes from an external work. Since a pull
+quote is an excerpt and repeats content from the article you should use the
+`aside` element.
 
 #### Default pull quote
 

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -583,10 +583,10 @@ typically legal copy.
 
 ### Pull quote
 
-Use a pull quote to highlight excerpts from the current work. This is not to
-be confused with `blockquote` which quotes from an external work. Since a pull
-quote is an excerpt and repeats content from the article you should use the
-`aside` element.
+Use a pull quote to highlight excerpts from the current work.
+This is not to be confused with `blockquote` which quotes from an external
+work. Since a pull quote is an excerpt and repeats content from the article
+you should use the `aside` element.
 
 #### Default pull quote
 

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -11,7 +11,7 @@ and has more basic typography patterns.
   or your compiled Capital Framework CSS will
   not work perfectly in older browsers.
 
-## Table of cntents
+## Table of contents
 
 - [Variables](#variables)
     - [Color variables](#color-variables)
@@ -42,8 +42,8 @@ project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Default color variables are from 18F's
-[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/18f-pages-staging/src/stylesheets/core/_variables.scss).
+`$color-` variables referenced in comments are from 18F's
+[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 ```
 // Headings


### PR DESCRIPTION
Updated all the docs to work with the v4 release, including some janitorial cleanup.

## Removals

- References to form icons. They were removed in v4.

## Changes

- Fixed max line lengths throughout the docs.
- Fixed intro formatting throughout the docs.

## Testing

- ~~checkout branch and run `npm install` or `npm update` if you've already worked on the `gh-pages` branch~~
- ~~run `npm run build && npm start` to start the local environment~~
- ~~navigate through the project and check the examples for each component.~~
- ¯\_(ツ)_/¯  Because the docs are in the project and install the components through NPM, it's not possible without copying each doc to your `npm_modules` location.

## Review

- @Scotchester 
- @anselmbradford 
- @cfarm 
- @contolini 

## Notes

- There's still more that could be done but this was a quick pass to get the site up and working again.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
