### PR TITLE
Move npm credentials to auth token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - "5"
+before_install:
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 before_script:
   - npm config set spin false --global
   - npm install -g gulp
@@ -12,7 +14,6 @@ env:
   global:
   - GH_PROD_BRANCH=master
   - GH_DEV_BRANCH=canary
-  - NPM_USERNAME=cfpbot
   - secure: d+i41c7frpGoSpo6WFwuDz5xgIHz2f5F40SArZUWdZw1+SUtWA+xQm474FY2Fm6QyJxtzRfrDytFap428WptZJryjDkfzuWMqNqw/BR0abeP0htxJ9SOFWqsdwt4d0vWB8JWUVFOSTkOg83cXdnZQt+Lzwgp2uMGc7bCC5/7zu4=
   - secure: NcthmXnpuSzj1nBqjTbraX9l0S/+1Wsj2Y737FI43vFthoqIFfrY4pgmIC2HT46r365e631lW3TRwPQp6QpqSK8e/1lH0nSkPWmyXIAL+y3S6OTPLthtLYNv9MBQVOqjPQu5z44i161yJRaPleAokQkiJxFkwuhzZVa/1idq7EA=
   - secure: OXCVx+umyxvsBBAdDnliKggeeDI6+MJnH01DRz3MSwcG2WMUxtzxKtPL4t03t+wfTmCoGmEMFa8OO1UgwfOoAMNwrEQHPG/AfEnV5A67FKoKY56vUD3rkNcWV5V/IfmQzrYzQSjyjgs19RY+1sD7CKK75bQWYuAQOoNrIpb84gc=

--- a/scripts/travis/release.sh
+++ b/scripts/travis/release.sh
@@ -14,10 +14,8 @@ if [[ -n "$TRAVIS" ]] &&
   exit 0;
 fi
 
-# If NPM env variables are set and we're in Travis
-if [[ -n "$NPM_USERNAME" ]] && [[ -n "$NPM_PASSWORD" ]] && [[ -n "$NPM_EMAIL" ]] && [[ -n "$TRAVIS" ]]; then
-  echo "Logging into npm..."
-  echo -e "${NPM_USERNAME}\n${NPM_PASSWORD}\n${NPM_EMAIL}\n" | npm login
+# If we're in Travis, configure git
+if [[ -n "$TRAVIS" ]]; then
   echo "Adding git credentials..."
   git config user.name "CFPBot"
   git config user.email "CFPBot@users.noreply.github.com"


### PR DESCRIPTION
npm is no longer accepting the `echo -e "${NPM_USERNAME}\n${NPM_PASSWORD}\n${NPM_EMAIL}\n" | npm login` hack so let's try authenticating with an auth token stored on Travis' settings page.