### PR TITLE
Call for Discussion - Fix a bug when animating icons within a button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ are 100% width when stacked on small screens
 
 ### Changed
 - **capital-framework:** [PATCH] Updated Travis script to print which components are published to npm
+- **cf-buttons:** [MINOR] Fixed a bug when animating icons within a button. Changes button icon markup,
+  see usage doc for details
 
 ### Removed
 -

--- a/src/cf-buttons/src/atoms/buttons-with-icons.less
+++ b/src/cf-buttons/src/atoms/buttons-with-icons.less
@@ -2,31 +2,30 @@
 
 // Icon locations
 
-.a-btn__icon-on-left:before {
+.a-btn_icon__on-left {
     padding-right: unit( 10.5px / @btn-font-size, em );
     border-right: 1px solid mix( @btn-bg, @btn-text, 50% );
     margin-right: unit( 7px / @btn-font-size, em );
 }
 
-.a-btn__icon-on-right:after  {
+.a-btn_icon__on-right {
     padding-left: unit( 10.5px / @btn-font-size, em );
     border-left: 1px solid mix( @btn-bg, @btn-text, 50% );
     margin-left: unit( 7px / @btn-font-size, em );
 }
 
 
-.a-btn__icon-on-left:before,
-.a-btn__icon-on-right:after {
-    .a-btn__secondary& {
+.a-btn_icon {
+    .a-btn__secondary & {
         border-color: mix( @btn__secondary-bg, @btn__secondary-text, 50% );
     }
 
-    .a-btn__warning& {
+    .a-btn__warning & {
         border-color: mix( @btn__warning-bg, @btn__warning-text, 50% );
     }
 
-    .a-btn__disabled&,
-    .a-btn[disabled]& {
+    .a-btn__disabled &,
+    .a-btn[disabled] & {
         border-color: mix( @btn__disabled-bg, @btn__disabled-text, 50% );
     }
 }

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -583,7 +583,7 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 
 #### Button with an animated icon
 
-<button class="a-btn">
+<button class="a-btn a-btn__disabled">
     Submit your complaint
     <span class="a-btn_icon
                  a-btn_icon__on-right

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -431,150 +431,178 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 
 #### Button with icon on the left
 
-<button class="a-btn
-               a-btn__icon-on-left
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button>
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__secondary
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__secondary">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button> - Secondary button
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__warning
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__warning">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button> - Warning button
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__disabled
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__disabled">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button> - Disabled button
 
 ```
-<button class="a-btn
-               a-btn__icon-on-left
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button>
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__secondary
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
+<button class="a-btn a-btn__secondary">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
   Close
 </button> - Secondary button
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__warning
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
+<button class="a-btn a-btn__warning">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
   Close
 </button> - Warning button
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__disabled
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
+<button class="a-btn a-btn__disabled">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
   Close
 </button> - Disabled button
 ```
 
 #### Button with icon on the right
 
-<button class="a-btn
-               a-btn__icon-on-right
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button>
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__secondary
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__secondary">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Secondary button
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__warning
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__warning">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Warning button
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__disabled
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__disabled">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Disabled button
 
 ```
-<button class="a-btn
-               a-btn__icon-on-right
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button>
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__secondary
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__secondary">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Secondary button
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__warning
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__warning">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Warning button
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__disabled
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__disabled">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Disabled button
+```
+
+#### Button with an animated icon
+
+<button class="a-btn">
+    Submit your complaint
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-update
+                 cf-icon__spin"></span>
+</button>
+
+```
+<button class="a-btn">
+    Submit your complaint
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-update
+                 cf-icon__spin"></span>
+</button>
 ```
 
 ## Molecules


### PR DESCRIPTION
Currently, if you add the `cf-icon__spin` class to an icon within a button, it spins everything, the padding, border, and margin due to those properties being attached to the icon pseudo element. 

![screen shot 2017-04-03 at 1 11 59 pm](https://cloud.githubusercontent.com/assets/1280430/24666027/c562561a-1924-11e7-9692-39c9bb5dcd71.png)

In order to spin the icon without spinning the other properties, we have to separate the two. This change won't affect icon usage anywhere else, only this specific case (meaning we would only need the empty spans here).

## Changes

- Updated buttons with icons styles and markup pattern

## Testing

1. Clone the this branch to ~/Downloads/capital-framework.
2. cd ~/Downloads/capital-framework and npm install && npm run cf-link
3. Clone the gh-pages branch to ~/Downloads/cf-site.
4. cd ~/Downloads/cf-site and npm install && npm run cf-link && npm run build && npm start
5. Navigate to http://localhost:3000/components/cf-buttons/#button-with-an-animated-icon

## Review

- @caheberer
- @Scotchester 
- @cfarm 
- @contolini 
- @anselmbradford 
- Anyone else that has had/has an opinion about icons and atomic organization

## Screenshots

![screen shot 2017-04-03 at 4 47 08 pm](https://cloud.githubusercontent.com/assets/1280430/24666045/d2267250-1924-11e7-8c9c-fc82e2ff5d20.png)

## Notes

- As much as I dislike using an empty element, and I was part of the push to remove them for icons, this is a bit of a complex situation. @Scotchester and I discussed the option to remove the border for animated icons and offsetting the rotation to account for the padding to avoid using an empty span. While short term I agree this keep things tidy and keeps from having a breaking change, long term it restricts the possibilities for animating the icon, especially when we move to svg icons and the possibilities for animation are opened up.
- This also brings up a good question of should we be animating icons within buttons and what are the use cases beyond loading data.
- See https://github.com/cfpb/design-manual/issues/227 for back discussion.

## Todos

- I didn't include a changelog entry because this is technically a breaking change. At the same time, none of v4 has been implemented yet, so I don't know that there's a risk of marking it as a minor change.
- Discuss the speed of the spin animation, it's really slow. @caheberer, do you have input on this?
- Move to SVG icons. If you look closely you can see the icon wobbles a bit due to the fact that it's a font icon and has a slightly offset baseline.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
