### PR TITLE
Remove inline code margin

### DIFF
--- a/src/static/css/main.less
+++ b/src/static/css/main.less
@@ -54,10 +54,6 @@ nav ul {
     padding: 0;
 }
 
-.highlighter-rouge {
-    margin-top: unit( 15px / @base-font-size-px, em );
-}
-
 // custom modules
 @import (less) "header.less";
 @import (less) "hero.less";


### PR DESCRIPTION
[This PR](https://github.com/cfpb/capital-framework/commit/94744fdc7bae8ffaa90d6d63a545d2aab95d299d) added this margin, but it messes with the line height of paragraphs across the board that have inline code blocks. I couldn't find where it was originally used. @Scotchester do you remember? Can it be removed?

## Removals

- Removes margin above inline code blocks.

## Testing

- `npm run build && npm start` and view the component pages vs the live site.

## Screenshots

Before:
![screen shot 2017-10-05 at 3 18 01 pm](https://user-images.githubusercontent.com/704760/31248041-73262956-a9e0-11e7-8fd9-5a5a53fd431e.png)

After:
![screen shot 2017-10-05 at 3 18 09 pm](https://user-images.githubusercontent.com/704760/31248040-731ea000-a9e0-11e7-82a5-ccae1dd47d33.png)

