### PR TITLE
Change example links to alerts

### DIFF
--- a/src/cf-tables/usage.md
+++ b/src/cf-tables/usage.md
@@ -189,14 +189,14 @@ highlighting and hyperlinking rows which contain links.
     <tbody>
         <tr>
             <td data-label="Column 1">
-                <a href="https://example.com/">Example 1</a>
+                <a href="javascript:alert('Row 1 clicked!');">Example 1</a>
             </td>
             <td data-label="Column 2">Cell A2</td>
             <td data-label="Column 3" >Cell A3</td>
         </tr>
         <tr>
             <td data-label="Column 1">
-                <a href="https://example.com/">Example 2</a>
+                <a href="javascript:alert('Row 2 clicked!');">Example 2</a>
             </td>
             <td data-label="Column 2">Cell B2</td>
             <td data-label="Column 3">Cell B3</td>
@@ -215,12 +215,16 @@ highlighting and hyperlinking rows which contain links.
     </thead>
     <tbody>
         <tr>
-            <td data-label="Column 1">Row A</td>
+            <td data-label="Column 1">
+                <a href="https://example.com/">Example 1</a>
+            </td>
             <td data-label="Column 2">Cell A2</td>
-            <td data-label="Column 3">Cell A3</td>
+            <td data-label="Column 3" >Cell A3</td>
         </tr>
         <tr>
-            <td data-label="Column 1">Row B</td>
+            <td data-label="Column 1">
+                <a href="https://example.com/">Example 2</a>
+            </td>
             <td data-label="Column 2">Cell B2</td>
             <td data-label="Column 3">Cell B3</td>
         </tr>


### PR DESCRIPTION
## Changes

- Change links in table row example to an alert instead of an actual URL link so that clicks of the example don't leave the docs page.
- Make example code block actually follow implemented code for row links in tables.

## Testing

- Set up local test environment and check docs for cf-tables and click a row link https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally

## Screenshot

![screen shot 2017-10-18 at 11 50 22 am](https://user-images.githubusercontent.com/704760/31728544-94b998a4-b3fa-11e7-8b27-ea2ec7def579.png)
