### PR TITLE
Add --dry-run option to simulate npm release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,3 +117,6 @@ Release management is now handled by [CFPB's chat bot](https://github.com/cfpb/C
 
 1. In the FEWD channel say "cfpbot capital framework prepare release"
 1. It will do a bunch of stuff and create a release PR. Visit the PR and merge it.
+
+After the PR is merged [Travis](https://travis-ci.org/cfpb/capital-framework) will run `npm run release`.
+To simulate a Travis release locally, run `npm run release -- --dryrun`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capital-framework",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "CFPB's UI framework",
   "main": "src/capital-framework.js",
   "less": "src/capital-framework.less",

--- a/scripts/npm/prepublish/lib/confirm.js
+++ b/scripts/npm/prepublish/lib/confirm.js
@@ -7,8 +7,8 @@ function confirm(opts) {
   opts = opts || {};
   var prompt = opts.prompt + ' [Y/n] ';
   return new Promise(function (resolve, reject) {
-    // If the -s option is passed or we're in a CI, don't prompt the user.
-    if (options.silent || process.env.CONTINUOUS_INTEGRATION) {
+    // If the silent or dryrun option is passed or we're in a CI, don't prompt the user.
+    if (options.silent || options.dryrun || process.env.CONTINUOUS_INTEGRATION) {
       return resolve(opts.data);
     }
     var rl = readline.createInterface({

--- a/scripts/npm/prepublish/lib/getArgs.js
+++ b/scripts/npm/prepublish/lib/getArgs.js
@@ -3,5 +3,6 @@ var argv = require('minimist')(process.argv.slice(2));
 module.exports = {
   component: argv.component,
   silent: (argv.s || argv.silent),
+  dryrun: (argv.dryrun),
   force: (argv.f || argv.force)
 }

--- a/scripts/travis/release.sh
+++ b/scripts/travis/release.sh
@@ -23,5 +23,8 @@ if [[ -n "$NPM_USERNAME" ]] && [[ -n "$NPM_PASSWORD" ]] && [[ -n "$NPM_EMAIL" ]]
   git config user.email "CFPBot@users.noreply.github.com"
 fi
 
-node scripts/npm/prepublish
-npm publish
+node scripts/npm/prepublish $1
+
+if [[ $1 != "--dryrun" ]]; then
+  npm publish
+fi


### PR DESCRIPTION
Travis' release script is admittedly a black box. It's hard to know exactly which components will be published to npm because running the release script locally results in components being tagged and permanently uploaded to npm. This new dry run option allows the script to be run without doing any permanent damage.

## Additions

- `--dry-run` option to release script

## Testing

- Pull down this branch and `npm run release -- --dryrun` ([yes, the -- is necessary](https://docs.npmjs.com/cli/run-script))

## Screenshots

![screen shot 2017-06-08 at 6 39 29 pm](https://user-images.githubusercontent.com/1060248/26953684-ddcd21a2-4c79-11e7-80cf-0e1d11065d2c.png)
