### PR TITLE
Fix the missing top border in Expandable Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-expandables:** [PATCH] Replaced the missing top border for expandable groups
 
 ### Removed
-- 
+-
 
 ## 4.3.0 - 2017-04-26
 

--- a/src/cf-expandables/src/cf-expandables.less
+++ b/src/cf-expandables/src/cf-expandables.less
@@ -195,6 +195,10 @@
             border-bottom: 1px solid @expandable-group-divider;
             margin-bottom: 0;
             background: @expandable-group-bg;
+
+            &:first-child {
+                border-top: 1px solid @expandable-group-divider;
+            }
         }
 
         .o-expandable_label {


### PR DESCRIPTION
A bug was introduced to Expandable Groups that removed the initial border at the top of the group. This change adds it back in.

## Changes

- Added the top border back to the first child of an expandable group.

## Testing

- Test in the sandbox by following the regular linking, building, serving instructions, check out the expandables page.

## Review

- @Scotchester 
- @sebworks 
- @mistergone 

## Screenshots

![screen shot 2017-04-27 at 4 46 04 pm](https://cloud.githubusercontent.com/assets/1280430/25505888/7c64ff74-2b69-11e7-9e1f-f7404194ea82.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
