### PR TITLE
Fixes #496 - old jump link references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-layout:** Update outdated jump link references in docs.
 
 ### Removed
-- 
+-
 
 ## 4.8.5 - 2017-07-24
 

--- a/src/cf-layout/usage.md
+++ b/src/cf-layout/usage.md
@@ -1310,8 +1310,12 @@ the available space.
                 instructior ex pri. Cu pri inani constituto, cum aeque noster
                 commodo cu.
             </p>
-            <a class="jump-link jump-link__underline">
-                <span class="jump-link_text">Read more about the feature</span>
+            <a class="a-link
+                      a-link__jump
+                      cf-icon
+                      cf-icon__after
+                      cf-icon-right">
+                <span class="a-link_text">Read more about the feature</span>
             </a>
         </div>
         <div class="o-featured-content-module_visual">
@@ -1337,8 +1341,12 @@ the available space.
                 instructior ex pri. Cu pri inani constituto, cum aeque noster
                 commodo cu.
             </p>
-            <a class="jump-link jump-link__underline">
-                <span class="jump-link_text">Read more about the feature</span>
+            <a class="a-link
+                      a-link__jump
+                      cf-icon
+                      cf-icon__after
+                      cf-icon-right">
+                <span class="a-link_text">Read more about the feature</span>
             </a>
         </div>
         <div class="o-featured-content-module_visual">
@@ -1372,8 +1380,12 @@ side so that the copyright information is displayed.
                 instructior ex pri. Cu pri inani constituto, cum aeque noster
                 commodo cu.
             </p>
-            <a class="jump-link jump-link__underline">
-                <span class="jump-link_text">Read more about the feature</span>
+            <a class="a-link
+                      a-link__jump
+                      cf-icon
+                      cf-icon__after
+                      cf-icon-right">
+                <span class="a-link_text">Read more about the feature</span>
             </a>
         </div>
         <div class="o-featured-content-module_visual">
@@ -1400,8 +1412,12 @@ side so that the copyright information is displayed.
                 instructior ex pri. Cu pri inani constituto, cum aeque noster
                 commodo cu.
             </p>
-            <a class="jump-link jump-link__underline">
-                <span class="jump-link_text">Read more about the feature</span>
+            <a class="a-link
+                      a-link__jump
+                      cf-icon
+                      cf-icon__after
+                      cf-icon-right">
+                <span class="a-link_text">Read more about the feature</span>
             </a>
         </div>
         <div class="o-featured-content-module_visual">
@@ -1436,8 +1452,12 @@ generally remains centered.
                 instructior ex pri. Cu pri inani constituto, cum aeque noster
                 commodo cu.
             </p>
-            <a class="jump-link jump-link__underline">
-                <span class="jump-link_text">Read more about the feature</span>
+            <a class="a-link
+                      a-link__jump
+                      cf-icon
+                      cf-icon__after
+                      cf-icon-right">
+                <span class="a-link_text">Read more about the feature</span>
             </a>
         </div>
         <div class="o-featured-content-module_visual">
@@ -1464,8 +1484,12 @@ generally remains centered.
                 instructior ex pri. Cu pri inani constituto, cum aeque noster
                 commodo cu.
             </p>
-            <a class="jump-link jump-link__underline">
-                <span class="jump-link_text">Read more about the feature</span>
+            <a class="a-link
+                      a-link__jump
+                      cf-icon
+                      cf-icon__after
+                      cf-icon-right">
+                <span class="a-link_text">Read more about the feature</span>
             </a>
         </div>
         <div class="o-featured-content-module_visual">


### PR DESCRIPTION
The layout documentation included older `jump-link` CSS class references. Fixes #496 
## Changes

- Convert `jump-link` to `a-link__jump` in cf-layout usage documentation.

## Testing

- Following local testing directions


## Screenshots

Before:
![screen shot 2017-08-02 at 10 43 46 am](https://user-images.githubusercontent.com/704760/28879321-d7f260aa-776f-11e7-9a04-4d00db646f2d.png)

After:
![screen shot 2017-08-02 at 10 43 40 am](https://user-images.githubusercontent.com/704760/28879332-dc8af9c4-776f-11e7-9cee-cbd138a91cf9.png)


## Notes

- The gap between the arrow and the text has narrowed. Is this expected from the updated markup?
- I'm unclear how this is currently working at all referencing the `jump-link` class in the live docs site. Is that not on CFv4?
- The hover state of the cursor is the I-beam, not a hand for some reason.
