### PR TITLE
Add Avenir web font variables to override Arial defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Added
 - **cf-forms:** [PATCH] Add sidecar `.hover` classes to basic inputs,
   for manually triggering hover/focus state.
+- **cf-typography:** [MINOR] Add Avenir web fonts to override default Arial fonts from cf-core.
 
 ### Changed
 -

--- a/src/cf-typography/src/cf-typography.less
+++ b/src/cf-typography/src/cf-typography.less
@@ -7,6 +7,12 @@
 // Theme variables
 //
 
+// Font variables
+@webfont-regular: 'AvenirNextLTW01-Regular';
+@webfont-italic: 'AvenirNextLTW01-Italic';
+@webfont-medium: 'AvenirNextLTW01-Medium';
+@webfont-demi: 'AvenirNextLTW01-Demi';
+
 // Color variables
 
 // Running text elements
@@ -69,3 +75,8 @@
 @import (less) 'molecules/meta-header.less';
 @import (less) 'molecules/pull-quote.less';
 @import (less) 'molecules/slug-header.less';
+
+//
+// Import web fonts
+//
+@import (less) 'licensed-fonts.css';

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -40,17 +40,20 @@ and has more basic typography patterns.
 Theme variables for setting the color and sizes. Overwrite them in your own
 project by duplicating the variable `@key: value`.
 
+### Font variables
+
+```
+@webfont-regular: 'AvenirNextLTW01-Regular';
+@webfont-italic: 'AvenirNextLTW01-Italic';
+@webfont-medium: 'AvenirNextLTW01-Medium';
+@webfont-demi: 'AvenirNextLTW01-Demi';
+```
+
 ### Color variables
 
 Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
 
 ```
-// Font variables
-@webfont-regular: 'AvenirNextLTW01-Regular';
-@webfont-italic: 'AvenirNextLTW01-Italic';
-@webfont-medium: 'AvenirNextLTW01-Medium';
-@webfont-demi: 'AvenirNextLTW01-Demi';
-
 // Running text elements
 
 // .a-micro-copy

--- a/src/cf-typography/usage.md
+++ b/src/cf-typography/usage.md
@@ -45,6 +45,12 @@ project by duplicating the variable `@key: value`.
 Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
 
 ```
+// Font variables
+@webfont-regular: 'AvenirNextLTW01-Regular';
+@webfont-italic: 'AvenirNextLTW01-Italic';
+@webfont-medium: 'AvenirNextLTW01-Medium';
+@webfont-demi: 'AvenirNextLTW01-Demi';
+
 // Running text elements
 
 // .a-micro-copy


### PR DESCRIPTION
Use licensed web fonts to override Arial defaults from cf-core and use Avenir. Like the recent colors update, this makes it possible to manage web fonts from 1 place within Capital Framework instead of individual repos. Currently, these variables are being declared in the cf-theme-overrides.less file, which we want to make obsolete.

## Additions

- adds Avenir font variables to cf-typography for importing into projects
- imports licensed-fonts.css file 

## Removals

-

## Changes

-

## Testing

- check out this branch and run `npm run cf-link`
- set up second cloned repo and check out the `gh-pages` branch: `git fetch && git checkout gh-pages`
- if you haven't already in this second clone, [run all the install steps for the project](https://github.com/cfpb/capital-framework/tree/gh-pages#installation)
- run `npm run cf-link`
- run `npm run build`
- run `npm start`
- comment out [lines 26-31 of main.less](https://github.com/cfpb/capital-framework/blob/gh-pages/src/static/css/main.less#L26-L31)
- Confirm Avenir web font loads on local site: 
   - http://localhost:3000/components/cf-typography/ 

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] FF
- [ ] IE10
- [ ] IE9
- [ ] IE8
- [ ] Opera
- [ ] iOS
- [ ] Android
- [ ] Blackberry Bold

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
