### PR TITLE
Adds a-label_helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-forms:** [MINOR] Add `a-label_helper` class.
 
 ### Changed
 - **cf-forms:** [PATCH] Convert fixed pixel units to ems.

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -3,6 +3,7 @@
 
     &_helper {
         color: @label-helper;
+        font-size: unit( 14px / @font-size, em );
     }
 
     &__heading {

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -3,7 +3,7 @@
 
     &_helper {
         color: @label-helper;
-        font-size: unit( 14px / @font-size, em );
+        font-size: unit( 14px / @base-font-size-px, em );
     }
 
     &__heading {

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -1,12 +1,16 @@
 .a-label {
     display: inline-block;
-}
 
-.a-label__heading {
-    .heading-4();
+    &_helper {
+        color: @label-helper;
+    }
 
-    display: block;
+    &__heading {
+        .heading-4();
 
-    // Overwrites heading-4 margin.
-    margin-bottom: unit( 10px / @font-size, em );
+        display: block;
+
+        // Overwrites heading-4 margin.
+        margin-bottom: unit( 10px / @font-size, em );
+    }
 }

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -44,7 +44,7 @@
 @input-lg-target__disabled:     #aeb0b5; // $color-gray-light
 
 // .a-label_helper
-@label-helper                   #43484e; // @dark-gray
+@label-helper:                  #43484e; // @dark-gray
 
 // Sizing variables
 

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -43,6 +43,9 @@
 @input-lg-target__selected:     #9bdaf1; // $color-primary-alt-light
 @input-lg-target__disabled:     #aeb0b5; // $color-gray-light
 
+// .a-label_helper
+@label-helper                   #43484e; // @dark-gray
+
 // Sizing variables
 
 // .a-select

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -19,6 +19,7 @@ Capital Framework.
 - [Labels](#labels)
     - [Basic label](#basic-label)
     - [Label heading](#label-heading)
+    - [Label helper text](#label-helper-text)
 - [Inputs](#inputs)
     - [Basic Text Inputs](#basic-text-inputs)
     - [Full-width inputs](#full-width-inputs)
@@ -79,6 +80,9 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 @input-lg-target:               #d6d7d9; // $color-gray-lighter
 @input-lg-target__selected:     #9bdaf1; // $color-primary-alt-light
 @input-lg-target__disabled:     #aeb0b5; // $color-gray-light
+
+// .a-label_helper
+@label-helper                   #43484e; // @dark-gray
 ```
 
 ### Sizing variables
@@ -123,6 +127,20 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 ```
 <label class="a-label a-label__heading">
     A label heading
+</label>
+```
+
+### Label helper text
+
+Used for designating an input as optional for user input.
+
+<label class="a-label">
+    A label <small class="a-label_helper">(optional)</small>
+</label>
+
+```
+<label class="a-label">
+    A label <small class="a-label_helper">(optional)</small>
 </label>
 ```
 


### PR DESCRIPTION
## Additions

- Adds `a-label_helper` class for setting optional text next to a form input.

## Testing

- Follow contributing docs in CF.

## Screenshots

![screen shot 2017-08-10 at 3 39 54 pm](https://user-images.githubusercontent.com/704760/29188903-ac1dbd16-7de2-11e7-9a41-b67cf2566e70.png)

![screen shot 2017-08-10 at 3 40 06 pm](https://user-images.githubusercontent.com/704760/29188916-b22e78f8-7de2-11e7-955c-650d6da056be.png)

![screen shot 2017-08-10 at 3 40 12 pm](https://user-images.githubusercontent.com/704760/29188928-b9c16378-7de2-11e7-85c0-6626c6aebdb7.png)
