### PR TITLE
Add `npm install` step to testing on local gh-pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ In this repo:
 In a second local clone of this repo in a different folder:
 
 - make sure you're on the gh-pages branch
+- run `npm install`
 - run `npm run cf-link`
 - run `npm run build`
 - run `npm start`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ In this repo:
 In a second local clone of this repo in a different folder:
 
 - make sure you're on the gh-pages branch
-- run `npm install`
+- [run all the install steps for the project](https://github.com/cfpb/capital-framework/tree/gh-pages#installation)
 - run `npm run cf-link`
 - run `npm run build`
 - run `npm start`


### PR DESCRIPTION
Add `npm install` step to testing on local gh-pages instructions.

When setting up your new clone for testing on gh-pages locally for the first time, you need to run `npm install` for the project before you can run `npm run cf-link`.

## Review

- @jimmynotjim OR @anselmbradford 

## Screenshots

Error you get if you follow the current instructions:
![screen shot 2017-08-01 at 11 40 37 am](https://user-images.githubusercontent.com/702526/28833837-8c1ddb8a-76ae-11e7-8df8-e37d43f8376d.png)


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
