### PR TITLE
Allow users to sym-link a locally installed Capital Framework repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 
+## Added
+
+- Added NPM linking and unlinking scripts
+
 ## Removed
 
 - Removed the Gulp usage task and related packages

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "start": "parallelshell 'bundle exec jekyll serve --watch --baseurl ''' 'gulp watch'",
     "build": "gulp build",
-    "cf-link": "npm link cf-core && npm link cf-buttons && npm link cf-pagination && npm link cf-typography && npm link cf-layout && npm link cf-icons && npm link cf-tables && npm link cf-expandables"
+    "cf-link": "node scripts/npm/link",
+    "cf-unlink": "node scripts/npm/unlink"
   },
   "license": "CC0",
   "keywords": [
@@ -33,6 +34,7 @@
   },
   "devDependencies": {
     "browser-sync": "2.13.0",
+    "child-process-promise": "2.2.0",
     "del": "2.2.0",
     "fs": "0.0.2",
     "gulp": "3.9.1",

--- a/scripts/npm/link/index.js
+++ b/scripts/npm/link/index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var path = require( 'path' );
+var fs = require( 'fs' );
+var componentsDir = path.join( __dirname, '..', '..', '..', 'components' );
+var components = getDirectories( componentsDir );
+var exec = require( 'child-process-promise' ).exec;
+
+function getDirectories( srcpath ) {
+  return fs.readdirSync( srcpath ).filter( function( file ) {
+    return fs.statSync( path.join( srcpath, file ) ).isDirectory();
+  } );
+}
+
+function npmLink( component ) {
+  exec( 'npm link ' + component,
+    function( err, out ) {
+      if ( err instanceof Error ) {
+        throw err;
+      }
+
+      process.stdout.write( out );
+    } );
+}
+
+for ( var i = 0, l = components.length; i < l; i++ ) {
+  npmLink( components[i] );
+}

--- a/scripts/npm/unlink/index.js
+++ b/scripts/npm/unlink/index.js
@@ -12,7 +12,7 @@ function getDirectories( srcpath ) {
   } );
 }
 
-function npmLink( component ) {
+function npmUnlink( component ) {
   exec( 'npm unlink ' + component + ' && npm install ' + component,
     function( err, out ) {
       if ( err instanceof Error ) {
@@ -24,5 +24,5 @@ function npmLink( component ) {
 }
 
 for ( var i = 0, l = components.length; i < l; i++ ) {
-  npmLink( components[i] );
+  npmUnlink( components[i] );
 }

--- a/scripts/npm/unlink/index.js
+++ b/scripts/npm/unlink/index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var path = require( 'path' );
+var fs = require( 'fs' );
+var componentsDir = path.join( __dirname, '..', '..', '..', 'components' );
+var components = getDirectories( componentsDir );
+var exec = require( 'child-process-promise' ).exec;
+
+function getDirectories( srcpath ) {
+  return fs.readdirSync( srcpath ).filter( function( file ) {
+    return fs.statSync( path.join( srcpath, file ) ).isDirectory();
+  } );
+}
+
+function npmLink( component ) {
+  exec( 'npm unlink ' + component + ' && npm install ' + component,
+    function( err, out ) {
+      if ( err instanceof Error ) {
+        throw err;
+      }
+
+      process.stdout.write( out );
+    } );
+}
+
+for ( var i = 0, l = components.length; i < l; i++ ) {
+  npmLink( components[i] );
+}


### PR DESCRIPTION
When working on multiple Capital Framework components, it's difficult to sym-link every component. We already have a NPM link script in the canary branch, this does the other half of NPM linking.

## Additions

- NPM linking and unlinking scripts

## Testing

- To symlink your local CF repo, you'll need to have a duplicate CF repo (I call my cf-site and only have the gh-pages branch available).
- In your main CF repo, run `npm run cf-link` to create the locally available packages
- In your gh-pages specific repo, run `npm run cf-link` to create the second half of the links. 
- In your gh-pages specific repo, run `npm run build && npm start` (~~this may fail due to some variable changes that are outstanding~~ __merged and rebased__). You should now be able to make changes to the usage docs or the source code in the main repo, and see them in the secondary repo. Note that you'll probably need to kick off the appropriate build task in the secondary repo, as browserSync doesn't watch the `node_modules` directory for changes. For usage files it's `gulp copy:usage` for styles it's `gulp styles`.
- To reset your secondary repo, run `npm run cf-unlink`. This will remove the sym-link and reinstall the latest version of each component on NPM.

## Review

- @Scotchester 
- @contolini 
- @anselmbradford 

## Notes

Should we move the Gulp scripts to this `/scripts` directory so it matches the main canary branch?

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
