### PR TITLE
Remove table row links init method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-forms:** [MINOR] Update default color variables to use brand colors.
 - **cf-buttons:** [MINOR] Update default color variables to use brand colors.
 
-
 ### Removed
--
+- **cf-tables:** [PATCH] Removed unused init method from `cf-table-row-links.js`.
+
 
 ## 4.8.5 - 2017-07-24
 

--- a/src/cf-tables/src/cf-table-row-links.js
+++ b/src/cf-tables/src/cf-table-row-links.js
@@ -33,21 +33,6 @@ var TableRowLinks = {
     target = closest( event.target, 'tr' );
     var link = target.querySelector( 'a' );
     if( link ) window.location = link.getAttribute( 'href' );
-  },
-
-  /**
-   * Handle initilization of Table Row Links. Added for standalone
-   * use cases.
-   *
-   */
-  init: function() {
-    var elements = document.querySelector( TableRowLinks.ui.base );
-    for ( var i = 0; i < elements.length; ++i ) {
-      if( elements[i].hasAttribute( 'data-bound' ) === false ) {
-        elements[i].addEventListener( 'click', table,
-        TableRowLinks.onRowLinkClick );
-      }
-    }
   }
 };
 


### PR DESCRIPTION
## Removals

- Removes unused init method that was created for demo purposes.
