### PR TITLE
CF Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,14 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- **cf-tables:** [PATCH] Added rule to .o-table__stack-on-small so that TD and TH elements
+- **cf-tables:** Added rule to .o-table__stack-on-small so that TD and TH elements
 are 100% width when stacked on small screens
 
 ### Changed
-- **capital-framework:** [PATCH] Updated Travis script to print which components are published to npm
-- **cf-buttons:** [MINOR] Fixed a bug when animating icons within a button. Changes button icon markup,
+- **capital-framework:** Updated Travis script to print which components are published to npm
+- **cf-buttons:** Fixed a bug when animating icons within a button. Changes button icon markup,
   see usage doc for details
 
-### Removed
--
 
 ## 4.1.2 - 2017-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ are 100% width when stacked on small screens
 
 ### Changed
 - **capital-framework:** [PATCH] Updated Travis script to print which components are published to npm
+- **cf-buttons:** [MINOR] Fixed a bug when animating icons within a button. Changes button icon markup,
+  see usage doc for details
 
 ### Removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-tables:** [PATCH] Added rule to .o-table__stack-on-small so that TD and TH elements
+are 100% width when stacked on small screens
 
 ### Changed
 - **capital-framework:** [PATCH] Updated Travis script to print which components are published to npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **capital-framework:** [PATCH] Updated Travis script to print which components are published to npm
 
 ### Removed
-- 
+-
 
 ## 4.1.2 - 2017-03-31
 

--- a/scripts/npm/prepublish/index.js
+++ b/scripts/npm/prepublish/index.js
@@ -215,6 +215,7 @@ function publishComponents(result) {
   var components = componentsToPublish.map(function(component) {
     return component.name;
   });
+  util.printLn.info('Publishing ' + components.join(', ') + ' to npm...');
   return Promise.all(components.map(util.publish));
 }
 

--- a/src/cf-buttons/package.json
+++ b/src/cf-buttons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-buttons",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Capital Framework buttons",
   "less": "src/cf-buttons.less",
   "style": "cf-buttons.css",

--- a/src/cf-buttons/src/atoms/buttons-with-icons.less
+++ b/src/cf-buttons/src/atoms/buttons-with-icons.less
@@ -2,31 +2,30 @@
 
 // Icon locations
 
