### PR TITLE
Update contributing doc for testing in the doc site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,18 +51,39 @@ by first clicking the fork button on top of the repository and cloning your fork
 
 ### Testing components locally
 
-If you're hacking on a component and want to test it in a local project, use `npm link`. For example:
+#### Testing in the documentation site
+
+If you're hacking on a component and want to test it in the documentation site follow the following steps.
+
+In this repo:
+- check out a working branch
+- run `npm run cf-link`
+
+In a site specific clone of this repo:
+
+- make sure you're on the gh-pages branch
+- run `npm run cf-link`
+- run `npm run build`
+- run `npm start`
+- open a browser at http://localhost:3000/ and navigate to the component you've changed
+```
+
+#### Testing in an outside project
+
+If you're hacking on a component and want to test it in a local project, use NPM linking. For example:
 
 ```sh
 cd ~/Projects/capital-framework/ # wherever you cloned this repo
-npm run build
-cd src/cf-buttons
-npm link
+npm run cf-link # this makes all the components linkable
+git checkout [branch] # make your edits on a branch
+
 cd ~/Projects/owning-a-home
-npm link cf-buttons
+npm link cf-buttons # or whatever component you're working on
+gulp build # or whatever build process your project uses
 ```
 
-Now `~/Projects/owning-a-home/node_modules/cf-buttons` will be a symlink pointing to the `~/Projects/capital-framework/tmp/cf-buttons` directory. Whenever you rebuild (`npm run build`, see above) the CF components, your local owning-a-home project will reference your local `tmp/` version of cf-buttons.
+Now `~/Projects/owning-a-home/node_modules/cf-buttons` will be a symlink pointing to the `~/Projects/capital-framework/src/cf-buttons` directory. Whenever you make changes in the Capital Framework repo run the build task in your project to see your changes.
+
 
 ### Updating Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,27 +59,26 @@ In this repo:
 - check out a working branch
 - run `npm run cf-link`
 
-In a site specific clone of this repo:
+In a second local clone of this repo in a different folder:
 
 - make sure you're on the gh-pages branch
 - run `npm run cf-link`
 - run `npm run build`
 - run `npm start`
 - open a browser at http://localhost:3000/ and navigate to the component you've changed
-```
 
 #### Testing in an outside project
 
-If you're hacking on a component and want to test it in a local project, use NPM linking. For example:
+If you're hacking on a component and want to test it in a local project, use npm linking. For example:
 
 ```sh
-cd ~/Projects/capital-framework/ # wherever you cloned this repo
-npm run cf-link # this makes all the components linkable
-git checkout [branch] # make your edits on a branch
+cd ~/Projects/capital-framework/ 	# wherever you cloned this repo
+npm run cf-link 					# this makes all the components linkable
+git checkout [branch] 				# make your edits on a branch
 
 cd ~/Projects/owning-a-home
-npm link cf-buttons # or whatever component you're working on
-gulp build # or whatever build process your project uses
+npm link cf-buttons 				# or whatever component you're working on
+gulp build 							# or whatever build process your project uses
 ```
 
 Now `~/Projects/owning-a-home/node_modules/cf-buttons` will be a symlink pointing to the `~/Projects/capital-framework/src/cf-buttons` directory. Whenever you make changes in the Capital Framework repo run the build task in your project to see your changes.


### PR DESCRIPTION
It's unclear how to test components changes in the documentation site. We've also made testing in a separate project much easier.

## Additions

- Added instructions for testing in the documentation site.

## Changes

- Updated the instructions for testing in an outside project.

## Testing

- Follow the instructions.

## Review

- @anselmbradford 
- @sebworks 
- @cfarm 
- @contolini 
- @Scotchester 

## Screenshots


## Notes

- Hopefully this clears some things up for people. Feel free to tear it apart and tell me it's still unclear and I need to make it better. I'm definitely closest to the process at the moment.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
