### PR TITLE
Update hover state of checkboxes and radio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
-- **cf-forms:** Fixed checkbox/radio borders on hover
+- **cf-forms:** [PATCH] Fixed checkbox/radio borders on hover
 
 ### Removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-forms:** Fixed checkbox/radio borders on hover
 
 ### Removed
-- 
+-
 
 ## 4.7.1 - 2017-06-09
 

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -72,7 +72,8 @@
         }
 
         .a-checkbox {
-            &:focus + .a-label:before {
+            &:focus + .a-label:before,
+            &:hover + .a-label:before {
                 border-color: @input-border__focused;
                 outline: 1px solid @input-border__focused;
             }
@@ -91,7 +92,8 @@
         }
 
         .a-radio {
-            &:focus + .a-label:before {
+            &:focus + .a-label:before,
+            &:hover + .a-label:before {
                 outline: none;
                 border-color: @input-border__focused;
                 box-shadow: 0 0 0 1px @input-border__focused;

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -104,7 +104,8 @@
                 box-shadow: inset 0 0 0 2px #fff;
             }
 
-            &:focus:checked + .a-label:before {
+            &:focus:checked + .a-label:before,
+            &:hover:checked + .a-label:before {
                 border-color: @input-border__focused;
                 box-shadow: 0 0 0 1px @input-border__focused, inset 0 0 0 2px #fff;
             }


### PR DESCRIPTION
The Design Manual Spec calls for a 2px border on checkboxes and radio buttons. It was only displaying as 1px.

## Changes

- Fixed checkbox/radio borders on hover

## Testing

- Follow the [instructions to test the CF Docs](https://github.com/cfpb/capital-framework/pull/495/files#diff-6a3371457528722a734f3c51d9238c13)
- Navigate to `http://localhost:3000/components/cf-forms/#basic-checkboxes`

## Review

- @Scotchester 
- @anselmbradford 
- @nataliafitzgerald

## Screenshots

![screen shot 2017-06-13 at 1 22 26 pm](https://user-images.githubusercontent.com/1280430/27097896-613d3ecc-503b-11e7-878c-ed234ab8d261.png)

![screen shot 2017-06-13 at 1 22 34 pm](https://user-images.githubusercontent.com/1280430/27097897-62633c2a-503b-11e7-8136-b2fe5eb34004.png)

## Notes

- Don't deploy this until the auto-doc script is tested locally.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
