### PR TITLE
Remove IE7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and `a-btn__icon-on-right` classes referenced in docs to correct
 `a-btn_icon__on-left` and `a-btn_icon__on-right` classes.
 
 ### Removed
--
+- **capital-framework:** [MINOR] Remove IE7 and below support.
 
 ## 4.7.1 - 2017-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and `a-btn__icon-on-right` classes referenced in docs to correct
 `a-btn_icon__on-left` and `a-btn_icon__on-right` classes.
 
 ### Removed
-- **capital-framework:** [MINOR] Remove IE7 and below support.
+- **cf-core:** [MINOR] Remove IE7 and below support.
+- **cf-buttons:** [MINOR] Remove IE7 and below support.
+- **cf-grid:** [MINOR] Remove IE7 and below support.
+- **cf-layout:** [MINOR] Remove IE7 and below support.
 
 ## 4.7.1 - 2017-06-09
 

--- a/src/cf-buttons/src/atoms/button-links.less
+++ b/src/cf-buttons/src/atoms/button-links.less
@@ -37,11 +37,6 @@
     color: @link-text-active;
   }
 
-  .lt-ie8 button&,
-  .lt-ie8 input& {
-    padding: 0;
-  }
-
   //
   // Secondary button link
   //

--- a/src/cf-buttons/src/atoms/buttons.less
+++ b/src/cf-buttons/src/atoms/buttons.less
@@ -58,14 +58,6 @@
     border: 0;
   }
 
-  // Fixes button and input sizes in IE7.
-  .lt-ie8 button&,
-  .lt-ie8 input& {
-    overflow: visible;
-    padding-top: unit( @btn-v-padding-modifier-ie * @btn-v-padding / @btn-font-size, em );
-    padding-bottom: unit( @btn-v-padding-modifier-ie * @btn-v-padding / @btn-font-size, em );
-  }
-
   //
   // Secondary button
   //
@@ -162,13 +154,6 @@
       unit( 11px / @btn__super-font-size, em )
       unit( 29px / @btn__super-font-size, em );
     font-size: unit( @btn__super-font-size / @base-font-size-px, em );
-
-    // Fixes button and input sizes in IE7.
-    .lt-ie8 button&,
-    .lt-ie8 input& {
-      padding-top: unit( @btn-v-padding-modifier-ie * 15px / @btn__super-font-size, em );
-      padding-bottom: unit( @btn-v-padding-modifier-ie * 15px / @btn__super-font-size, em );
-    }
   }
 
   //

--- a/src/cf-core/src/cf-utilities.less
+++ b/src/cf-core/src/cf-utilities.less
@@ -23,10 +23,6 @@
         display: table;
         clear: both;
     }
-
-    .lt-ie8 & {
-        zoom: 1; // For IE 6/7 (triggers hasLayout)
-    }
 }
 
 //
@@ -48,17 +44,13 @@
     clip: rect(0 0 0 0);
 }
 
+// TODO: Deprecated. Remove in CFv5.
 //
 // Inline block
 //
 
 .u-inline-block {
     display: inline-block;
-
-    .lt-ie8 & {
-        // Hack inline-block into submission
-        display: inline;
-    }
 }
 
 //

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -294,7 +294,7 @@ users to understand the context, add descriptive text with the
 
 #### Inline block
 
-Adds a `.lt-ie8` fallback to hack inline block for Internet Explorer 7 and below.
+*DEPRECATED*. Identical to `display: inline-block`.
 
 ```
 <div class="u-inline-block"></div>

--- a/src/cf-grid/src/cf-grid.less
+++ b/src/cf-grid/src/cf-grid.less
@@ -56,11 +56,6 @@
 
   vertical-align: top;
 
-  .lt-ie8 & {
-    // Hack inline-block into submission
-    display: inline;
-  }
-
   // Modifying standard width and padding for prefixed/suffixed columns, if necessary:
   // LESS will now run through four possible child mixins, only one of which will
   // actually be activated, depending on which one's guard conditions are met.
@@ -84,9 +79,6 @@
     @offset: percentage( @prefix / @total );
     width: @width + @offset;
     padding-left: @offset;
-    .lt-ie8 & {
-      padding-left: 0;
-    }
   }
 
   // Run this when only suffix is specified
@@ -94,9 +86,6 @@
     @offset: percentage( @suffix / @total );
     width: @width + @offset;
     padding-right: @offset;
-    .lt-ie8 & {
-      padding-right: 0;
-    }
   }
 
   // Run this when both prefix and suffix are specified
@@ -106,10 +95,6 @@
     width: @width + @left + @right;
     padding-right: @right;
     padding-left: @left;
-    .lt-ie8 & {
-      padding-right: 0;
-      padding-left: 0;
-    }
   }
 
 }

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -477,12 +477,6 @@
             // Remove background color from actual sidebar.
             // It will now be provided by pseudoelement :after sidebar parent.
             background: transparent;
-
-            .lt-ie8 & {
-                // Make sure the sidebar still has a background in IE7.
-                padding-right: @grid_gutter-width;
-                background: @content_sidebar-bg;
-            }
         }
 
         .content_wrapper {


### PR DESCRIPTION
Folks, is it time???

## Removals

- Removes references to `lt-ie8` class and associated style rules that are used only for IE7 and below support.

## Testing

- Should not work as expected in IE7.
