### PR TITLE
Adds states for large checkboxes/radio buttons + disabled states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- **cf-forms:** [PATCH] Add sidecar `.hover` classes to basic inputs,
-  for manually triggering hover/focus state.
+- **cf-forms:** [PATCH] Add sidecar `.hover` classes to basic inputs
+  and drop-down for manually triggering hover/focus state.
 
 ### Changed
--
+- **cf-forms:** [PATCH] Adds CSS to target disabled option color in drop-downs.
 
 ### Removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- **cf-forms:** [PATCH] Add sidecar `.hover` classes to basic inputs
-  and drop-down for manually triggering hover/focus state.
+- **cf-forms:** [PATCH] Add sidecar `.hover` classes to basic inputs,
+  for manually triggering hover/focus state.
+- **cf-forms:** [PATCH] Update disabled state appearance for checkboxes/radio.
 
 ### Changed
 - **cf-forms:** [PATCH] Adds CSS to target disabled option color in drop-downs.

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -21,7 +21,7 @@
 // .a-text-input backgrounds
 @input-bg:                      @white;
 @input-bg__selected:            @pacific;
-@input-bg__disabled:            @gray-10;
+@input-bg__disabled:            @gray-20;
 
 // .a-text-input text
 @input-text__disabled:          @gray;
@@ -37,9 +37,9 @@
 @select-text__disabled:         @input-text__disabled;
 
 // .m-form-field__lg-target
-@input-lg-target:               @gray-10;
-@input-lg-target__selected:     @pacific-20;
-@input-lg-target__disabled:     @gray-20;
+@input-lg-target-bg:            @gray-10;
+@input-lg-target-bg__selected:  @pacific-20;
+@input-lg-target-bg__disabled:  @gray-20;
 
 // .a-label_helper
 @label-helper:                  @gray;

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -39,7 +39,7 @@
 // .m-form-field__lg-target
 @input-lg-target:               @gray-10;
 @input-lg-target__selected:     @pacific-20;
