### PR TITLE
Use brand colors in cf-tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-tables:** [PATCH] Fix linting errors.
 - **cf-expandables:** [PATCH] Fix linting errors.
 - **cf-layout:** [MINOR] Update default color variables to use brand colors.
+- **cf-tables:** [MINOR] Update default color variables to use brand colors.
 
 ### Removed
 - **cf-tables:** [PATCH] Removed unused init method from `cf-table-row-links.js`.

--- a/src/cf-tables/src/cf-tables.less
+++ b/src/cf-tables/src/cf-tables.less
@@ -8,15 +8,14 @@
 //
 
 // Color variables
-// `$color-` variables referenced in comments are from 18F's U.S. Web Design Standards
-// https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
-@table-cell-bg:              #ffffff; // $color-white
-@table-cell-bg_alt:          #f1f1f1; // $color-gray-lightest
-@table-row-link-bg-hover:    #205493; // $color-cool-blue
-@table-row-link-hover-color: #ffffff; // $color-white
-@table-scrolling-border:     #e4e2e0; // $color-gray-warm-light
-
+@table-head-bg:                 @gray-10;
+@table-cell-bg:                 @white;
+@table-cell-bg_alt:             @gray-5;
+@table-row-link-bg-hover:       @pacific-80;
+@table-row-link-hover-color:    @white;
+@table-scrolling-border:        @gray-40;
+@table-border:                  @gray;
 
 //
 // Import external dependencies

--- a/src/cf-tables/src/cf-tables.less
+++ b/src/cf-tables/src/cf-tables.less
@@ -9,7 +9,7 @@
 
 // Color variables
 
-@table-head-bg:                 @gray-10;
+@table-head-bg:                 @gray-5;
 @table-cell-bg:                 @white;
 @table-cell-bg_alt:             @gray-5;
 @table-row-link-bg-hover:       @pacific-80;
@@ -31,6 +31,12 @@
         & > td {
             background: @table-cell-bg_alt;
         }
+    }
+}
+
+.o-table {
+    th {
+        background: @table-head-bg;
     }
 }
 

--- a/src/cf-tables/usage.md
+++ b/src/cf-tables/usage.md
@@ -35,15 +35,16 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables referenced in comments are from 18F's
-[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
 
 ```
-@table-cell-bg:              #ffffff; // $color-white
-@table-cell-bg_alt:          #f1f1f1; // $color-gray-lightest
-@table-row-link-bg-hover:    #205493; // $color-cool-blue
-@table-row-link-hover-color: #ffffff; // $color-white
-@table-scrolling-border:     #e4e2e0; // $color-gray-warm-light
+@table-head-bg:                 @gray-10;
+@table-cell-bg:                 @white;
+@table-cell-bg_alt:             @gray-5;
+@table-row-link-bg-hover:       @pacific-80;
+@table-row-link-hover-color:    @white;
+@table-scrolling-border:        @gray-40;
+@table-border:                  @gray;
 ```
 
 

--- a/src/cf-tables/usage.md
+++ b/src/cf-tables/usage.md
@@ -38,7 +38,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
 
 ```
-@table-head-bg:                 @gray-10;
+@table-head-bg:                 @gray-5;
 @table-cell-bg:                 @white;
 @table-cell-bg_alt:             @gray-5;
 @table-row-link-bg-hover:       @pacific-80;


### PR DESCRIPTION
Adds CFPB brand colors as the default variable values for colors in `cf-tables`. 


## Testing

In this repo:
- check out this branch
- run `npm run cf-link`

In a second local clone of this repo in a different folder:

- pull down and check out the `gh-pages-rm-overrides` branch: `git fetch && git checkout gh-pages-rm-overrides`
- if you haven't already in this second clone, [run all the install steps for the project](https://github.com/cfpb/capital-framework/tree/gh-pages#installation)
- run `npm run cf-link`
- run `npm run build`
- run `npm start`
- Compare colors on local site: 
   - http://localhost:3000/components/cf-tables/ 
   - to the live example here to make sure they match: https://www.consumerfinance.gov/about-us/doing-business-with-us/upcoming-procurement-needs/

## Review

- @anselmbradford 

## Screenshots
![screen shot 2017-09-05 at 6 11 14 pm](https://user-images.githubusercontent.com/702526/30085679-a91c633c-9265-11e7-9183-cc1487261315.png)
![screen shot 2017-09-05 at 6 11 09 pm](https://user-images.githubusercontent.com/702526/30085678-a91c16ac-9265-11e7-9a95-86dcac47e5c1.png)



## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
