### PR TITLE
Update atomic-component dep to v1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **capital-framework:** [patch] Update atomic-component dependency in main package.json.
+- **cf-expandables:** [patch] Update atomic-component dependency to 1.4.0.
+- **cf-tables:** [patch] Update atomic-component dependency to 1.4.0.
 
 ### Removed
-- 
+-
 
 ## 4.11.0 - 2017-09-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "capital-framework",
-  "version": "4.9.2",
+  "version": "4.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -347,9 +347,9 @@
       "dev": true
     },
     "atomic-component": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/atomic-component/-/atomic-component-1.3.2.tgz",
-      "integrity": "sha512-RI0k9U9No6oZ0hBpf7Kcisf4FHXTG5B78FlA4h96z1XjOX+k8q7Im5eU0TC+/YqyjHi269ldDjr1WkrhvuY75w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/atomic-component/-/atomic-component-1.4.0.tgz",
+      "integrity": "sha512-9ndPNbsHCMlmEm8i3vG+mi7YzU827HZ2ibgDNOh+ShpKyE+k/TaWrmdF4E/j33oECU/M2aBvPOXky/aC1u2pQQ==",
       "requires": {
         "dom-delegate": "2.0.3"
       }
@@ -3812,15 +3812,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3830,6 +3821,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8476,12 +8476,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -8501,6 +8495,12 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "webpack-stream": "^4.0.0"
   },
   "dependencies": {
-    "atomic-component": "^1.3.2",
+    "atomic-component": "^1.4.0",
     "classlist-polyfill": "^1.0.3",
     "jquery": "~1.11.0",
     "jquery.easing": "~1.3.0",

--- a/src/cf-expandables/package.json
+++ b/src/cf-expandables/package.json
@@ -10,7 +10,7 @@
     "test": "case $(pwd) in */capital-framework/src/*) cd ../.. && npm test;; esac"
   },
   "dependencies": {
-    "atomic-component": "1.3.2",
+    "atomic-component": "1.4.0",
     "cf-core": "^4.0.0",
     "cf-icons": "^4.0.0",
     "classlist-polyfill": "1.0.3"

--- a/src/cf-tables/package.json
+++ b/src/cf-tables/package.json
@@ -10,7 +10,7 @@
     "test": "case $(pwd) in */capital-framework/src/*) cd ../.. && npm test;; esac"
   },
   "dependencies": {
-    "atomic-component": "1.3.2",
+    "atomic-component": "1.4.0",
     "cf-core": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
Bumping atomic-component to the new [pre-transpiled version](https://github.com/cfpb/AtomicComponent/pull/11).

## Changes

- **capital-framework:** [patch] Update atomic-component dependency in main package.json.
- **cf-expandables:** [patch] Update atomic-component dependency to 1.4.0.
- **cf-tables:** [patch] Update atomic-component dependency to 1.4.0.

## Testing

-

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] FF
- [ ] IE10
- [ ] IE9
- [ ] IE8
- [ ] Opera
- [ ] iOS
- [ ] Android
- [ ] Blackberry Bold

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
