### PR TITLE
Add transition.less CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Added
 - **cf-atomic-component:** [MINOR] Add cf-atomic-component module.
+- **cf-atomic-component:** [MINOR] Add transition.less CSS.
 
 ### Changed
 - **cf-expandables:** [MINOR] Change to internal cf-atomic-component dependency.

--- a/src/cf-atomic-component/src/cf-atomic-component.less
+++ b/src/cf-atomic-component/src/cf-atomic-component.less
@@ -4,4 +4,4 @@
    ========================================================================== */
 
 // Import utilities.
-// TODO: Add and import transition.less.
+@import 'utilities/transition/transition.less';

--- a/src/cf-atomic-component/src/utilities/transition/transition.less
+++ b/src/cf-atomic-component/src/utilities/transition/transition.less
@@ -1,0 +1,58 @@
+/* ==========================================================================
+   Utility classes for transitions.
+
+   Adds transitions utilty classes for transform, opacity,
+   and for the removing the transition duration.
+   ========================================================================== */
+
+.u-move-transition {
+    transition: transform 0.25s ease-out;
+}
+
+.u-alpha-transition {
+    transition: opacity 0.25s linear;
+}
+
+.u-no-animation {
+    transition-duration: 0s;
+}
+
+//
+// Utility classes for moving an element using transform translate values.
+//
+
+.u-move-to-origin {
+    transform: translate3d( 0, 0, 0 );
+}
+
+.u-move-left {
+    transform: translate3d( -100%, 0, 0 );
+}
+
+// TODO: Look into adding a mixin for movement multiples.
+.u-move-left-2x {
+    transform: translate3d( -200%, 0, 0 );
+}
+
+.u-move-left-3x {
+    transform: translate3d( -300%, 0, 0 );
+}
+
+.u-move-right {
+    transform: translate3d( 100%, 0, 0 );
+}
+
+.u-move-up {
+    transform: translate3d( 0, -100%, 0 );
+}
+
+//
+// Utility classes for setting an element's opacity.
+//
+.u-alpha-100 {
+    opacity: 1;
+}
+
+.u-alpha-0 {
+    opacity: 0;
+}


### PR DESCRIPTION
## Additions

- Adds `transition.less` utility CSS into cf-atomic-component, which controls the transition CSS classes. 

## Testing

- `npm run build` should run fine.

## Notes

- After merge and release https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/unprocessed/css/misc.less#L327-L395 can be removed from cfgov-refresh.
