### PR TITLE
Add a level of basic styling to legend elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+- **cf-forms:** [MINOR] Added base styling for legend elements
 
 ### Changed
-- 
+-
 
 ### Removed
-- 
+-
 
 ## 4.6.0 - 2017-05-23
 

--- a/src/cf-forms/src/atoms/legend.less
+++ b/src/cf-forms/src/atoms/legend.less
@@ -1,0 +1,10 @@
+.a-legend {
+    .h4();
+
+    // Legends do not wrap in IE.
+    // Different styles are required to ensure wrapping in different versions.
+    box-sizing: border-box; // IE9-11 & Edge 12-13
+    display: table; // IE8-11
+    max-width: 100%; // Patch for IE9-11 & Edge 12-13
+    white-space: normal; // IE8-11
+}

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -64,6 +64,7 @@
 //
 
 @import (less) 'atoms/label.less';
+@import (less) 'atoms/legend.less';
 @import (less) 'atoms/multiselect.less';
 @import (less) 'atoms/select.less';
 @import (less) 'atoms/text-input.less';

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -88,14 +88,14 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ## Legends
 
-<label class="a-legend">
+<legend class="a-legend">
     A basic legend
-</label>
+</legend>
 
 ```
-<label class="a-legend">
+<legend class="a-legend">
     A basic legend
-</label>
+</legend>
 ```
 
 ## Labels

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -15,6 +15,7 @@ Capital Framework.
 
 - [Variables](#variables)
     - [Color variables](#color-variables)
+- [Legends](#legends)
 - [Labels](#labels)
     - [Basic label](#basic-label)
     - [Label heading](#label-heading)
@@ -85,6 +86,17 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 @select-height:                  30px;
 ```
 
+## Legends
+
+<label class="a-legend">
+    A basic legend
+</label>
+
+```
+<label class="a-legend">
+    A basic legend
+</label>
+```
 
 ## Labels
 
@@ -111,7 +123,6 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
     A label heading
 </label>
 ```
-
 
 ## Inputs
 


### PR DESCRIPTION
Legends are currently unstyled in Capital Framework.

## Additions

- Added legend styling

## Testing

- Follow the [instructions to test the CF Docs](https://github.com/cfpb/capital-framework/pull/495/files#diff-6a3371457528722a734f3c51d9238c13)
- Navigate to `http://localhost:3000/components/cf-forms/#legends`

## Review

- @virginiacc 
- @Scotchester 
- @anselmbradford 

## Screenshots

![screen shot 2017-06-01 at 3 57 16 pm](https://cloud.githubusercontent.com/assets/1280430/26700451/002e4344-46e3-11e7-9fa9-1f087a5bdc08.png)

## Notes

- See https://github.com/cfpb/cfgov-refresh/commit/1412edfb93c8b6d4b0ca0e1e9fe54adc21a599c8#diff-bb9725e42c42447534e5b670dbe94b8c for source

## Todos

- Note legend styling in cfgov-refresh has been ported.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
