### PR TITLE
Add a full width input modifier to cf-forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Changed
 - **cf-forms:** [PATCH] Convert fixed pixel units to ems.
 - **cf-layout:** [PATCH] Fix the background size of overlay hero images
+- **cf-forms:** [MINOR] Add full width modifier to text inputs
 
 ### Removed
 -

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -1,5 +1,5 @@
 .m-form-field {
-    .a-text-input {
+    .a-text-input__full {
         box-sizing: border-box;
         width: 100%;
     }

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -21,6 +21,7 @@ Capital Framework.
     - [Label heading](#label-heading)
 - [Inputs](#inputs)
     - [Basic Text Inputs](#basic-text-inputs)
+    - [Full-width inputs](#full-width-inputs)
     - [Basic checkboxes](#basic-checkboxes)
     - [Basic radio buttons](#basic-radio-buttons)
     - [Input states](#input-states)
@@ -130,51 +131,51 @@ Inputs should always be paired with a `label` for accessibility reasons.
 
 ### Basic text inputs
 
-<label class="a-label" for="text-input-example">A text input</label>
+<label class="a-label" for="textinput-example">A text input</label>
 <input class="a-text-input"
        type="text"
-       id="text-input example"
+       id="textinput-example"
+       value="Lorem ipsum">
+
+<label class="a-label" for="full-textarea-example">A textarea input</label>
+<textarea class="a-text-input" id="full-textarea-example">Lorem Ipsum</textarea>
+
+```
+<label class="a-label" for="textinput-example">A text input</label>
+<input class="a-text-input"
+       type="text"
+       id="textinput-example"
        value="Lorem ipsum">
 
 <label class="a-label" for="textarea-example">A textarea input</label>
 <textarea class="a-text-input" id="textarea-example">Lorem Ipsum</textarea>
-
-```
-<label class="a-label" for="text-input-example">A text input</label>
-<input class="a-text-input"
-       type="text"
-       id="text-input example"
-       value="Lorem ipsum">
-
-<label class="a-label" for="textarea-example">A textarea input</label>
-<textarea class="a-text-input" id="textarea-example">Lorem Ipsum</textarea>
 ```
 
-### Full width inputs
+### Full-width inputs
 
 <div class="m-form-field">
-    <label class="a-label" for="text-input-example">A text input</label>
+    <label class="a-label" for="full-textinput-example">A full-width text input</label>
     <input class="a-text-input a-text-input__full"
            type="text"
-           id="text-input example"
+           id="full-textinput-example"
            value="Lorem ipsum">
-
-    <label class="a-label" for="textarea-example">A textarea input</label>
+    <br><br>
+    <label class="a-label" for="full-textarea-example">A full-width textarea input</label>
     <textarea class="a-text-input a-text-input__full"
-              id="textarea-example">Lorem Ipsum</textarea>
+              id="full-textarea-example">Lorem Ipsum</textarea>
 </div>
 
 ```
 <div class="m-form-field">
-    <label class="a-label" for="text-input-example">A text input</label>
+    <label class="a-label" for="full-textinput-example">A text input</label>
     <input class="a-text-input a-text-input__full"
            type="text"
-           id="text-input example"
+           id="full-textinput-example"
            value="Lorem ipsum">
 
-    <label class="a-label" for="textarea-example">A textarea input</label>
+    <label class="a-label" for="full-textarea-example">A textarea input</label>
     <textarea class="a-text-input a-text-input__full"
-              id="textarea-example">Lorem Ipsum</textarea>
+              id="full-textarea-example">Lorem Ipsum</textarea>
 </div>
 ```
 

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -150,6 +150,34 @@ Inputs should always be paired with a `label` for accessibility reasons.
 <textarea class="a-text-input" id="textarea-example">Lorem Ipsum</textarea>
 ```
 
+### Full width inputs
+
+<div class="m-form-field">
+    <label class="a-label" for="text-input-example">A text input</label>
+    <input class="a-text-input a-text-input__full"
+           type="text"
+           id="text-input example"
+           value="Lorem ipsum">
+
+    <label class="a-label" for="textarea-example">A textarea input</label>
+    <textarea class="a-text-input a-text-input__full"
+              id="textarea-example">Lorem Ipsum</textarea>
+</div>
+
+```
+<div class="m-form-field">
+    <label class="a-label" for="text-input-example">A text input</label>
+    <input class="a-text-input a-text-input__full"
+           type="text"
+           id="text-input example"
+           value="Lorem ipsum">
+
+    <label class="a-label" for="textarea-example">A textarea input</label>
+    <textarea class="a-text-input a-text-input__full"
+              id="textarea-example">Lorem Ipsum</textarea>
+</div>
+```
+
 ### Basic checkboxes
 
 <div class="m-form-field m-form-field__checkbox">


### PR DESCRIPTION
Inputs often need to fill their container, but not always, so it can not be
the default behavior.

## Additions

- Added full width text input modifier

## Testing

- Follow instructions in [http://localhost:3000/contributing/#testing-components-locally](http://localhost:3000/contributing/#testing-components-locally) and visit cf-forms.

## Review

- @Scotchester 
- @anselmbradford 
- @cfarm 
- @sebworks 

## Screenshots

![screen shot 2017-07-21 at 9 37 05 am](https://user-images.githubusercontent.com/1280430/28467920-697a12fe-6dff-11e7-85d5-0555d039eaa1.png)

## Todos

- Update cfgov-refresh feedback forms to use the new modifier.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