-@input-lg-target__disabled:     @input-lg-target;
+@input-lg-target__disabled:     @gray-20;
 
 // .a-label_helper
 @label-helper:                  @gray;

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -64,6 +64,7 @@
 
                 & + .a-label {
                     cursor: not-allowed;
+                    color: @input-text__disabled;
 
                     &:before {
                         background: @input-bg__disabled;
@@ -131,7 +132,7 @@
         .a-label {
             display: block;
             padding: 15px;
-            background-color: @input-lg-target;
+            background-color: @input-lg-target-bg;
         }
 
         .a-checkbox,
@@ -142,16 +143,15 @@
             }
 
             &:checked + .a-label {
-                background-color: @input-lg-target__selected;
+                background-color: @input-lg-target-bg__selected;
             }
 
             &:disabled + .a-label,
             &:hover:disabled + .a-label {
-                color: @input-lg-target__disabled;
+                color: @input-text__disabled;
 
                 &:before {
-                    border: none;
-                    background-color: @input-lg-target__disabled;
+                    background-color: @input-lg-target-bg__disabled;
                     font-family: 'CFPB Minicons';
                     font-size: unit( 20px / 18px, em );
                 }

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -52,12 +52,22 @@
                 clear: both;
             }
 
-            &:disabled + .a-label {
-                cursor: not-allowed;
+            &:disabled {
 
-                &:before {
+                &:focus + .a-label:before,
+                &:hover + .a-label:before,
+                &.hover + .a-label:before {
                     border-color: @input-border;
-                    background: @input-bg__disabled;
+                    outline: none;
+                    box-shadow: none; // Applies only to radio buttons.
+                }
+
+                & + .a-label {
+                    cursor: not-allowed;
+
+                    &:before {
+                        background: @input-bg__disabled;
+                    }
                 }
             }
         }
@@ -120,9 +130,7 @@
 
         .a-label {
             display: block;
-
             padding: 15px;
-
             background-color: @input-lg-target;
         }
 
@@ -137,13 +145,13 @@
                 background-color: @input-lg-target__selected;
             }
 
-            &:disabled + .a-label {
+            &:disabled + .a-label,
+            &:hover:disabled + .a-label {
+                color: @input-lg-target__disabled;
 
                 &:before {
                     border: none;
-                    background-color: transparent;
-                    color: @input-lg-target__disabled;
-                    content: @cf-icon-minus-round;
+                    background-color: @input-lg-target__disabled;
                     font-family: 'CFPB Minicons';
                     font-size: unit( 20px / 18px, em );
                 }

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -22,12 +22,28 @@ Capital Framework.
     - [Label helper text](#label-helper-text)
 - [Inputs](#inputs)
     - [Basic Text Inputs](#basic-text-inputs)
+        - [Disabled state](#disabled-state)
     - [Full-width inputs](#full-width-inputs)
     - [Basic checkboxes](#basic-checkboxes)
+        - [Default state](#default-state)
+        - [Hover/focus state](#hoverfocus-state)
+        - [Selected state](#selected-state)
+        - [Disabled state](#disabled-state)
     - [Basic radio buttons](#basic-radio-buttons)
+        - [Default state](#default-state)
+        - [Hover/focus state](#hoverfocus-state)
+        - [Selected state](#selected-state)
+        - [Disabled state](#disabled-state)
     - [Large target area checkboxes](#large-target-area-checkboxes)
+        - [Default state](#default-state)
+        - [Hover/focus state](#hoverfocus-state)
+        - [Selected state](#selected-state)
+        - [Disabled state](#disabled-state)
     - [Large target area radio buttons](#large-target-area-radio-buttons)
-    - [Input states](#input-states)
+        - [Default state](#default-state)
+        - [Hover/focus state](#hoverfocus-state)
+        - [Selected state](#selected-state)
+        - [Disabled state](#disabled-state)
 - [Buttons](#buttons)
     - [Simple input with a button](#simple-input-with-a-button)
     - [Button inside an input](#button-inside-an-input)
@@ -94,6 +110,7 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 @select-height:                  30px;
 ```
 
+
 ## Legends
 
 <legend class="a-legend">
@@ -105,6 +122,7 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
     A basic legend
 </legend>
 ```
+
 
 ## Labels
 
@@ -146,6 +164,7 @@ Used for designating an input as optional for user input.
 </label>
 ```
 
+
 ## Inputs
 
 Inputs should always be paired with a `label` for accessibility reasons.
@@ -170,6 +189,22 @@ Inputs should always be paired with a `label` for accessibility reasons.
 
 <label class="a-label" for="textarea-example">A textarea input</label>
 <textarea class="a-text-input" id="textarea-example">Lorem Ipsum</textarea>
+```
+
+#### Disabled state
+
+<input class="a-text-input disabled"
+       disabled="true"
+       autocomplete="off"
+       type="text"
+       value="Disabled input">
+
+```
+<input class="a-text-input disabled"
+       disabled="true"
+       autocomplete="off"
+       type="text"
+       value="Disabled input">
 ```
 
 ### Full-width inputs
@@ -200,12 +235,13 @@ Inputs should always be paired with a `label` for accessibility reasons.
 </div>
 ```
 
+
 ### Basic checkboxes
 
 The default section below demonstrates how a checkbox would normally
 appear in code.
 
-#### Default
+#### Default state
 
 <div class="m-form-field m-form-field__checkbox">
     <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_default">
@@ -223,7 +259,7 @@ The following sections demonstrate how a particular state of a checkbox
 could be forced to be shown.
 Generally this is only useful for documentation purposes.
 
-#### Hover/Focus
+#### Hover/focus state
 
 <div class="m-form-field m-form-field__checkbox">
     <input class="a-checkbox hover" type="checkbox" id="test_checkbox_basic_hover">
@@ -237,7 +273,7 @@ Generally this is only useful for documentation purposes.
 </div>
 ```
 
-#### Selected
+#### Selected state
 
 <div class="m-form-field m-form-field__checkbox">
     <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_checked" checked>
@@ -251,7 +287,7 @@ Generally this is only useful for documentation purposes.
 </div>
 ```
 
-#### Disabled
+#### Disabled state
 
 <div class="m-form-field m-form-field__checkbox">
     <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_disabled" disabled>
@@ -264,13 +300,14 @@ Generally this is only useful for documentation purposes.
     <label class="a-label" for="test_checkbox_basic_disabled">Label</label>
 </div>
 ```
+
 
 ### Basic radio buttons
 
 The default section below demonstrates how a radio button would normally
 appear in code.
 
-#### Default
+#### Default state
 
 <div class="m-form-field m-form-field__radio">
     <input class="a-radio" type="radio" id="test_radio_basic_default">
@@ -288,7 +325,7 @@ The following sections demonstrate how a particular state of a radio button
 could be forced to be shown.
 Generally this is only useful for documentation purposes.
 
-#### Hover/Focus
+#### Hover/focus state
 
 <div class="m-form-field m-form-field__radio">
     <input class="a-radio hover" type="radio" id="test_radio_basic_hover">
@@ -302,7 +339,7 @@ Generally this is only useful for documentation purposes.
 </div>
 ```
 
-#### Selected
+#### Selected state
 
 <div class="m-form-field m-form-field__radio">
     <input class="a-radio" type="radio" id="test_radio_basic_checked" checked>
@@ -316,7 +353,7 @@ Generally this is only useful for documentation purposes.
 </div>
 ```
 
-#### Disabled
+#### Disabled state
 
 <div class="m-form-field m-form-field__radio">
     <input class="a-radio" type="radio" id="test_radio_basic_disabled" disabled>
@@ -329,55 +366,137 @@ Generally this is only useful for documentation purposes.
     <label class="a-label" for="test_radio_basic_disabled">Label</label>
 </div>
 ```
+
 
 ### Large target area checkboxes
 
+The default section below demonstrates how a checkbox would normally
+appear in code.
+
+#### Default state
+
 <div class="m-form-field m-form-field__checkbox m-form-field__lg-target">
-    <input class="a-checkbox" type="checkbox" id="test_checkbox_lg">
-    <label class="a-label" for="test_checkbox_lg">Label</label>
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_lg_default">
+    <label class="a-label" for="test_checkbox_lg_default">Label</label>
 </div>
 
 ```
 <div class="m-form-field m-form-field__checkbox m-form-field__lg-target">
-    <input class="a-checkbox" type="checkbox" id="test_checkbox_lg">
-    <label class="a-label" for="test_checkbox_lg">Label</label>
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_lg_default">
+    <label class="a-label" for="test_checkbox_lg_default">Label</label>
+</div>
+```
+
+The following sections demonstrate how a particular state of a checkbox
+could be forced to be shown.
+Generally this is only useful for documentation purposes.
+
+#### Hover/focus state
+
+<div class="m-form-field m-form-field__checkbox m-form-field__lg-target">
+    <input class="a-checkbox hover" type="checkbox" id="test_checkbox_lg_hover">
+    <label class="a-label" for="test_checkbox_lg_hover">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__checkbox m-form-field__lg-target">
+    <input class="a-checkbox hover" type="checkbox" id="test_checkbox_lg_hover">
+    <label class="a-label" for="test_checkbox_lg_hover">Label</label>
+</div>
+```
+
+#### Selected state
+
+<div class="m-form-field m-form-field__checkbox m-form-field__lg-target">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_lg_checked" checked>
+    <label class="a-label" for="test_checkbox_lg_checked">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__checkbox m-form-field__lg-target">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_lg_checked" checked>
+    <label class="a-label" for="test_checkbox_lg_checked">Label</label>
+</div>
+```
+
+#### Disabled state
+
+<div class="m-form-field m-form-field__checkbox m-form-field__lg-target">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_lg_disabled" disabled>
+    <label class="a-label" for="test_checkbox_lg_disabled">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__checkbox m-form-field__lg-target">
+    <input class="a-checkbox" type="checkbox" id="test_checkbox_lg_disabled" disabled>
+    <label class="a-label" for="test_checkbox_lg_disabled">Label</label>
 </div>
 ```
 
 
 ### Large target area radio buttons
 
+The default section below demonstrates how a radio button would normally
+appear in code.
+
+#### Default state
+
 <div class="m-form-field m-form-field__radio m-form-field__lg-target">
-    <input class="a-radio" type="radio" id="test_radio_lg">
-    <label class="a-label" for="test_radio_lg">Label</label>
+    <input class="a-radio" type="radio" id="test_radio_lg_default">
+    <label class="a-label" for="test_radio_lg_default">Label</label>
 </div>
 
 ```
 <div class="m-form-field m-form-field__radio m-form-field__lg-target">
-    <input class="a-radio" type="radio" id="test_radio_lg">
-    <label class="a-label" for="test_radio_lg">Label</label>
+    <input class="a-radio" type="radio" id="test_radio_lg_default">
+    <label class="a-label" for="test_radio_lg_default">Label</label>
 </div>
 ```
 
+The following sections demonstrate how a particular state of a radio button
+could be forced to be shown.
+Generally this is only useful for documentation purposes.
 
-### Input states
+#### Hover/focus state
 
-See the 'Form icons' section below for guidance on adding icons to states.
+<div class="m-form-field m-form-field__radio m-form-field__lg-target">
+    <input class="a-radio hover" type="radio" id="test_radio_lg_hover">
+    <label class="a-label" for="test_radio_lg_hover">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__radio m-form-field__lg-target">
+    <input class="a-radio hover" type="radio" id="test_radio_lg_hover">
+    <label class="a-label" for="test_radio_lg_hover">Label</label>
+</div>
+```
+
+#### Selected state
+
+<div class="m-form-field m-form-field__radio m-form-field__lg-target">
+    <input class="a-radio" type="radio" id="test_radio_lg_checked" checked>
+    <label class="a-label" for="test_radio_lg_checked">Label</label>
+</div>
+
+```
+<div class="m-form-field m-form-field__radio m-form-field__lg-target">
+    <input class="a-radio" type="radio" id="test_radio_lg_checked" checked>
+    <label class="a-label" for="test_radio_lg_checked">Label</label>
+</div>
+```
 
 #### Disabled state
 
-<input class="a-text-input disabled"
-       disabled="true"
-       autocomplete="off"
-       type="text"
-       value="Disabled input">
+<div class="m-form-field m-form-field__radio m-form-field__lg-target">
+    <input class="a-radio" type="radio" id="test_radio_lg_disabled" disabled>
+    <label class="a-label" for="test_radio_lg_disabled">Label</label>
+</div>
 
 ```
-<input class="a-text-input disabled"
-       disabled="true"
-       autocomplete="off"
-       type="text"
-       value="Disabled input">
+<div class="m-form-field m-form-field__radio m-form-field__lg-target">
+    <input class="a-radio" type="radio" id="test_radio_lg_disabled" disabled>
+    <label class="a-label" for="test_radio_lg_disabled">Label</label>
+</div>
 ```
 
 ### Inline Form Validation
@@ -410,6 +529,7 @@ See the 'Form icons' section below for guidance on adding icons to states.
 </div>
 ```
 
+
 ## Buttons
 
 ### Simple input with a button
@@ -435,6 +555,7 @@ These are used for simple forms where a full filter isn't necessary.
     </div>
 </div>
 ```
+
 
 ### Button inside an input
 
@@ -468,6 +589,7 @@ typically to clear the input.
     </button>
 </div>
 ```
+
 
 ### Button inside an input with a button
 
@@ -610,6 +732,7 @@ Generally this is only useful for documentation purposes.
 </div>
 ```
 
+
 ## Basic multiselect
 
 <div class="m-form-field m-form-field__select">
@@ -642,7 +765,7 @@ Generally this is only useful for documentation purposes.
 </div>
 ```
 
-### Form fieldsets
+## Form fieldsets
 
 <form class="o-form">
     <div class="o-form_group">


### PR DESCRIPTION
## Changes

- Add states for large checkboxes/radio buttons.
- Update disabled states for checkboxes/radio buttons.

## Testing

- `git fetch && git checkout form_states`
- `npm run cf-link`
- Switch to a CF clone repo.
- `git fetch && git checkout gh-pages-form_states`
- `npm run cf-link`
- `npm run build && npm start`

## Screenshots


![screen shot 2017-09-13 at 12 03 12 pm](https://user-images.githubusercontent.com/704760/30387831-cd7fd21a-987b-11e7-85e0-b2ee9b44d2e1.png)

![screen shot 2017-09-13 at 12 03 21 pm](https://user-images.githubusercontent.com/704760/30387832-cd805e38-987b-11e7-9472-6a01b26326b1.png)

![screen shot 2017-09-13 at 12 02 55 pm](https://user-images.githubusercontent.com/704760/30387829-cd7a228e-987b-11e7-8aa9-813b221ac92b.png)

![screen shot 2017-09-13 at 12 03 03 pm](https://user-images.githubusercontent.com/704760/30387830-cd7d6728-987b-11e7-986c-e864d58929fb.png)

## Todos

- We need to handle when both the `disabled` and `checked` attributes are added to checkboxes/radio buttons.
