### PR TITLE
Fixes pagination docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - **cf-forms:** [PATCH] Fixed checkbox/radio borders on hover
+- **cf-pagination:** [PATCH] Fixed outdated `a-btn__icon-on-left`
+and `a-btn__icon-on-right` classes referenced in docs to correct
+`a-btn_icon__on-left` and `a-btn_icon__on-right` classes.
 
 ### Removed
 -

--- a/src/cf-pagination/usage.md
+++ b/src/cf-pagination/usage.md
@@ -59,7 +59,7 @@ include an `id` on a wrapper of the paginated content
 
 <nav class="m-pagination" role="navigation" aria-label="Pagination">
     <a class="a-btn
-              a-btn__icon-on-left
+              a-btn_icon__on-left
               cf-icon
               cf-icon-left
               cf-icon__before
@@ -68,7 +68,7 @@ include an `id` on a wrapper of the paginated content
         Newer
     </a>
     <a class="a-btn
-              a-btn__icon-on-right
+              a-btn_icon__on-right
               cf-icon
               cf-icon-right
               cf-icon__after
@@ -110,7 +110,7 @@ include an `id` on a wrapper of the paginated content
 
 <nav class="m-pagination" role="navigation" aria-label="Pagination">
     <a class="a-btn
-              a-btn__icon-on-left
+              a-btn_icon__on-left
               cf-icon
               cf-icon-left
               cf-icon__before
@@ -119,7 +119,7 @@ include an `id` on a wrapper of the paginated content
         Newer
     </a>
     <a class="a-btn
-              a-btn__icon-on-right
+              a-btn_icon__on-right
               cf-icon
               cf-icon-right
               cf-icon__after
@@ -166,7 +166,7 @@ For example:
 
 <nav class="m-pagination" role="navigation" aria-label="Pagination">
     <a class="a-btn
-              a-btn__icon-on-left
+              a-btn_icon__on-left
               a-btn__disabled
               cf-icon
               cf-icon-left
@@ -175,7 +175,7 @@ For example:
         Newer
     </a>
     <a class="a-btn
-              a-btn__icon-on-right
+              a-btn_icon__on-right
               cf-icon
               cf-icon-right
               cf-icon__after
@@ -213,7 +213,7 @@ For example:
 ```
 <nav class="m-pagination" role="navigation" aria-label="Pagination">
     <a class="a-btn
-              a-btn__icon-on-left
+              a-btn_icon__on-left
               a-btn__disabled
               cf-icon
               cf-icon-left
@@ -222,7 +222,7 @@ For example:
         Newer
     </a>
     <a class="a-btn
-              a-btn__icon-on-right
+              a-btn_icon__on-right
               cf-icon
               cf-icon-right
               cf-icon__after


### PR DESCRIPTION
## Changes

- Updates outdated class name references for `a-btn__icon-on-left` and `a-btn__icon-on-right`, which have updated names in https://github.com/cfpb/capital-framework/blob/canary/src/cf-buttons/src/atoms/buttons-with-icons.less#L15 
