### PR TITLE
Add purple color variables to cf-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Added
 - **cf-forms:** [PATCH] Add sidecar `.hover` classes to basic inputs,
   for manually triggering hover/focus state.
+- **cf-core:** [PATCH] Add purple to color variables.
 
 ### Changed
 -

--- a/src/cf-core/src/cf-brand-colors.less
+++ b/src/cf-core/src/cf-brand-colors.less
@@ -55,6 +55,14 @@
 @navy-40:      #b3c0d9;
 @navy-20:      #d3daeb;
 
+// Purple family
+@dark-purple: #a01b68;
+@purple: #b4267a;
+@purple-80: #c55998;
+@purple-60: #d486b2;
+@purple-40: #e3b2cc;
+@purple-20: #f0d8e2;
+
 // Red family (formerly known as "Red Orange")
 @dark-red:     #b63014;
 @red:          #d14124;

--- a/src/cf-core/src/cf-brand-colors.less
+++ b/src/cf-core/src/cf-brand-colors.less
@@ -56,12 +56,12 @@
 @navy-20:      #d3daeb;
 
 // Purple family
-@dark-purple: #a01b68;
-@purple: #b4267a;
-@purple-80: #c55998;
-@purple-60: #d486b2;
-@purple-40: #e3b2cc;
-@purple-20: #f0d8e2;
+@dark-purple:  #a01b68;
+@purple:       #b4267a;
+@purple-80:    #c55998;
+@purple-60:    #d486b2;
+@purple-40:    #e3b2cc;
+@purple-20:    #f0d8e2;
 
 // Red family (formerly known as "Red Orange")
 @dark-red:     #b63014;


### PR DESCRIPTION
Adds purple colors to Capital Framework. These are in the Design Manual, but not in CF yet.

## Additions

- purple variables from https://github.com/cfpb/design-manual/blob/gh-pages/src/static/css/brand-palette.less

## Removals

-

## Changes

-

## Testing

-

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] FF
- [ ] IE10
- [ ] IE9
- [ ] IE8
- [ ] Opera
- [ ] iOS
- [ ] Android
- [ ] Blackberry Bold

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
