### PR TITLE
Fix the spacing and alignment of radio and checkbox inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-forms:** [PATCH] Fix the spacing and alignment of radio and checkbox inputs
 
 ### Removed
-- 
+-
 
 ## 4.8.2 - 2017-07-03
 

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -11,7 +11,7 @@
     &__checkbox,
     &__radio {
         .a-label {
-            vertical-align: middle;
+            vertical-align: top;
             cursor: pointer;
 
             &:before {

--- a/src/cf-forms/src/organisms/form.less
+++ b/src/cf-forms/src/organisms/form.less
@@ -1,6 +1,6 @@
 .o-form {
     &_group {
-        margin-bottom: 30px;
+        margin-bottom: unit( 30px / @base-font-size-px, em );
     }
 
     &_fieldset {
@@ -9,8 +9,8 @@
         margin: 0;
         padding: 0;
 
-        .m-field + .m-field {
-            margin-top: 10px;
+        .m-form-field + .m-form-field {
+            margin-top: unit( 10px / @base-font-size-px, em );
         }
     }
 

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -32,6 +32,7 @@ Capital Framework.
     - [Basic select](#basic-select)
     - [Disabled select](#disabled-select)
 - [Basic multiselect](#basic-multiselect)
+- [Form fieldsets](#form-fieldsets)
 
 
 ## Variables
@@ -393,7 +394,7 @@ creating a typical site search form.
 </div>
 ```
 
-### Basic multiselect
+## Basic multiselect
 
 <div class="m-form-field m-form-field__select">
     <label class="a-label" for="test_select__multiple">Label</label>
@@ -423,4 +424,62 @@ creating a typical site search form.
         <option value="option4">Option 8</option>
     </select>
 </div>
+```
+
+### Form fieldsets
+
+<form class="o-form">
+    <div class="o-form_group">
+        <fieldset class="o-form_fieldset">
+            <div class="m-form-field m-form-field__checkbox">
+                <input class="a-checkbox" type="checkbox" id="test_checkbox_1" name="test_checkbox">
+                <label class="a-label" for="test_checkbox_1">Label</label>
+            </div>
+            <div class="m-form-field m-form-field__checkbox">
+                <input class="a-checkbox" type="checkbox" id="test_checkbox_2" name="test_checkbox">
+                <label class="a-label" for="test_checkbox_2">Label</label>
+            </div>
+        </fieldset>
+    </div>
+    <div class="o-form_group">
+        <fieldset class="o-form_fieldset">
+            <div class="m-form-field m-form-field__radio">
+                <input class="a-radio" type="radio" id="test_radio_1" name="test_radio">
+                <label class="a-label" for="test_radio_1">Label</label>
+            </div>
+            <div class="m-form-field m-form-field__radio">
+                <input class="a-radio" type="radio" id="test_radio_2" name="test_radio">
+                <label class="a-label" for="test_radio_2">Label</label>
+            </div>
+        </fieldset>
+    </div>
+</form>
+
+```
+<form class="o-form">
+    <div class="o-form_group">
+        <fieldset class="o-form_fieldset">
+            <div class="m-form-field m-form-field__checkbox">
+                <input class="a-checkbox" type="checkbox" id="test_checkbox_1" name="test_checkbox">
+                <label class="a-label" for="test_checkbox_1">Label</label>
+            </div>
+            <div class="m-form-field m-form-field__checkbox">
+                <input class="a-checkbox" type="checkbox" id="test_checkbox_2" name="test_checkbox">
+                <label class="a-label" for="test_checkbox_2">Label</label>
+            </div>
+        </fieldset>
+    </div>
+    <div class="o-form_group">
+        <fieldset class="o-form_fieldset">
+            <div class="m-form-field m-form-field__radio">
+                <input class="a-radio" type="radio" id="test_radio_1" name="test_radio">
+                <label class="a-label" for="test_radio_1">Label</label>
+            </div>
+            <div class="m-form-field m-form-field__radio">
+                <input class="a-radio" type="radio" id="test_radio_2" name="test_radio">
+                <label class="a-label" for="test_radio_2">Label</label>
+            </div>
+        </fieldset>
+    </div>
+</form>
 ```


### PR DESCRIPTION
There is currently no space between a list of radios or checkboxes. The
label text is also misaligned vertically.

## Changes

- Added vertical spacing between radios/checkboxes
- Fixed the vertical alignment between the input and the label
- Added basic form group example to the documentation

## Testing

- Follow the instructions for [testing components locally](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally)
- In your gh-pages specific clone, run `npm run build && npm start`
- Navigate to http://localhost:3000/components/cf-forms/#form-groups

## Review

- @anselmbradford 
- @cfarm 
- @Scotchester 

## Screenshots

![screen shot 2017-07-13 at 12 08 48 pm](https://user-images.githubusercontent.com/1280430/28178431-0ab217c6-67c4-11e7-8443-bb0493de4796.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
