### PR TITLE
Reference cf-atomic-component locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Changed
 - **cf-expandables:** [PATCH] Update to ES6 syntax.
 - **cf-tables:** [PATCH] Update to ES6 syntax.
+- **cf-atomic-component:** [PATCH] Reference cf-atomic-component locally.
 
 ### Removed
 - **cf-expandables:** [PATCH] Remove on-ready check.

--- a/src/cf-atomic-component/src/utilities/transition/ExpandableTransition.js
+++ b/src/cf-atomic-component/src/utilities/transition/ExpandableTransition.js
@@ -1,10 +1,10 @@
 'use strict';
 
 // Required modules.
-const Events = require( 'cf-atomic-component/src/mixins/Events.js' );
-const BaseTransition = require( 'cf-atomic-component/src/utilities/transition/BaseTransition' );
-const contains = require( 'cf-atomic-component/src/utilities/dom-class-list' ).contains;
-const fnBind = require( 'cf-atomic-component/src/utilities/function-bind' ).bind;
+const Events = require( '../../src/mixins/Events.js' );
+const BaseTransition = require( '../../utilities/transition/BaseTransition' );
+const contains = require( '../../utilities/dom-class-list' ).contains;
+const fnBind = require( '../../utilities/function-bind' ).bind;
 
 // Exported constants.
 const CLASSES = {


### PR DESCRIPTION
Now that cf-atomic-component is apart of CF, we don't need to reach into node_modules for it, but instead can reference it through relative paths.

## Changes

- References cf-atomic-component requires locally.

## Testing

- https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally expandable docs should be unchanged.
