### PR TITLE
Exclude unneeded paths

### DIFF
--- a/scripts/gulp/test.js
+++ b/scripts/gulp/test.js
@@ -13,7 +13,10 @@ const gulpMocha = require( 'gulp-mocha' );
  * @param {Function} cb - Callback function to call on completion.
  */
 function unitTest( cb ) {
-  gulp.src( ['./src/**/*.js', '!./src/**/node_modules/**/*.js'] )
+  gulp.src( ['./src/**/*.js',
+             '!./src/**/node_modules/**/*.js',
+             '!./src/**/src/cf-*',
+             '!./src/capital-framework.js'] )
   .pipe( gulpIstanbul( {
     includeUntested: true
   } ) )


### PR DESCRIPTION
## Changes

- Exclude paths that don't need testing from unit tests.

## Testing

- `gulp test:unit` shouldn't include top-level aggregating JS files like capital-framework.js, cf-expandables.js, and cf-tables.js.
