### PR TITLE
Remove on-ready check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Removed
--
+- **cf-expandables:** [PATCH] Remove on-ready check.
 
 
 ## 4.14.1 - 2017-10-17

--- a/src/cf-atomic-component/src/utilities/transition/ExpandableTransition.js
+++ b/src/cf-atomic-component/src/utilities/transition/ExpandableTransition.js
@@ -5,7 +5,6 @@ const Events = require( 'cf-atomic-component/src/mixins/Events.js' );
 const BaseTransition = require( 'cf-atomic-component/src/utilities/transition/BaseTransition' );
 const contains = require( 'cf-atomic-component/src/utilities/dom-class-list' ).contains;
 const fnBind = require( 'cf-atomic-component/src/utilities/function-bind' ).bind;
-const onReady = require( 'cf-atomic-component/src/utilities//on-ready' ).onReady;
 
 // Exported constants.
 const CLASSES = {
@@ -41,15 +40,13 @@ function ExpandableTransition( element, classes ) { // eslint-disable-line max-s
     _baseTransition.addEventListener( BaseTransition.END_EVENT,
                                       _transitionCompleteBinded );
 
-    onReady( function() {
-      if ( contains( element, classObject.OPEN_DEFAULT ) ) {
-        _baseTransition.applyClass( classObject.EXPANDED );
-        element.style.maxHeight = element.scrollHeight + 'px';
-      } else {
-        previousHeight = element.scrollHeight;
-        _baseTransition.applyClass( classObject.COLLAPSED );
-      }
-    } );
+    if ( contains( element, classObject.OPEN_DEFAULT ) ) {
+      _baseTransition.applyClass( classObject.EXPANDED );
+      element.style.maxHeight = element.scrollHeight + 'px';
+    } else {
+      previousHeight = element.scrollHeight;
+      _baseTransition.applyClass( classObject.COLLAPSED );
+    }
 
     return this;
   }


### PR DESCRIPTION
On-ready check ensures `element` is not undefined, but `BaseTransition` [reference to `element`](https://github.com/cfpb/capital-framework/blob/canary/src/cf-atomic-component/src/utilities/transition/ExpandableTransition.js#L32) is not wrapped in on-ready, so if `element` is undefined, there will be greater problems than where it is being checked. 

If we want an on-ready function as a precaution in case CF is not added in footer, we could add on-ready at a higher level within the code, as opposed to within individual components.

## Removals

- Remove on-ready check in ExpandableTransition.

## Testing

- https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally expandable docs should be unchanged.
