### PR TITLE
Block helper txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Added
 - **cf-core:** [MINOR] Add `u-hidden` utility class.
+- **cf-forms:** [MINOR] Add block modifier to label helper text.
 
 ### Changed
 - **cf-forms:** [PATCH] Change font size in helper text to use variable.

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -8,11 +8,10 @@
 
         &__block {
             display: block;
-        }
-    }
 
-    & > &_helper__block {
-        margin-top: unit( 10px / @base-font-size-px, em );
+            // Add a gap between the label helper and label.
+            margin-top: unit( 10px / @base-font-size-px, em );
+        }
     }
 
     &__heading {

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -5,6 +5,14 @@
         .u-webfont-regular();
         color: @label-helper;
         font-size: unit( @size-v / @base-font-size-px, em );
+
+        &__block {
+            display: block;
+        }
+    }
+
+    & > &_helper__block {
+        margin-top: unit( 10px / @base-font-size-px, em );
     }
 
     &__heading {

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -133,15 +133,34 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 
 ### Label helper text
 
+#### Inline helper text
+
+Appears with label headings.
 Used for designating an input as optional for user input.
 
 <label class="a-label a-label__heading">
-    A label <small class="a-label_helper">(optional)</small>
+    A label heading <small class="a-label_helper">(optional)</small>
 </label>
 
 ```html
 <label class="a-label a-label__heading">
-    A label <small class="a-label_helper">(optional)</small>
+    A label heading <small class="a-label_helper">(optional)</small>
+</label>
+```
+
+#### Block helper text
+
+Appears with labels and label headings.
+
+<label class="a-label a-label__heading">
+    A label heading
+    <small class="a-label_helper a-label_helper__block">Helper text</small>
+</label>
+
+```html
+<label class="a-label a-label__heading">
+    A label heading
+    <small class="a-label_helper a-label_helper__block">Helper text</small>
 </label>
 ```
 


### PR DESCRIPTION
## Additions

- Add `a-label_helper__block` modifier to create block helper text below a label.

## Testing

- https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally

## Screenshots

![screen shot 2017-10-04 at 11 50 34 am](https://user-images.githubusercontent.com/704760/31185562-4c05bd8c-a8fa-11e7-86dd-7bad35a15165.png)

