### PR TITLE
Add a base level of styling to standard multiselect elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+- **cf-forms:** [MINOR] Added base styling for multiselect element
 
 ### Changed
-- 
+-
 
 ### Removed
-- 
+-
 
 ## 4.5.0 - 2017-05-18
 

--- a/src/cf-forms/src/atoms/multiselect.less
+++ b/src/cf-forms/src/atoms/multiselect.less
@@ -1,0 +1,16 @@
+.a-multiselect {
+    display: block;
+
+    box-sizing: border-box;
+    width: 100%;
+    height: 5.5em; // This height breaks the bottom border mid-character so it's clear there's more
+    padding-top: unit( 4px / @base-font-size-px, em );
+    padding-bottom: unit( 4px / @base-font-size-px, em );
+
+    border: 1px solid @select-border;
+
+    option {
+        padding: unit( 2px / @base-font-size-px, em )
+                 unit( 6px / @base-font-size-px, em );
+    }
+}

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -64,6 +64,7 @@
 //
 
 @import (less) 'atoms/label.less';
+@import (less) 'atoms/multiselect.less';
 @import (less) 'atoms/select.less';
 @import (less) 'atoms/text-input.less';
 

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -30,6 +30,7 @@ Capital Framework.
 - [Select dropdown](#select-dropdown)
     - [Basic select](#basic-select)
     - [Disabled select](#disabled-select)
+- [Basic multiselect](#basic-multiselect)
 
 
 ## Variables

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -381,7 +381,7 @@ creating a typical site search form.
 </div>
 ```
 
-### Basic Multi-select
+### Basic multiselect
 
 <div class="m-form-field m-form-field__select">
     <label class="a-label" for="test_select__multiple">Label</label>
@@ -396,3 +396,19 @@ creating a typical site search form.
         <option value="option4">Option 8</option>
     </select>
 </div>
+
+```
+<div class="m-form-field m-form-field__select">
+    <label class="a-label" for="test_select__multiple">Label</label>
+    <select class="a-multiselect" id="test_select__multiple" multiple>
+        <option value="option1">Option 1</option>
+        <option value="option2">Option 2</option>
+        <option value="option3">Option 3</option>
+        <option value="option4">Option 4</option>
+        <option value="option1">Option 5</option>
+        <option value="option2">Option 6</option>
+        <option value="option3">Option 7</option>
+        <option value="option4">Option 8</option>
+    </select>
+</div>
+```

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -380,3 +380,19 @@ creating a typical site search form.
     </div>
 </div>
 ```
+
+### Basic Multi-select
+
+<div class="m-form-field m-form-field__select">
+    <label class="a-label" for="test_select__multiple">Label</label>
+    <select class="a-multiselect" id="test_select__multiple" multiple>
+        <option value="option1">Option 1</option>
+        <option value="option2">Option 2</option>
+        <option value="option3">Option 3</option>
+        <option value="option4">Option 4</option>
+        <option value="option1">Option 5</option>
+        <option value="option2">Option 6</option>
+        <option value="option3">Option 7</option>
+        <option value="option4">Option 8</option>
+    </select>
+</div>


### PR DESCRIPTION
These styles lived within cfgov-refresh and need to be ported to Capital Framework.

## Additions

- Base multi-select styles

## Review

- @sebworks 
- @cfarm 
- @Scotchester 
- @anselmbradford 

## Screenshots

![screen shot 2017-05-19 at 4 20 43 pm](https://cloud.githubusercontent.com/assets/1280430/26267339/31b09068-3caf-11e7-819d-4283aa30d205.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
