### PR TITLE
Updates heading level to match design manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-pagination:** [PATCH] Fixed outdated `a-btn__icon-on-left`
 and `a-btn__icon-on-right` classes referenced in docs to correct
 `a-btn_icon__on-left` and `a-btn_icon__on-right` classes.
+- **cf-forms:** [PATCH] Changed label heading from 5 to 4, per design manual.
 
 ### Removed
 - **cf-core:** [MINOR] Remove IE7 and below support.

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -3,10 +3,10 @@
 }
 
 .a-label__heading {
-    .heading-5();
+    .heading-4();
 
     display: block;
 
-    // Overwrites heading-5 margin.
-    margin-bottom: 10px;
+    // Overwrites heading-4 margin.
+    margin-bottom: unit(10px / @font-size, em);
 }

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -8,5 +8,5 @@
     display: block;
 
     // Overwrites heading-4 margin.
-    margin-bottom: unit(10px / @font-size, em);
+    margin-bottom: unit( 10px / @font-size, em );
 }


### PR DESCRIPTION
## Changes

- Updates heading level of labels to match design manual https://cfpb.github.io/design-manual/page-components/form-fields.html#labels-and-helper-text

## Testing

- Follow instructions in https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#changing-the-codebase

## Notes

- The margin override was a hardcoded 10px originally, but is ems in cfgov refresh so updating here. I think that's correct?
