### PR TITLE
Add base styling for inline and fenced code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+- **cf-core:** [MINOR] Added base styling for inline and fenced code blocks
 
 ### Changed
-- 
+-
 
 ### Removed
-- 
+-
 
 ## 4.3.2 - 2017-05-01
 

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -539,5 +539,38 @@ figure {
 }
 
 //
+// Code blocks
+//
+
+pre,
+code {
+    background: @code-bg;
+    border-radius: 4px;
+    color: @code-text;
+    font-family: 'Input Mono', Consolas, Monaco, 'Courier New', monospace;
+}
+
+code {
+    display: inline-block;
+    padding: unit( 3px / @size-code, em )
+             unit( 6px / @size-code, em )
+             0;
+    font-size: unit( @size-code / @base-font-size-px, em );
+}
+
+pre {
+    display: block;
+    padding: unit( 10px / @base-font-size-px, em)
+             unit( 15px / @base-font-size-px, em );
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+
+    code {
+        padding: 0;
+        background-color: transparent;
+    }
+}
+
+//
 // EOF
 //

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -553,7 +553,7 @@ code {
 code {
     display: inline-block;
     padding: unit( 3px / @size-code, em )
-             unit( 6px / @size-code, em )
+             unit( 3px / @size-code, em )
              0;
     font-size: unit( @size-code / @base-font-size-px, em );
 }

--- a/src/cf-core/src/cf-vars.less
+++ b/src/cf-core/src/cf-vars.less
@@ -31,6 +31,10 @@
 @thead-text:                    @text;
 @thead-bg:                      #f1f1f1; // $color-gray-lightest
 
+// code
+@code-text:                     @text;
+@code-bg:                       #f1f1f1;
+
 
 // Sizing variables
 
@@ -46,6 +50,7 @@
 @size-iv:                       18px; // h4-size
 @size-v:                        14px; // h5-site
 @size-vi:                       12px; // h6-size
+@size-code:                     13px; // Custom size only for Mono code blocks
 
 
 // Breakpoint variables

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -1165,3 +1165,33 @@ and removes bottom inline spacing from `img` elements within.
     <img src="http://placekitten.com/340/320">
 </figure>
 ```
+
+## Code blocks
+
+### Inline code
+
+<p>This is an example of paragraph text <code>&lt;a href="#"&gt;Test Link&lt;/a&gt;</code> with an inline code block</p>
+
+```
+<p>This is an example of paragraph text with an inline code block <code>&lt;a href="#" class="a-btn" title="Test button"&gt;Anchor Tag&lt;/a&gt;</code></p>
+```
+
+### Fenced code block
+
+This is an example of a fenced code block following some paragraph text.
+
+<pre>
+<code>&lt;a href="#" class="a-btn" title="Test button"&gt;Anchor Tag&lt;/a&gt;
+&lt;button class="a-btn" title="Test button"&gt;Button Tag&lt;/button&gt;
+&lt;input type="submit" value="Input Tag" class="a-btn"&gt;</code>
+</pre>
+
+```
+<pre>
+<code>&lt;a href="#" class="a-btn" title="Test button"&gt;Anchor Tag&lt;/a&gt;
+&lt;button class="a-btn" title="Test button"&gt;Button Tag&lt;/button&gt;
+&lt;input type="submit" value="Input Tag" class="a-btn"&gt;</code>
+</pre>
+```
+
+_Do not include indentation or white space within the `<code>` tags unless you want it to be rendered._


### PR DESCRIPTION
The project doesn't currently style code blocks in any way. This adds sensible defaults that can easily be overridden through variables.

## Additions

- Added base styling for inline and fenced code blocks

## Testing

- This is difficult to test in any of our doc sites due to the existing code styling that lives in those. 

## Review

- @Scotchester 
- @cfarm 
- @anselmbradford 
- @sebworks 

## Screenshots

![screen shot 2017-05-02 at 12 52 34 pm](https://cloud.githubusercontent.com/assets/1280430/25633872/3af7a7fc-2f3e-11e7-943c-27b6bc168480.png)

![screen shot 2017-05-02 at 12 58 07 pm](https://cloud.githubusercontent.com/assets/1280430/25633874/3c6eb454-2f3e-11e7-844f-0d070e3b1c9b.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
