### PR TITLE
Fix default super button font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,19 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-buttons:** [PATCH] Fix default font-size for super buttons
 
 ### Removed
-- 
+-
+
 
 ## 4.3.0 - 2017-04-26
 
 ### Changed
-- **cf-layout:** Updated Heros to match latest spec from the Design Manual
+- **cf-layout:** Updated Heroes to match latest spec from the Design Manual
 
 
 ## 4.2.1 - 2017-04-24
@@ -49,7 +50,7 @@ are 100% width when stacked on small screens
 ## 4.1.1 - 2017-03-03
 
 ### Changed
-- **cf-core:** Fixed line breaks before codefences
+- **cf-core:** Fixed line breaks before code fences
 
 
 ## 4.1.0 - 2017-03-02

--- a/src/cf-buttons/src/cf-buttons.less
+++ b/src/cf-buttons/src/cf-buttons.less
@@ -44,7 +44,7 @@
 @btn-v-padding-modifier-ie:     0.8;
 
 // .btn__super
-@btn__super-font-size:          20px;
+@btn__super-font-size:          18px;
 
 
 // Import external dependencies

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -72,7 +72,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 @btn-v-padding-modifier-ie:     0.8;
 
 // .btn__super
-@btn__super-font-size:           20px;
+@btn__super-font-size:          18px;
 ```
 
 ## Atoms
@@ -483,7 +483,7 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
                  cf-icon
                  cf-icon__before
                  cf-icon-delete"></span>
-  Close
+    Close
 </button> - Secondary button
 
 <button class="a-btn a-btn__warning">
@@ -492,7 +492,7 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
                  cf-icon
                  cf-icon__before
                  cf-icon-delete"></span>
-  Close
+    Close
 </button> - Warning button
 
 <button class="a-btn a-btn__disabled">
@@ -501,7 +501,7 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
                  cf-icon
                  cf-icon__before
                  cf-icon-delete"></span>
-  Close
+    Close
 </button> - Disabled button
 ```
 


### PR DESCRIPTION
The default font size for super buttons was out-of-step with [the standard](http://cfpb.github.io/design-manual/page-components/buttons.html#large-primary-button).

## Changes

- Changes the value of `@btn__super-font-size` to 18px.

## Review

- @jimmynotjim 
- @ajbush
- @caheberer

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
