### PR TITLE
Fix a spacing bug in the expandable content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-expandables:** [PATCH] Fixed bottom spacing of the expandable content
 
 ### Removed
-- 
+-
 
 ## 4.2.0 - 2017-04-21
 

--- a/src/cf-expandables/package.json
+++ b/src/cf-expandables/package.json
@@ -10,7 +10,7 @@
     "test": "case $(pwd) in */capital-framework/src/*) cd ../.. && npm test;; esac"
   },
   "dependencies": {
-    "atomic-component": "1.2.2",
+    "atomic-component": "1.3.0",
     "cf-core": "^4.0.0",
     "cf-icons": "^4.0.0",
     "classlist-polyfill": "1.0.3"

--- a/src/cf-expandables/src/cf-expandables.less
+++ b/src/cf-expandables/src/cf-expandables.less
@@ -160,13 +160,13 @@
 
         .o-expandable_header {
             padding: unit( 10px / @base-font-size-px, em )
-                     unit( 16px / @base-font-size-px, em );
+                     unit( 15px / @base-font-size-px, em );
         }
 
         .o-expandable_content {
             // Margin collapsing trick for more consistent bottom padding.
             margin: 0
-                    unit( 16px / @base-font-size-px, em )
+                    unit( 15px / @base-font-size-px, em )
                     unit( 22px / @base-font-size-px, em );
 
             // The divider between _header and _content.
@@ -174,11 +174,11 @@
                 content: '';
                 display: block;
                 border-bottom: 1px solid @expandable__padded-divider;
-                margin-bottom: unit( 16px / @base-font-size-px, em );
+                margin-bottom: unit( 15px / @base-font-size-px, em );
             }
 
             &:after {
-                margin-bottom: unit( 16px / @base-font-size-px, em );
+                margin-bottom: unit( 15px / @base-font-size-px, em );
                 width: 100%;
             }
         }

--- a/src/cf-expandables/src/cf-expandables.less
+++ b/src/cf-expandables/src/cf-expandables.less
@@ -98,7 +98,6 @@
         &__expanded {
             max-height: 1000px;
         }
-
     }
 
     //
@@ -174,9 +173,13 @@
             &:before {
                 content: '';
                 display: block;
-                height: 1px;
+                border-bottom: 1px solid @expandable__padded-divider;
                 margin-bottom: unit( 16px / @base-font-size-px, em );
-                background: @expandable__padded-divider;
+            }
+
+            &:after {
+                margin-bottom: unit( 16px / @base-font-size-px, em );
+                width: 100%;
             }
         }
     }


### PR DESCRIPTION
The expandable content has been missing it's bottom spacing for some time. Half the problem is that we started removing bottom margin from the `p:last-child` a while back. This fixes that particular issue by adding bottom margin to the `:after` pseudo element. Margin bottom is used over padding because it naturally collapses when the height is set to 0. 

Fixes #462 

## Changes

- Added spacing to the bottom of expandable content

## Testing

- While this fixes the css side of things, there's also a bug in the expandable js code that is being addressed at https://github.com/cfpb/AtomicComponent/pull/4. If you want to test this you'll need to symlink the atomic component into your cf-expandables directory. Follow these steps

- cd to this repo, checkout this branch, and make the link connections
  ```
  cd ~./[Your Repos Directory]/capital-framework/
  git checkout bugfix/expandable-spacing
  npm run cf-link // this makes each component available to other projects and installs the latest from Atomic Component
  ```
- In another tab cd to the CF sandbox
  ```
  cd ~./[Your Repos Directory]/capital-framework-sandbox
  npm run cf-link // this connects each of the local CF components to this repo
  npm run build // build the stuff
  npm start // start the server
  ```
- navigate to `http://localhost:3000/components/cf-expandables/`

## Review

- @sebworks
- @scotchester
- @contolini

## Screenshots

![screen shot 2017-04-21 at 2 45 49 pm](https://cloud.githubusercontent.com/assets/1280430/25293598/3a4a79a6-26a1-11e7-9a9a-c5c5c07aa3be.png)

## Notes

- ~~Sorry testing is such a bear, if you'd rather, feel free to wait till the AtomicComponent has been fixed to review this PR.~~ The corresponding AtomicComponent release has been published. Testing instructions have been updated.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
