### PR TITLE
Removes unused data-accordion attribute from docs

### DIFF
--- a/src/cf-expandables/usage.md
+++ b/src/cf-expandables/usage.md
@@ -523,10 +523,10 @@ In this barebones example there are no visual styles.
 ### Accordion-style group
 
 Accordions can only show one open expandable at a time.
-Add the `data-accordion="true"` attribute to the expandable group to activate
-the accordion mode.
+Add the `o-expandable-group__accordion` class to the expandable group
+to activate the accordion mode.
 
-<div class="o-expandable-group o-expandable-group__accordion" >
+<div class="o-expandable-group o-expandable-group__accordion">
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
@@ -611,7 +611,7 @@ the accordion mode.
 </div>
 
 ```
-<div class="o-expandable-group o-expandable-group__accordion" >
+<div class="o-expandable-group o-expandable-group__accordion">
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
@@ -695,4 +695,3 @@ the accordion mode.
     </div>
 </div>
 ```
-

--- a/test/cf-expandables.html
+++ b/test/cf-expandables.html
@@ -69,7 +69,8 @@
             </div>
         </div>
 
-        <div class="o-expandable-group" id="test-subject-three" data-accordion="true">
+        <div class="o-expandable-group o-expandable-group__accordion"
+             id="test-subject-three">
             <div class="o-expandable-group_header">Expandable group header</div>
             <div class="o-expandable o-expandable__padded" id="test-subject-three-a">
                 <button class="o-expandable_header o-expandable_target" title="Expand content">
@@ -125,7 +126,8 @@
             </div>
         </div>
 
-        <div class="o-expandable-group o-expandable-group__accordion" id="test-subject-four" data-accordion="true">
+        <div class="o-expandable-group o-expandable-group__accordion"
+             id="test-subject-four">
             <div class="o-expandable-group_header">Expandable group header</div>
             <div class="o-expandable o-expandable__padded" id="test-subject-four-a">
                 <button class="o-expandable_header o-expandable_target" title="Expand content">


### PR DESCRIPTION
## Removals

- Removes unused `data-accordion` attribute from tests and docs.

## Testing

- `gulp test` should pass.
