### PR TITLE
Add em dash to pull quote citation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-typography:** [PATCH] Add em dash to pull quote citation.
 
 ### Changed
 - **cf-forms:** [PATCH] Fixed checkbox/radio borders on hover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- **cf-typography:** [PATCH] Add em dash to pull quote citation.
+- **cf-typography:** [PATCH] Automatically add em dash to pull quote citation.
 
 ### Changed
 - **cf-forms:** [PATCH] Fixed checkbox/radio borders on hover

--- a/src/cf-typography/src/molecules/pull-quote.less
+++ b/src/cf-typography/src/molecules/pull-quote.less
@@ -14,6 +14,10 @@
         .heading-5();
 
         color: @pull-quote_citation;
+
+        &:before {
+            content: "\2014 ";
+        }
     }
 
     &__large .m-pull-quote_body {

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -584,7 +584,7 @@ you should use the `aside` element.
     </p>
     <footer>
         <cite class="m-pull-quote_citation">
-            - Author Name
+            Author Name
         </cite>
     </footer>
 </aside>
@@ -599,7 +599,7 @@ you should use the `aside` element.
     </p>
     <footer>
         <cite class="m-pull-quote_citation">
-            - Author Name
+            Author Name
         </cite>
     </footer>
 </aside>
@@ -615,7 +615,7 @@ you should use the `aside` element.
     </div>
     <footer>
         <cite class="m-pull-quote_citation">
-            - Author Name
+            Author Name
         </cite>
     </footer>
 </aside>
@@ -629,7 +629,7 @@ you should use the `aside` element.
     </div>
     <footer>
         <cite class="m-pull-quote_citation">
-            - Author Name
+            Author Name
         </cite>
     </footer>
 </aside>


### PR DESCRIPTION
Migrating this from cfgov-refresh.

## Additions

- Add em dash to quote citation.

## Testing

- Follow https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally
- Check /components/cf-typography/#pull-quote and note that dash is not manually added before the author in the pull quote, but still appears in the pull quote.

- @user

## Screenshots

Before:
![screen shot 2017-06-23 at 6 55 31 pm](https://user-images.githubusercontent.com/704760/27502926-c4254fb8-5845-11e7-8f36-ce6db1b97d8b.png)

After:
![screen shot 2017-06-23 at 6 56 33 pm](https://user-images.githubusercontent.com/704760/27502962-0963fcfa-5846-11e7-9e24-53d60beb13e4.png)
