### PR TITLE
Changes label helper to Avenir Regular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-forms:** [PATCH] Changes label helper text to Avenir Regular.
 
 ### Removed
-- 
+-
 
 ## 4.10.0 - 2017-09-19
 

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -2,8 +2,8 @@
     display: inline-block;
 
     &_helper {
+        .u-webfont-regular();
         color: @label-helper;
-        font-size: unit( 16px / @base-font-size-px, em );
     }
 
     &__heading {

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -4,6 +4,7 @@
     &_helper {
         .u-webfont-regular();
         color: @label-helper;
+        font-size: unit( 16px / @base-font-size-px, em );
     }
 
     &__heading {


### PR DESCRIPTION
## Changes

- Sets label helper text to Avenir Regular.

## Testing

- https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally

## Screenshots

<img width="162" alt="screen shot 2017-09-20 at 10 38 02 am" src="https://user-images.githubusercontent.com/704760/30650009-d1308804-9def-11e7-9e01-04827f9e7489.png">
