### PR TITLE
Set max-width for top-level elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-layout:** [MINOR] Set max-width on top-level elements.
 
 ### Removed
 -

--- a/src/cf-layout/src/cf-layout.less
+++ b/src/cf-layout/src/cf-layout.less
@@ -232,6 +232,21 @@
     &:extend( .wrapper all );
 }
 
+.content_main,
+.content_intro {
+    dd,
+    dt,
+    h3,
+    h4,
+    h5,
+    h6,
+    li,
+    p,
+    label {
+        max-width: 41.875rem;
+    }
+}
+
 .content_intro,
 .content_main,
 .content_sidebar {


### PR DESCRIPTION
Fixes https://github.com/cfpb/capital-framework/issues/207 and https://[GHE]/CFGOV/platform/issues/727

## Changes

- Set max-width on top-level elements.

## Testing

- https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally
- Check any paragraph, dd, dt, heading, list, or label and edit the source in the inspect to add long text as needed then and/remove this style rule to see before/after.

## Screenshot

 Before:
![screen shot 2017-10-05 at 11 36 45 am](https://user-images.githubusercontent.com/704760/31236213-86c4543e-a9c1-11e7-9062-eb506455f386.png)

After:
![screen shot 2017-10-05 at 11 36 50 am](https://user-images.githubusercontent.com/704760/31236221-8b192ad2-a9c1-11e7-8097-505305d02eeb.png)

## Notes

- This differs from what's in cfgov-refresh by including labels.
