### PR TITLE
Improve the Form Button documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-core:** [MINOR] Added base styling for inline and fenced code blocks
 
 ### Changed
 - **cf-forms:** [PATCH] Improved the form buttons documentation
-- **cf-core:** [MINOR] Added base styling for inline and fenced code blocks
 
 ### Removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-forms:** [PATCH] Improved the form buttons documentation
 
 ### Removed
-- 
+-
 
 ## 4.4.0 - 2017-05-16
 

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -24,8 +24,9 @@ Capital Framework.
     - [Basic radio buttons](#basic-radio-buttons)
     - [Input states](#input-states)
 - [Buttons](#buttons)
-    - [Input and button](#input-and-button)
-    - [Button inside input](#button-inside-input)
+    - [Simple input with a button](#simple-input-with-a-button)
+    - [Button inside an input](#button-inside-an-input)
+    - [Button inside an input with a button](#button-inside-an-input-with-a-button)
 - [Select dropdown](#select-dropdown)
     - [Basic select](#basic-select)
     - [Disabled select](#disabled-select)
@@ -217,7 +218,9 @@ See the 'Form icons' section below for guidance on adding icons to states.
 
 ## Buttons
 
-### Input and button
+### Simple input with a button
+
+These are used for simple forms where a full filter isn't necessary.
 
 <div class="o-form__input-w-btn">
     <div class="o-form__input-w-btn_input-container">
@@ -239,9 +242,10 @@ See the 'Form icons' section below for guidance on adding icons to states.
 </div>
 ```
 
-### Button inside input
+### Button inside an input
 
-#### Default button inside of an default input
+These offer the user an action to take related to the input,
+typically to clear the input.
 
 <div class="m-btn-inside-input">
     <input type="text"
@@ -256,7 +260,25 @@ See the 'Form icons' section below for guidance on adding icons to states.
     </button>
 </div>
 
-#### Button inside input and button
+```
+<div class="m-btn-inside-input">
+    <input type="text"
+        value="This is some really long text to make sure that the button
+               doesn't overlap the content in such a way that this input
+               becomes unusable."
+        title="Test input"
+        class="a-text-input">
+    <button class="a-btn a-btn__link">
+        Clear
+        <span class="cf-icon cf-icon-delete"></span>
+    </button>
+</div>
+```
+
+### Button inside an input with a button
+
+This example combines both of the previous patterns,
+creating a typical site search form.
 
 <div class="o-form__input-w-btn">
     <div class="o-form__input-w-btn_input-container">
@@ -277,6 +299,28 @@ See the 'Form icons' section below for guidance on adding icons to states.
         <button class="a-btn">Search</button>
     </div>
 </div>
+
+```
+<div class="o-form__input-w-btn">
+    <div class="o-form__input-w-btn_input-container">
+        <div class="m-btn-inside-input">
+            <input type="text"
+                value="This is some really long text to make sure that the
+                       button doesn't overlap the content in such a way
+                       that this input becomes unusable."
+                title="Test input"
+                class="a-text-input">
+            <button class="a-btn a-btn__link">
+                Clear
+                <span class="cf-icon cf-icon-delete"></span>
+            </button>
+        </div>
+    </div>
+    <div class="o-form__input-w-btn_btn-container">
+        <button class="a-btn">Search</button>
+    </div>
+</div>
+```
 
 
 ## Select dropdown


### PR DESCRIPTION
The documentation was missing the code blocks for the two button and input examples. It also wasn't clear when and how they should be used. Updated the md file to address both issues

## Changes

- Improved the form button docs

## Review

- @cfarm 
- @mistergone 
- @anselmbradford 
- @contolini 

## Screenshots

<img width="951" alt="screen shot 2017-05-16 at 2 16 01 pm" src="https://cloud.githubusercontent.com/assets/1280430/26123897/3512a490-3a42-11e7-9d86-5241e1377a27.png">

## Notes

- Patch necessary to pull into the docs site.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
