### PR TITLE
Replaces category-slug with a-heading in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 through `gulp-load-plugins`.
 - **capital-framework:** [PATCH] Updates some gulp task parts to ES6 syntax.
 - **capital-framework:** [PATCH] Drops IE7 support setting in autoprefixer task.
+- **cf-typography:** [PATCH] Updates `category-slug` to `a-heading` in docs.
+- **cf-layout:** [PATCH] Updates `category-slug` to `a-heading` in docs.
 
 ### Removed
 - **capital-framework:** [PATCH] Removes `gulp-load-plugins`, and unused

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -1298,7 +1298,7 @@ the available space.
 <div class="block block__border block__flush-sides">
     <section class="o-featured-content-module">
         <div class="o-featured-content-module_text">
-            <div class="category-slug">
+            <div class="a-heading a-heading__icon">
                 <span class="o-featured-content-module_icon
                              cf-icon
                              cf-icon-speech-bubble"></span>
@@ -1325,7 +1325,7 @@ the available space.
 <div class="block block__border block__flush-sides">
     <section class="o-featured-content-module">
         <div class="o-featured-content-module_text">
-            <div class="category-slug">
+            <div class="a-heading a-heading__icon">
                 <span class="o-featured-content-module_icon
                              cf-icon
                              cf-icon-speech-bubble"></span>
@@ -1360,7 +1360,7 @@ side so that the copyright information is displayed.
     <section class="o-featured-content-module
                     o-featured-content-module__right">
         <div class="o-featured-content-module_text">
-            <div class="category-slug">
+            <div class="a-heading a-heading__icon">
                 <span class="o-featured-content-module_icon
                              cf-icon
                              cf-icon-speech-bubble"></span>
@@ -1388,7 +1388,7 @@ side so that the copyright information is displayed.
     <section class="o-featured-content-module
                     o-featured-content-module__right">
         <div class="o-featured-content-module_text">
-            <div class="category-slug">
+            <div class="a-heading a-heading__icon">
                 <span class="o-featured-content-module_icon
                              cf-icon
                              cf-icon-speech-bubble"></span>
@@ -1424,7 +1424,7 @@ generally remains centered.
     <section class="o-featured-content-module
                     o-featured-content-module__center">
         <div class="o-featured-content-module_text">
-            <div class="category-slug">
+            <div class="a-heading a-heading__icon">
                 <span class="o-featured-content-module_icon
                              cf-icon
                              cf-icon-speech-bubble"></span>
@@ -1452,7 +1452,7 @@ generally remains centered.
     <section class="o-featured-content-module
                     o-featured-content-module__center">
         <div class="o-featured-content-module_text">
-            <div class="category-slug">
+            <div class="a-heading a-heading__icon">
                 <span class="o-featured-content-module_icon
                              cf-icon
                              cf-icon-speech-bubble"></span>

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -122,10 +122,10 @@ readers (see Meta Header below).
 ### Meta header
 
 Note that the example shows `.m-meta-header_left` using the `.a-heading__icon`
-pattern and `.meta-header_right` using the `.a-date` pattern but you could use
+pattern and `.m-meta-header_right` using the `.a-date` pattern but you could use
 other patterns in place of them. Or you can even swap them so that date is
-attached to `.meta-header_left` and `.category-slug` is attached to
-`.meta-header_right`.
+attached to `.m-meta-header_left` and `.a-heading.a-heading__icon` is attached to
+`.m-meta-header_right`.
 
 #### Default meta header
 


### PR DESCRIPTION
## Changes

- Replaces outdated `category-slug`with `a-heading` in docs. This affects the appearance of the slug on FCM, as there were no styles being applied before.

## Testing

- Follow https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally
- Check FCM docs.

## Screenshots

Before:
![screen shot 2017-06-28 at 6 35 22 pm](https://user-images.githubusercontent.com/704760/27663501-9ac3528e-5c30-11e7-9ac6-80fe9d3dbdee.png)

After:
![screen shot 2017-06-28 at 6 35 15 pm](https://user-images.githubusercontent.com/704760/27663500-9abe60f8-5c30-11e7-9260-fec3560b2d5d.png)