### PR TITLE
Full width button utility for x-small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+- **cf-buttons:** [MINOR] Added full width button utility for x-small screens
 
 ### Changed
-- 
+-
 
 ### Removed
-- 
+-
 
 ## 4.3.2 - 2017-05-01
 

--- a/src/cf-buttons/src/atoms/buttons.less
+++ b/src/cf-buttons/src/atoms/buttons.less
@@ -20,6 +20,7 @@
   cursor: pointer;
   font-size: unit( @btn-font-size / @base-font-size-px, em );
   line-height: normal;
+  text-align: center;
   text-decoration: none;
   transition: background-color 0.1s;
 
@@ -168,5 +169,15 @@
       padding-top: unit( @btn-v-padding-modifier-ie * 15px / @btn__super-font-size, em );
       padding-bottom: unit( @btn-v-padding-modifier-ie * 15px / @btn__super-font-size, em );
     }
+  }
+
+  //
+  // Full width button on x-small screens
+  //
+  &__full-on-xsmall {
+    .respond-to-max( @bp-xs-max, {
+        display: block;
+        width: 100%;
+    } );
   }
 }

--- a/src/cf-buttons/src/atoms/buttons.less
+++ b/src/cf-buttons/src/atoms/buttons.less
@@ -174,10 +174,10 @@
   //
   // Full width button on x-small screens
   //
-  &__full-on-xsmall {
+  &__full-on-xs {
     .respond-to-max( @bp-xs-max, {
-        display: block;
-        width: 100%;
+      display: block;
+      width: 100%;
     } );
   }
 }

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -21,6 +21,7 @@ dependencies of this component.
     - [Destructive action button](#destructive-action-button)
     - [Disabled button](#disabled-button)
     - [Super button](#super-button)
+    - [Full-width buttons on x-small screens](#full-width-buttons-on-x-small-screens)
     - [Button links](#button-links)
     - [Icon buttons](#icon-buttons)
 - [Molecules](#molecules)
@@ -359,6 +360,26 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
     Button Tag
 </button>
 <input type="submit" value="Input Tag" class="a-btn a-btn__super active">
+```
+
+### Full-width buttons on x-small screens
+
+_Reduce screen size to see these in action_
+
+<a href="#" class="a-btn a-btn__full-on-xsmall">Anchor Tag</a>
+
+<button class="a-btn a-btn__full-on-xsmall" title="Test button">
+    Button Tag
+</button>
+
+<input type="submit" value="Input Tag" class="a-btn a-btn__full-on-xsmall">
+
+```
+<a href="#" class="a-btn a-btn__full-on-xsmall">Anchor Tag</a>
+<button class="a-btn a-btn__full-on-xsmall" title="Test button">
+    Button Tag
+</button>
+<input type="submit" value="Input Tag" class="a-btn a-btn__full-on-xsmall">
 ```
 
 ### Button links

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -366,20 +366,20 @@ For accessibility reasons, use the semantic `<button>` instead of a link when po
 
 _Reduce screen size to see these in action_
 
-<a href="#" class="a-btn a-btn__full-on-xsmall">Anchor Tag</a>
+<a href="#" class="a-btn a-btn__full-on-xs">Anchor Tag</a>
 
-<button class="a-btn a-btn__full-on-xsmall" title="Test button">
+<button class="a-btn a-btn__full-on-xs" title="Test button">
     Button Tag
 </button>
 
-<input type="submit" value="Input Tag" class="a-btn a-btn__full-on-xsmall">
+<input type="submit" value="Input Tag" class="a-btn a-btn__full-on-xs">
 
 ```
-<a href="#" class="a-btn a-btn__full-on-xsmall">Anchor Tag</a>
-<button class="a-btn a-btn__full-on-xsmall" title="Test button">
+<a href="#" class="a-btn a-btn__full-on-xs">Anchor Tag</a>
+<button class="a-btn a-btn__full-on-xs" title="Test button">
     Button Tag
 </button>
-<input type="submit" value="Input Tag" class="a-btn a-btn__full-on-xsmall">
+<input type="submit" value="Input Tag" class="a-btn a-btn__full-on-xs">
 ```
 
 ### Button links


### PR DESCRIPTION
It's currently an enhancement in cfgov-refresh that needed to make it's way to this project.

## Additions

- Added full width button utility for x-small screens

## Testing

- NPM Link this project `npm run cf-link`
- NPM Link this into your docs clone and build the site
  ```
  cd /[repodir]/capital-framework-site
  npm run cf-link
  npm run build
  npm run start
  ```
- Open `http://localhost:3000/components/cf-buttons/#full-width-buttons-on-x-small-screens`

## Notes

- Fixes #201 

## Review

- @anselmbradford 
- @Scotchester 
- @sebworks 
- @cfarm (YAY! YOU'RE BACK!)

## Screenshots

![screen shot 2017-05-01 at 5 20 14 pm](https://cloud.githubusercontent.com/assets/1280430/25597205/1b89a95c-2e93-11e7-8195-129a6753da0e.png)

## Notes

- Moved from https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/unprocessed/css/enhancements/buttons.less#L15

## Todos

- Leave a note in cfgov-refresh once this is live.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
