### PR TITLE
Update text input border values to gray-60 to match Design Manual standard

### DIFF
--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -11,7 +11,7 @@
 // https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 // .a-text-input borders
-@input-border:                  #5b616b;
+@input-border:                  #919395;
 @input-border__hover:           #0072ce; // @pacific;
 @input-border__focused:         #0072ce; // @pacific;
 @input-border__active:          #0072ce; // @pacific;

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -11,7 +11,7 @@
 // https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 // .a-text-input borders
-@input-border:                  #919395;
+@input-border:                  #919395; // @gray-60
 @input-border__hover:           #0072ce; // @pacific;
 @input-border__focused:         #0072ce; // @pacific;
 @input-border__active:          #0072ce; // @pacific;

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -46,7 +46,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ```
 // .a-text-input borders
-@input-border:                  #919395;
+@input-border:                  #919395; // @gray-60
 @input-border__hover:           #0072ce; // @pacific;
 @input-border__focused:         #0072ce; // @pacific;
 @input-border__active:          #0072ce; // @pacific;

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -46,7 +46,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ```
 // .a-text-input borders
-@input-border:                  #5b616b;
+@input-border:                  #919395;
 @input-border__hover:           #0072ce; // @pacific;
 @input-border__focused:         #0072ce; // @pacific;
 @input-border__active:          #0072ce; // @pacific;


### PR DESCRIPTION
https://github.com/cfpb/design-manual/pull/503/ updates the standard to grey-60 (used to be gray-40). This makes the change in Capital Framework.

Same change over at cfgov-refresh: https://github.com/cfpb/cfgov-refresh/pull/3218


## Changes

- Change `input-border` variable to grey-60 to match latest Design Manual updates for text inputs and checkboxes
