### PR TITLE
Remove header padding cruft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and `a-btn__icon-on-right` classes referenced in docs to correct
 - **cf-buttons:** [MINOR] Remove IE7 and below support.
 - **cf-grid:** [MINOR] Remove IE7 and below support.
 - **cf-layout:** [MINOR] Remove IE7 and below support.
+- **cf-typography:** [PATCH] Remove unused a-heading__padded variables and docs.
 
 ## 4.7.1 - 2017-06-09
 

--- a/src/cf-typography/src/cf-typography.less
+++ b/src/cf-typography/src/cf-typography.less
@@ -29,11 +29,6 @@
 @heading__icon:             #112e51; // $color-primary-darkest
 @heading__icon__hover:      #205493; // $color-primary-darker
 
-// .a-heading__padded
-@heading__padded:           #046b99; // $color-primary-alt-darkest
-@heading__padded_bg:        #dce4ef; // color-gray-cool-light
-@heading__padded_border:    #046b99; // $color-primary-alt-darkest
-
 // Headers
 
 // .m-slug-header

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -64,11 +64,6 @@ project by duplicating the variable `@key: value`.
 @heading__icon:             #112e51; // $color-primary-darkest
 @heading__icon__hover:      #205493; // $color-primary-darker
 
-// .a-heading__padded
-@heading__padded:           #046b99; // $color-primary-alt-darkest
-@heading__padded_bg:        #dce4ef; // color-gray-cool-light
-@heading__padded_border:    #046b99; // $color-primary-alt-darkest
-
 // Headers
 
 // .m-slug-header
@@ -84,15 +79,6 @@ project by duplicating the variable `@key: value`.
 @jump-link_bg:              #f1f1f1; // $color-gray-lightest
 @jump-link_border:          #323a45; // $color-gray-dark
 ```
-
-
-## Headings
-
-### Padded heading
-
-<h2 class="a-heading a-heading__padded">
-    Heading
-</h2>
 
 
 ### Heading with icon


### PR DESCRIPTION
These variables were defined but their associated class was removed, so this PR removes the leftover bits.

## Removals

- Removes unused `a-heading__padding` variables and documentation.