### PR TITLE
Adds sidebar .hover class to dropdown

### DIFF
--- a/src/cf-forms/src/atoms/select.less
+++ b/src/cf-forms/src/atoms/select.less
@@ -15,6 +15,7 @@
         color: @text;
 
         &:hover,
+        &.hover,
         &:active,
         &:focus {
             outline: 2px solid @input-border__focused;

--- a/src/cf-forms/src/atoms/select.less
+++ b/src/cf-forms/src/atoms/select.less
@@ -33,6 +33,8 @@
         }
     }
 
+    select[disabled] option,
+    select[disabled] option:disabled,
     select option:disabled {
         color: @select-text__disabled;
     }

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -33,8 +33,9 @@ Capital Framework.
     - [Button inside an input](#button-inside-an-input)
     - [Button inside an input with a button](#button-inside-an-input-with-a-button)
 - [Select dropdown](#select-dropdown)
-    - [Basic select](#basic-select)
-    - [Disabled select](#disabled-select)
+    - [Default state](#default-state)
+    - [Hover/focus state](#hoverfocus-state)
+    - [Disabled state](#disabled-state)
 - [Basic multiselect](#basic-multiselect)
 - [Form fieldsets](#form-fieldsets)
 
@@ -518,12 +519,15 @@ creating a typical site search form.
 
 ## Select dropdown
 
-### Basic select
+The default section below demonstrates how a dropdown would normally
+appear in code.
+
+### Default state
 
 <div class="m-form-field m-form-field__select">
-    <label class="a-label" for="test_select">Label</label>
+    <label class="a-label" for="test_select_default">Label</label>
     <div class="a-select">
-        <select id="test_select">
+        <select id="test_select_default">
             <option value="option1">Option 1</option>
             <option value="option2">Option 2</option>
             <option value="option3">Option 3</option>
@@ -534,9 +538,9 @@ creating a typical site search form.
 
 ```
 <div class="m-form-field m-form-field__select">
-    <label class="a-label" for="test_select">Label</label>
+    <label class="a-label" for="test_select_default">Label</label>
     <div class="a-select">
-        <select id="test_select">
+        <select id="test_select_default">
             <option value="option1">Option 1</option>
             <option value="option2">Option 2</option>
             <option value="option3">Option 3</option>
@@ -546,7 +550,39 @@ creating a typical site search form.
 </div>
 ```
 
-### Disabled select
+The following sections demonstrate how a particular state of a dropdown
+could be forced to be shown.
+Generally this is only useful for documentation purposes.
+
+### Hover/focus state
+
+<div class="m-form-field m-form-field__select">
+    <label class="a-label" for="test_select__hover">Label</label>
+    <div class="a-select">
+        <select id="test_select__hover" class="hover">
+            <option value="option1">Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+            <option value="option4">Option 4</option>
+        </select>
+    </div>
+</div>
+
+```
+<div class="m-form-field m-form-field__select">
+    <label class="a-label" for="test_select__hover">Label</label>
+    <div class="a-select">
+        <select id="test_select__hover" class="hover">
+            <option value="option1">Option 1</option>
+            <option value="option2">Option 2</option>
+            <option value="option3">Option 3</option>
+            <option value="option4">Option 4</option>
+        </select>
+    </div>
+</div>
+```
+
+### Disabled state
 
 <div class="m-form-field m-form-field__select">
     <label class="a-label" for="test_select__disabled">Label</label>


### PR DESCRIPTION
## Additions

- Adds `.hover` class to dropdown and updates docs to show hover/focus state.

## Testing

- `git fetch && git checkout form_states`
- `npm run cf-link`
- Switch to a CF clone repo.
- `git fetch && git checkout gh-pages-form_states`
- `npm run cf-link`
- `npm run build && npm start`

## Screenshots

![screen shot 2017-09-13 at 1 21 52 pm](https://user-images.githubusercontent.com/704760/30391252-b35eba12-9886-11e7-8849-d7307817ed90.png)


## Notes

- Covered under existing changelog entry for cf-forms hover classes.
