### PR TITLE
Fix the background size of overlay hero images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
 - **cf-forms:** [PATCH] Convert fixed pixel units to ems.
+- **cf-layout:** [PATCH] Fix the background size of overlay hero images
 
 ### Removed
-- 
+-
 
 ## 4.8.2 - 2017-07-03
 

--- a/src/cf-layout/src/molecules/heroes.less
+++ b/src/cf-layout/src/molecules/heroes.less
@@ -156,8 +156,9 @@
 
     &__overlay {
         .m-hero_wrapper {
-            background-repeat: no-repeat;
             background-position: center;
+            background-repeat: no-repeat;
+            background-size: cover;
         }
 
         .respond-to-max( @bp-xs-max, {


### PR DESCRIPTION
When the images were moved to the wrapper the background size rule was
accidentally skipped.

## Changes

- Added background size to overlay hero background image

## Testing

- Follow the instructions on testing in your local project (cfgov-refresh in this case)
- Run `gulp build`
- Run `./runserver.sh`
- Navigate to `http://localhost:8000/consumer-tools/credit-reports-and-scores/`

## Review

- @sebworks 
- @cfarm 
- @anselmbradford 
- @Scotchester 

## Screenshots

__Before:__

<img width="1282" alt="screen shot 2017-07-19 at 9 15 45 am" src="https://user-images.githubusercontent.com/1280430/28368598-dd30259c-6c62-11e7-8621-f29479a0892d.png">

__After:__

<img width="1280" alt="screen shot 2017-07-19 at 9 15 35 am" src="https://user-images.githubusercontent.com/1280430/28368605-e3e3351e-6c62-11e7-9c6b-855218fa9d43.png">

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
