### PR TITLE
Hands placeholder to autoprefixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-forms:** [PATCH] Lets autoprefixer handle placeholder pseudoselector.
 
 ### Removed
-- 
+-
 
 ## 4.10.0 - 2017-09-19
 

--- a/src/cf-forms/src/atoms/text-input.less
+++ b/src/cf-forms/src/atoms/text-input.less
@@ -45,12 +45,6 @@
     appearance: none;
 }
 
-::-webkit-input-placeholder {
-    color: @input-text__placeholder;
-}
-::-moz-placeholder {
-    color: @input-text__placeholder;
-}
-:-ms-input-placeholder {
+::placeholder {
     color: @input-text__placeholder;
 }


### PR DESCRIPTION
## Changes

- Let's autoprefixer handle placeholder pseudoelement.

## Testing

- Comment out `.pipe(gulpCssmin())` in `styles.js`
- Run `npm run build`
- View `dist/capital-framework.min.css`
- Search for "placeholder" to see prefixed output.

## Screenshots

Before:
```
::-webkit-input-placeholder {
    color: @input-text__placeholder;
}
::-moz-placeholder {
    color: @input-text__placeholder;
}
:-ms-input-placeholder {
    color: @input-text__placeholder;
}
```

After:
```
::-webkit-input-placeholder {
  color: #5a5d61;
}
:-ms-input-placeholder {
  color: #5a5d61;
}
::placeholder {
  color: #5a5d61;
}
```


## Notes

- Drops `::-moz-placeholder` as newer FF targeted by autoprefixer is handled by `::placeholder`.
