### PR TITLE
Remove inline block style from inline code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
-- **cf-core:** [MINOR] Remove inline-block style from inline code.
+- **cf-core:** [PATCH] Remove inline-block style from inline code.
 
 ### Removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-core:** [MINOR] Remove inline-block style from inline code.
 
 ### Removed
 -

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -551,7 +551,6 @@ code {
 }
 
 code {
-    display: inline-block;
     padding: unit( 3px / @size-code, em )
              unit( 3px / @size-code, em )
              0;


### PR DESCRIPTION
Fixes https://github.com/cfpb/capital-framework/issues/555

## Removals

- Removes `display: inline-block` from inline `code` elements.

## Testing

- https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally
- Look at inline code on the docs pages and compare to live site.

## Note
- Inline-block added a gap, so maybe https://github.com/cfpb/capital-framework/pull/639 isn't necessary with this?