-.a-btn__icon-on-left:before {
+.a-btn_icon__on-left {
     padding-right: unit( 10.5px / @btn-font-size, em );
     border-right: 1px solid mix( @btn-bg, @btn-text, 50% );
     margin-right: unit( 7px / @btn-font-size, em );
 }
 
-.a-btn__icon-on-right:after  {
+.a-btn_icon__on-right {
     padding-left: unit( 10.5px / @btn-font-size, em );
     border-left: 1px solid mix( @btn-bg, @btn-text, 50% );
     margin-left: unit( 7px / @btn-font-size, em );
 }
 
 
-.a-btn__icon-on-left:before,
-.a-btn__icon-on-right:after {
-    .a-btn__secondary& {
+.a-btn_icon {
+    .a-btn__secondary & {
         border-color: mix( @btn__secondary-bg, @btn__secondary-text, 50% );
     }
 
-    .a-btn__warning& {
+    .a-btn__warning & {
         border-color: mix( @btn__warning-bg, @btn__warning-text, 50% );
     }
 
-    .a-btn__disabled&,
-    .a-btn[disabled]& {
+    .a-btn__disabled &,
+    .a-btn[disabled] & {
         border-color: mix( @btn__disabled-bg, @btn__disabled-text, 50% );
     }
 }

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -431,150 +431,178 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 
 #### Button with icon on the left
 
-<button class="a-btn
-               a-btn__icon-on-left
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button>
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__secondary
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__secondary">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button> - Secondary button
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__warning
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__warning">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button> - Warning button
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__disabled
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__disabled">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button> - Disabled button
 
 ```
-<button class="a-btn
-               a-btn__icon-on-left
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
-  Close
+<button class="a-btn">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
+    Close
 </button>
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__secondary
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
+<button class="a-btn a-btn__secondary">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
   Close
 </button> - Secondary button
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__warning
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
+<button class="a-btn a-btn__warning">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
   Close
 </button> - Warning button
 
-<button class="a-btn
-               a-btn__icon-on-left
-               a-btn__disabled
-               cf-icon
-               cf-icon__before
-               cf-icon-delete">
+<button class="a-btn a-btn__disabled">
+    <span class="a-btn_icon
+                 a-btn_icon__on-left
+                 cf-icon
+                 cf-icon__before
+                 cf-icon-delete"></span>
   Close
 </button> - Disabled button
 ```
 
 #### Button with icon on the right
 
-<button class="a-btn
-               a-btn__icon-on-right
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button>
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__secondary
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__secondary">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Secondary button
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__warning
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__warning">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Warning button
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__disabled
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__disabled">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Disabled button
 
 ```
-<button class="a-btn
-               a-btn__icon-on-right
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button>
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__secondary
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__secondary">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Secondary button
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__warning
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__warning">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Warning button
 
-<button class="a-btn
-               a-btn__icon-on-right
-               a-btn__disabled
-               cf-icon
-               cf-icon__after
-               cf-icon-delete">
-  Close
+<button class="a-btn a-btn__disabled">
+    Close
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-delete"></span>
 </button> - Disabled button
+```
+
+#### Button with an animated icon
+
+<button class="a-btn a-btn__disabled">
+    Submit your complaint
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-update
+                 cf-icon__spin"></span>
+</button>
+
+```
+<button class="a-btn">
+    Submit your complaint
+    <span class="a-btn_icon
+                 a-btn_icon__on-right
+                 cf-icon
+                 cf-icon__after
+                 cf-icon-update
+                 cf-icon__spin"></span>
+</button>
 ```
 
 ## Molecules

--- a/src/cf-tables/package.json
+++ b/src/cf-tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-tables",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Capital Framework tables",
   "main": "src/cf-tables.js",
   "less": "src/cf-tables.less",

--- a/src/cf-tables/src/cf-tables.less
+++ b/src/cf-tables/src/cf-tables.less
@@ -127,6 +127,11 @@
             display: block;
         }
 
+        th,
+        td {
+            width: 100%;
+        }
+
         & > thead {
           display: none
         }


### PR DESCRIPTION
## Updates

### Added
- **cf-tables:** Added rule to .o-table__stack-on-small so that TD and TH elements
are 100% width when stacked on small screens

### Changed
- **capital-framework:** Updated Travis script to print which components are published to npm
- **cf-buttons:** Fixed a bug when animating icons within a button. Changes button icon markup,
  see usage doc for details


## Review

- @cfpb/front-end-team-admin

## I am a bot

After this PR is merged, I will instruct Travis to [automagically](https://github.com/cfpb/capital-framework/tree/master/scripts/npm/prepublish) perform the following steps:

1. Increment Capital Framework's [version](https://github.com/cfpb/capital-framework/blob/canary/package.json#L3) per our [guidelines](https://github.com/cfpb/capital-framework/issues/179).
2. Add a timestamped entry to the [changelog](https://github.com/cfpb/capital-framework/blob/canary/CHANGELOG.md) with the new version and its changes.
3. [Tag](https://github.com/cfpb/capital-framework/tags) the release and push it to GitHub.
4. Publish both [capital-framework](https://www.npmjs.com/package/capital-framework) and any individually updated [components](http://cfpb.github.io/capital-framework/components/) to npm.
5. Update both [canary](https://github.com/cfpb/capital-framework/tree/canary), our development branch, and [master](https://github.com/cfpb/capital-framework/tree/master), our release branch.

If I do something wrong, [blame a human](https://github.com/cfpb/hubot-capital-framework/issues/new).

![kitten gif](http://thecatapi.com/api/images/get?format=src&type=gif)