### PR TITLE
Convert button links to actual buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
-- **cf-buttons:** Change button links in docs to actual buttons.
+- **cf-buttons:** [PATCH] Change button links in docs to actual buttons.
 - **cf-forms:** [PATCH] Convert fixed pixel units to ems.
 - **cf-layout:** [PATCH] Fix the background size of overlay hero images
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- **cf-buttons:** Change button links in docs to actual buttons.
+- **cf-buttons:** [PATCH] Change button links in docs to actual buttons.
 
 ### Removed
-- 
+-
 
 ## 4.8.3 - 2017-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
-- **cf-buttons:** Convert button links to actual buttons.
+- **cf-buttons:** Change button links in docs to actual buttons.
 
 ### Removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-buttons:** Convert button links to actual buttons.
 
 ### Removed
-- 
+-
 
 ## 4.8.2 - 2017-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
-- **cf-buttons:** [PATCH] Change button links in docs to actual buttons.
+- **cf-buttons:** Change button links in docs to actual buttons.
 - **cf-forms:** [PATCH] Convert fixed pixel units to ems.
 - **cf-layout:** [PATCH] Fix the background size of overlay hero images
 

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -386,66 +386,66 @@ _Reduce screen size to see these in action_
 
 #### Default state
 
-<a href="#" class="a-btn a-btn__link">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary">
+<button href="#" class="a-btn a-btn__link">Button Link</button>
+<button href="#" class="a-btn a-btn__link a-btn__secondary">
     Secondary Button Link
-</a>
-<a href="#" class="a-btn a-btn__link a-btn__warning">Warning Button Link</a>
+</button>
+<button href="#" class="a-btn a-btn__link a-btn__warning">Warning Button Link</button>
 
 ```
-<a href="#" class="a-btn a-btn__link">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary">
+<button href="#" class="a-btn a-btn__link">Button Link</button>
+<button href="#" class="a-btn a-btn__link a-btn__secondary">
     Secondary Button Link
-</a>
-<a href="#" class="a-btn a-btn__link a-btn__warning">Warning Button Link</a>
+</button>
+<button href="#" class="a-btn a-btn__link a-btn__warning">Warning Button Link</button>
 ```
 
 #### Hovered state
 
-<a href="#" class="a-btn a-btn__link hover">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary hover">
+<button href="#" class="a-btn a-btn__link hover">Button Link</button>
+<button href="#" class="a-btn a-btn__link a-btn__secondary hover">
     Secondary Button Link
-</a>
-<a href="#" class="a-btn a-btn__link a-btn__warning hover">Warning Button Link</a>
+</button>
+<button href="#" class="a-btn a-btn__link a-btn__warning hover">Warning Button Link</button>
 
 ```
-<a href="#" class="a-btn a-btn__link hover">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary hover">
+<button href="#" class="a-btn a-btn__link hover">Button Link</button>
+<button href="#" class="a-btn a-btn__link a-btn__secondary hover">
     Secondary Button Link
-</a>
-<a href="#" class="a-btn a-btn__link a-btn__warning hover">Warning Button Link</a>
+</button>
+<button href="#" class="a-btn a-btn__link a-btn__warning hover">Warning Button Link</button>
 ```
 
 #### Focus state
 
-<a href="#" class="a-btn a-btn__link focus">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary focus">
+<button href="#" class="a-btn a-btn__link focus">Button Link</button>
+<button href="#" class="a-btn a-btn__link a-btn__secondary focus">
     Secondary Button Link
-</a>
-<a href="#" class="a-btn a-btn__link a-btn__warning focus">Warning Button Link</a>
+</button>
+<button href="#" class="a-btn a-btn__link a-btn__warning focus">Warning Button Link</button>
 
 ```
-<a href="#" class="a-btn a-btn__link focus">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary focus">
+<button href="#" class="a-btn a-btn__link focus">Button Link</button>
+<button href="#" class="a-btn a-btn__link a-btn__secondary focus">
     Secondary Button Link
-</a>
-<a href="#" class="a-btn a-btn__link a-btn__warning focus">Warning Button Link</a>
+</button>
+<button href="#" class="a-btn a-btn__link a-btn__warning focus">Warning Button Link</button>
 ```
 
 #### Active state
 
-<a href="#" class="a-btn a-btn__link active">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary active">
+<button href="#" class="a-btn a-btn__link active">Button Link</button>
+<button href="#" class="a-btn a-btn__link a-btn__secondary active">
     Secondary Button Link
-</a>
-<a href="#" class="a-btn a-btn__link a-btn__warning active">Warning Button Link</a>
+</button>
+<button href="#" class="a-btn a-btn__link a-btn__warning active">Warning Button Link</button>
 
 ```
-<a href="#" class="a-btn a-btn__link active">Button Link</a>
-<a href="#" class="a-btn a-btn__link a-btn__secondary active">
+<button href="#" class="a-btn a-btn__link active">Button Link</button>
+<button href="#" class="a-btn a-btn__link a-btn__secondary active">
     Secondary Button Link
-</a>
-<a href="#" class="a-btn a-btn__link a-btn__warning active">Warning Button Link</a>
+</button>
+<button href="#" class="a-btn a-btn__link a-btn__warning active">Warning Button Link</button>
 ```
 
 ### Icon buttons


### PR DESCRIPTION
## Changes

- Button links were `a` tags, so essentially styling a link to look like a link. This PR converts them to `button`.

## Testing

- Follow instructions in http://localhost:3000/contributing/#testing-components-locally and visit cf-buttons. 

## Screenshots

<img width="761" alt="screen shot 2017-07-20 at 3 23 32 pm" src="https://user-images.githubusercontent.com/704760/28435163-ed0ab57e-6d5f-11e7-8d56-80031fc72629.png">

