### PR TITLE
Update Travis script to print which components are published to npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **capital-framework:** [PATCH] Updated Travis script to print which components are published to npm
 
 ### Removed
-- 
+-
 
 ## 4.1.2 - 2017-03-31
 

--- a/scripts/npm/prepublish/index.js
+++ b/scripts/npm/prepublish/index.js
@@ -215,6 +215,7 @@ function publishComponents(result) {
   var components = componentsToPublish.map(function(component) {
     return component.name;
   });
+  util.printLn.info('Publishing ' + components.join(', ') + ' to npm...');
   return Promise.all(components.map(util.publish));
 }
 


### PR DESCRIPTION
Travis prints all sorts of messages during its npm prepublish script but is silent during its publishing step.

See: https://[mm]/cfpb/pl/tyawf6wfhtbedguopa7w39nawy

## Additions

- Print the name of every component that's about to be published.

## Review

- @Scotchester 
- @jimmynotjim 