### PR TITLE
Fix the documentation for form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-forms:** [PATCH] Fixed the documentation for form fields
 
 ### Removed
-- 
+-
 
 ## 4.3.1 - 2017-04-28
 

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -139,13 +139,13 @@ Inputs should always be paired with a `label` for accessibility reasons.
 
 ### Basic checkboxes
 
-<div class="m-form-field__checkbox">
+<div class="m-form-field m-form-field__checkbox">
     <input class="a-checkbox" type="checkbox" id="test_checkbox">
     <label class="a-label" for="test_checkbox">Label</label>
 </div>
 
 ```
-<div class="m-form-field__checkbox">
+<div class="m-form-field m-form-field__checkbox">
     <input class="a-checkbox" type="checkbox" id="test_checkbox">
     <label class="a-label" for="test_checkbox">Label</label>
 </div>
@@ -153,13 +153,13 @@ Inputs should always be paired with a `label` for accessibility reasons.
 
 ### Basic radio buttons
 
-<div class="m-form-field__radio">
+<div class="m-form-field m-form-field__radio">
     <input class="a-radio" type="radio" id="test_radio">
     <label class="a-label" for="test_radio">Label</label>
 </div>
 
 ```
-<div class="m-form-field__radio">
+<div class="m-form-field m-form-field__radio">
     <input class="a-radio" type="radio" id="test_radio">
     <label class="a-label" for="test_radio">Label</label>
 </div>
@@ -283,7 +283,7 @@ See the 'Form icons' section below for guidance on adding icons to states.
 
 ### Basic select
 
-<div class="m-form-field__select">
+<div class="m-form-field m-form-field__select">
     <label class="a-label" for="test_select">Label</label>
     <div class="a-select">
         <select id="test_select">
@@ -296,7 +296,7 @@ See the 'Form icons' section below for guidance on adding icons to states.
 </div>
 
 ```
-<div class="m-form-field__select">
+<div class="m-form-field m-form-field__select">
     <label class="a-label" for="test_select">Label</label>
     <div class="a-select">
         <select id="test_select">
@@ -311,7 +311,7 @@ See the 'Form icons' section below for guidance on adding icons to states.
 
 ### Disabled select
 
-<div class="m-form-field__select">
+<div class="m-form-field m-form-field__select">
     <label class="a-label" for="test_select__disabled">Label</label>
     <div class="a-select">
         <select id="test_select__disabled" disabled>
@@ -324,7 +324,7 @@ See the 'Form icons' section below for guidance on adding icons to states.
 </div>
 
 ```
-<div class="m-form-field__select">
+<div class="m-form-field m-form-field__select">
     <label class="a-label" for="test_select__disabled">Label</label>
     <div class="a-select">
         <select id="test_select__disabled" disabled>


### PR DESCRIPTION
The form field documentation was showing outdated and incorrect code examples.

## Changes

- Updated the form fields documentation to fix the incorrect examples.

## Testing

- Checkout this branch locally and run `npm run cf-link`
- In your `gh-pages` duplicate clone, run `npm run cf-link`
- In your `gh-pages` duplicate clone, run `npm run build && npm start`
- Check out `http://localhost:3000/components/cf-forms/` and ensure code examples for form fields is correct.

## Review

- @anselmbradford 
- @Scotchester 

## Screenshots

![screen shot 2017-04-28 at 5 09 35 pm](https://cloud.githubusercontent.com/assets/1280430/25549098/77adb1fc-2c35-11e7-9a1b-5a236cb8e562.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
