### PR TITLE
Have git ignore dynamically generated .npmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ src/vendor/
 tmp/
 util.js
 dist/
+.npmrc


### PR DESCRIPTION
To prevent "working directory not clean" errors.