### PR TITLE
Provide the first half of a fix to the CF Grid docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-grid:** [PATCH] Fix for nested grid doc examples
 
 ### Removed
-- 
+-
 
 ## 4.6.0 - 2017-05-23
 

--- a/src/cf-grid/usage.md
+++ b/src/cf-grid/usage.md
@@ -404,7 +404,7 @@ content first in the source order, but it's here if you absolutely need it.
     <section>
         <div class="col col-6">
             <p>six</p>
-            <section>
+            <section class="nested">
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
@@ -413,7 +413,7 @@ content first in the source order, but it's here if you absolutely need it.
 
         <div class="col col-6">
             <p>six</p>
-            <section>
+            <section class="nested">
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
@@ -424,7 +424,7 @@ content first in the source order, but it's here if you absolutely need it.
     <section>
         <div class="col col-3">
             <p>three</p>
-            <section>
+            <section class="nested">
                 <div class="col col-6"><p>six</p></div>
                 <div class="col col-6"><p>six</p></div>
             </section>
@@ -432,7 +432,7 @@ content first in the source order, but it's here if you absolutely need it.
 
         <div class="col col-6">
             <p>six</p>
-            <section>
+            <section class="nested">
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
@@ -441,7 +441,7 @@ content first in the source order, but it's here if you absolutely need it.
 
         <div class="col col-3">
             <p>three</p>
-            <section>
+            <section class="nested">
                 <div class="col col-3"><p>three</p></div>
                 <div class="col col-3"><p>three</p></div>
                 <div class="col col-3"><p>three</p></div>
@@ -456,7 +456,7 @@ content first in the source order, but it's here if you absolutely need it.
     <section>
         <div class="col col-6">
             <p>six</p>
-            <section>
+            <section class="nested">
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
@@ -465,7 +465,7 @@ content first in the source order, but it's here if you absolutely need it.
 
         <div class="col col-6">
             <p>six</p>
-            <section>
+            <section class="nested">
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
@@ -476,7 +476,7 @@ content first in the source order, but it's here if you absolutely need it.
     <section>
         <div class="col col-3">
             <p>three</p>
-            <section>
+            <section class="nested">
                 <div class="col col-6"><p>six</p></div>
                 <div class="col col-6"><p>six</p></div>
             </section>
@@ -484,7 +484,7 @@ content first in the source order, but it's here if you absolutely need it.
 
         <div class="col col-6">
             <p>six</p>
-            <section>
+            <section class="nested">
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
                 <div class="col col-4"><p>four</p></div>
@@ -493,7 +493,7 @@ content first in the source order, but it's here if you absolutely need it.
 
         <div class="col col-3">
             <p>three</p>
-            <section>
+            <section class="nested">
                 <div class="col col-3"><p>three</p></div>
                 <div class="col col-3"><p>three</p></div>
                 <div class="col col-3"><p>three</p></div>


### PR DESCRIPTION
The CF Grid docs are not displaying the correct examples for nested grids.

## Changes

- Added `nested` class for the nested examples.

## Testing

- There's no way to test this yet, the style changes are separate. 

## Review

- @Scotchester 
- @anselmbradford 

## Screenshots

__Before:__

<img width="920" alt="screen shot 2017-06-06 at 4 23 12 pm" src="https://user-images.githubusercontent.com/1280430/26852627-7c823352-4ad4-11e7-8e6a-44bd6e306361.png">

__After:__ (includes some color and spacing changes I'll be PR-ing to the docs branch)

<img width="877" alt="screen shot 2017-06-06 at 4 22 54 pm" src="https://user-images.githubusercontent.com/1280430/26852642-89109212-4ad4-11e7-9430-c9b5ef196c80.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
