### PR TITLE
Fix codefences in core's usage doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-core** [PATCH] Fixed line breaks before codefences
 
 ### Removed
-- 
+-
 
 ## 4.1.0 - 2017-03-02
 

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -128,6 +128,7 @@ them to the corresponding min or max width media query.
 ```
 
 Ex.
+
 ```
 .respond-to-min( @bp-sm-min, {
     .title {
@@ -154,6 +155,7 @@ converts them to the corresponding min and max media query.
 ```
 
 Ex.
+
 ```
 .respond-to-range( @bp-sm-min, @bp-sm-max, {
     .title {
@@ -235,11 +237,13 @@ Hide an element when JavaScript isn't available. Requires a small script in the
 `<head>` of your `<html>` document that removes a `.no-js` class.
 
 1. Add a `no-js` class added to the `html`
+
   ```
   <html class="no-js">
   ```
 
 2. Add a script to remove the `no-js` class after confirming JavaScript is available
+
   ```
   <script>
       // Confirm availability of JavaScript and remove no-js class from html
@@ -249,6 +253,7 @@ Hide an element when JavaScript isn't available. Requires a small script in the
   ```
 
 3. Add the utility class to the element you want to hide
+
   ```
   <div class="u-js-only"></div>
   ```


### PR DESCRIPTION
With the change to Markdown processing, some codefences aren't being created. The ticks are printed to the page and code is rendered as normal text.

https://github.com/cfpb/capital-framework/pull/454#pullrequestreview-24584398

## Changes

-  Fixed line breaks before codefences

## Testing

- run `npm run cf-link`
- While testing #454 in a different directory, run `npm link cf-core`
- run `npm start`
- Check cf-core usage files and double check the codefences referenced above are outputting correctly.

## Review

- @Scotchester 
- @ascott1
- @contolini 

## Screenshots

![screen shot 2017-03-03 at 1 22 28 pm](https://cloud.githubusercontent.com/assets/1280430/23565749/76fdc906-0014-11e7-854d-a22af7504c7a.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
