### PR TITLE
Use brand colors for cf-typography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-expandables:** [PATCH] Fix linting errors.
 - **cf-layout:** [MINOR] Update default color variables to use brand colors.
 - **cf-pagination:** [MINOR] Update default color variables to use brand colors.
+- **cf-typography:** [MINOR] Update default color variables to use brand colors.
 
 ### Removed
 - **cf-tables:** [PATCH] Removed unused init method from `cf-table-row-links.js`.

--- a/src/cf-typography/src/cf-typography.less
+++ b/src/cf-typography/src/cf-typography.less
@@ -8,41 +8,39 @@
 //
 
 // Color variables
-// `$color-` variables referenced in comments are from 18F's U.S. Web Design Standards
-// https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
 
 // Running text elements
 
 // .a-micro-copy
-@micro-copy:                #112e51; // $color-primary-darkest
+@micro-copy:                    @black;
 
 // .a-date
-@date:                      #112e51; // $color-primary-darkest
+@date:                          @gray;
 
 // .m-pull-quote
-@pull-quote_body:           #494440; // $color-gray-warm-dark
-@pull-quote_citation:       #205493; // $color-cool-blue
+@pull-quote_body:               @black;
+@pull-quote_citation:           @gray;
 
 // Headings
 
 // .a-heading__icon
-@heading__icon:             #112e51; // $color-primary-darkest
-@heading__icon__hover:      #205493; // $color-primary-darker
+@heading__icon:                 @black;
+@heading__icon__hover:          @link-text-hover;
 
 // Headers
 
 // .m-slug-header
-@slug-header_border__thin:  #323a45; // $color-gray-dark
-@slug-header_border__thick: #02bfe7; // $color-primary-alt
+@slug-header_border__thin:      @gray-10;
+@slug-header_border__thick:     @green;
 
 // .m-meta-header
-@meta-header_border:        #323a45; // $color-gray-dark
+@meta-header_border:            @gray-40;
 
 // Links
 
 // .a-link__jump
-@jump-link_bg:              #f1f1f1; // $color-gray-lightest
-@jump-link_border:          #323a45; // $color-gray-dark
+@jump-link_bg:                  @gray-10;
+@jump-link_border:              @gray-40;
 
 
 //

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -45,8 +45,6 @@ project by duplicating the variable `@key: value`.
 Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
 
 ```
-// Color variables
-
 // Running text elements
 
 // .a-micro-copy

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -42,42 +42,43 @@ project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-`$color-` variables referenced in comments are from 18F's
-[U.S. Web Design Standards](https://github.com/18F/web-design-standards/blob/staging/src/stylesheets/core/_variables.scss)
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
 
 ```
+// Color variables
+
 // Running text elements
 
 // .a-micro-copy
-@micro-copy:                #112e51; // $color-primary-darkest
+@micro-copy:                    @black;
 
 // .a-date
-@date:                      #112e51; // $color-primary-darkest
+@date:                          @gray;
 
 // .m-pull-quote
-@pull-quote_body:           #494440; // $color-gray-warm-dark
-@pull-quote_citation:       #205493; // $color-cool-blue
+@pull-quote_body:               @black;
+@pull-quote_citation:           @gray;
 
 // Headings
 
 // .a-heading__icon
-@heading__icon:             #112e51; // $color-primary-darkest
-@heading__icon__hover:      #205493; // $color-primary-darker
+@heading__icon:                 @black;
+@heading__icon__hover:          @link-text-hover;
 
 // Headers
 
 // .m-slug-header
-@slug-header_border__thin:  #323a45; // $color-gray-dark
-@slug-header_border__thick: #02bfe7; // $color-primary-alt
+@slug-header_border__thin:      @gray-10;
+@slug-header_border__thick:     @green;
 
 // .m-meta-header
-@meta-header_border:        #323a45; // $color-gray-dark
+@meta-header_border:            @gray-40;
 
 // Links
 
 // .a-link__jump
-@jump-link_bg:              #f1f1f1; // $color-gray-lightest
-@jump-link_border:          #323a45; // $color-gray-dark
+@jump-link_bg:                  @gray-10;
+@jump-link_border:              @gray-40;
 ```
 
 


### PR DESCRIPTION
Adds CFPB brand colors as the default variable values for colors in `cf-typography`. 


## Testing

In this repo:
- check out this branch
- run `npm run cf-link`

In a second local clone of this repo in a different folder:

- pull down and check out the `gh-pages-rm-overrides` branch: `git fetch && git checkout gh-pages-rm-overrides`
- if you haven't already in this second clone, [run all the install steps for the project](https://github.com/cfpb/capital-framework/tree/gh-pages#installation)
- run `npm run cf-link`
- run `npm run build`
- run `npm start`
- Review colors on local site: 
   - http://localhost:3000/components/cf-typography/ 
   - Compare to live site - https://cfpb.github.io/capital-framework/components/cf-typography/#slug-header slug header should be green locally, not blue. All local examples should use brand colors.

## Review

- @anselmbradford 

## Screenshots
![screen shot 2017-09-06 at 10 46 54 am](https://user-images.githubusercontent.com/702526/30118364-d843861e-92f0-11e7-9a1a-78514cee3341.png)


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
