### PR TITLE
Fix: Stacking tables on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-tables:** [PATCH] Added rule to .o-table__stack-on-small so that TD and TH elements
+are 100% width when stacked on small screens
 
 ### Changed
 - **capital-framework:** [PATCH] Updated Travis script to print which components are published to npm

--- a/src/cf-tables/src/cf-tables.less
+++ b/src/cf-tables/src/cf-tables.less
@@ -127,6 +127,11 @@
             display: block;
         }
 
+        th,
+        td {
+            width: 100%;
+        }
+
         & > thead {
           display: none
         }


### PR DESCRIPTION
This PR adds a small fix for stacking tables on small screens. Byspecifying width: 100%, we override a fixed width for the column, forcing the columns to use the full width available when stacked.

## Additions
- LESS in the `.o-table__stack-on-small` that adds `width: 100%` to `th, td`

## Review
- @Scotchester or perhaps @jimmynotjim ?

## Screenshots
### Before
_(Second and third columns are width: 20%)_

<img width="285" alt="screen shot 2017-04-11 at 2 03 21 pm" src="https://cloud.githubusercontent.com/assets/1490703/25198311/0fff0a28-2515-11e7-8909-1687615db75b.png">

### After
_(Second and third columns are width: 20%)_

<img width="409" alt="screen shot 2017-04-18 at 2 25 22 pm" src="https://cloud.githubusercontent.com/assets/1490703/25198318/15ec1a66-2515-11e7-8ca1-11cf5efa4cf0.png">

## Notes
- I have a slight concern that this rule might not be specific enough to override other CSS rules. However, it's internally consistent in `capital-framework`. That is, if you put a class like `u-w25pct` on a cell, it will be overridden by this rule on small screens.

## Checklist
* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
