### PR TITLE
Adds state sidecar .hover to basic inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+- **cf-forms:** [PATCH] Add sidecar `.hover` classes to basic inputs,
+  for manually triggering hover/focus state.
 
 ### Changed
-- 
+-
 
 ### Removed
-- 
+-
 
 ## 4.9.2 - 2017-09-07
 

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -31,8 +31,9 @@
                 }
             }
 
-            &:hover:before {
-                border-color: @input-border__focused;
+            &:hover:before,
+            &.hover:before {
+                border-color: @input-border__hover;
             }
         }
 
@@ -73,7 +74,8 @@
 
         .a-checkbox {
             &:focus + .a-label:before,
-            &:hover + .a-label:before {
+            &:hover + .a-label:before,
+            &.hover + .a-label:before {
                 border-color: @input-border__focused;
                 outline: 1px solid @input-border__focused;
             }
@@ -93,7 +95,8 @@
 
         .a-radio {
             &:focus + .a-label:before,
-            &:hover + .a-label:before {
+            &:hover + .a-label:before,
+            &.hover + .a-label:before {
                 outline: none;
                 border-color: @input-border__focused;
                 box-shadow: 0 0 0 1px @input-border__focused;
@@ -105,7 +108,8 @@
             }
 
             &:focus:checked + .a-label:before,
-            &:hover:checked + .a-label:before {
+            &:hover:checked + .a-label:before,
+            &.hover:checked + .a-label:before {
                 border-color: @input-border__focused;
                 box-shadow: 0 0 0 1px @input-border__focused, inset 0 0 0 2px #fff;
             }

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -201,29 +201,131 @@ Inputs should always be paired with a `label` for accessibility reasons.
 
 ### Basic checkboxes
 
+The default section below demonstrates how a checkbox would normally
+appear in code.
+
+#### Default
+
 <div class="m-form-field m-form-field__checkbox">
-    <input class="a-checkbox" type="checkbox" id="test_checkbox">
-    <label class="a-label" for="test_checkbox">Label</label>
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_default">
+    <label class="a-label" for="test_checkbox_basic_default">Label</label>
 </div>
 
 ```
 <div class="m-form-field m-form-field__checkbox">
     <input class="a-checkbox" type="checkbox" id="test_checkbox">
     <label class="a-label" for="test_checkbox">Label</label>
+</div>
+```
+
+The following sections demonstrate how a particular state of a checkbox
+could be forced to be shown.
+Generally this is only useful for documentation purposes.
+
+#### Hover/Focus
+
+<div class="m-form-field m-form-field__checkbox">
+    <input class="a-checkbox hover" type="checkbox" id="test_checkbox_basic_hover">
+    <label class="a-label" for="test_checkbox_basic_hover">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__checkbox">
+    <input class="a-checkbox hover" type="checkbox" id="test_checkbox_basic_hover">
+    <label class="a-label" for="test_checkbox_basic_hover">Label</label>
+</div>
+```
+
+#### Selected
+
+<div class="m-form-field m-form-field__checkbox">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_checked" checked>
+    <label class="a-label" for="test_checkbox_basic_checked">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__checkbox">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_checked" checked>
+    <label class="a-label" for="test_checkbox_basic_checked">Label</label>
+</div>
+```
+
+#### Disabled
+
+<div class="m-form-field m-form-field__checkbox">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_disabled" disabled>
+    <label class="a-label" for="test_checkbox_basic_disabled">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__checkbox">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_disabled" disabled>
+    <label class="a-label" for="test_checkbox_basic_disabled">Label</label>
 </div>
 ```
 
 ### Basic radio buttons
 
+The default section below demonstrates how a radio button would normally
+appear in code.
+
+#### Default
+
 <div class="m-form-field m-form-field__radio">
-    <input class="a-radio" type="radio" id="test_radio">
-    <label class="a-label" for="test_radio">Label</label>
+    <input class="a-radio" type="radio" id="test_radio_basic_default">
+    <label class="a-label" for="test_radio_basic_default">Label</label>
 </div>
 
 ```
 <div class="m-form-field m-form-field__radio">
-    <input class="a-radio" type="radio" id="test_radio">
-    <label class="a-label" for="test_radio">Label</label>
+    <input class="a-radio" type="radio" id="test_radio_basic_default">
+    <label class="a-label" for="test_radio_basic_default">Label</label>
+</div>
+```
+
+The following sections demonstrate how a particular state of a radio button
+could be forced to be shown.
+Generally this is only useful for documentation purposes.
+
+#### Hover/Focus
+
+<div class="m-form-field m-form-field__radio">
+    <input class="a-radio hover" type="radio" id="test_radio_basic_hover">
+    <label class="a-label" for="test_radio_basic_hover">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__radio">
+    <input class="a-radio hover" type="radio" id="test_radio_basic_hover">
+    <label class="a-label" for="test_radio_basic_hover">Label</label>
+</div>
+```
+
+#### Selected
+
+<div class="m-form-field m-form-field__radio">
+    <input class="a-radio" type="radio" id="test_radio_basic_checked" checked>
+    <label class="a-label" for="test_radio_basic_checked">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__radio">
+    <input class="a-radio" type="radio" id="test_radio_basic_checked" checked>
+    <label class="a-label" for="test_radio_basic_checked">Label</label>
+</div>
+```
+
+#### Disabled
+
+<div class="m-form-field m-form-field__radio">
+    <input class="a-radio" type="radio" id="test_radio_basic_disabled" disabled>
+    <label class="a-label" for="test_radio_basic_disabled">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__radio">
+    <input class="a-radio" type="radio" id="test_radio_basic_disabled" disabled>
+    <label class="a-label" for="test_radio_basic_disabled">Label</label>
 </div>
 ```
 


### PR DESCRIPTION
`a-btn__link` have a `hover` class for manually triggering the hover state. This adds that to basic form inputs.

## Additions

- Adds sidebar `.hover` class to support manually triggering the hover/focus state in documentation.

## Testing

- `git fetch && git checkout form_states`
- `npm run cf-link`
- Switch to a CF clone repo.
- `git fetch && git checkout gh-pages-form_states`
- `npm run cf-link`
- `npm run build && npm start`

## Screenshots

![screen shot 2017-09-08 at 3 16 55 pm](https://user-images.githubusercontent.com/704760/30227860-485c1560-94a9-11e7-96e4-97eb72720ddc.png)

![screen shot 2017-09-08 at 3 17 01 pm](https://user-images.githubusercontent.com/704760/30227859-485a6f6c-94a9-11e7-870b-e58ee864348e.png)


## Notes

- I converted
```
&:hover:before {
        border-color: @input-border__focused;
}
```
…to…
```
&:hover:before,
&.hover:before {
        border-color: @input-border__hover;
}
```
…which made me realize we have variables for `@input-border__focused` and `@input-border__hover`, but since the CSS for those two states is separate in the basic inputs those variables will not work as expected in regard to checkboxes and radio buttons. Opened issue https://github.com/cfpb/capital-framework/issues/600