### PR TITLE
Add transition tests

### DIFF
--- a/test/unit-test/cf-atomic-component/utilities/transition/AlphaTransition-spec.js
+++ b/test/unit-test/cf-atomic-component/utilities/transition/AlphaTransition-spec.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const srcPath = require( '../../src-path' );
+
+const chai = require( 'chai' );
+const expect = chai.expect;
+
+const AlphaTransition =
+  require( '../' + srcPath + 'utilities/transition/AlphaTransition' );
+
+describe( 'AlphaTransition', () => {
+  let transition;
+
+  // DOM-related settings.
+  let document;
+  const HTML_SNIPPET = '<div class="content-1"></div>';
+  let contentDom;
+
+  before( () => {
+    this.jsdom = require( 'jsdom-global' )( HTML_SNIPPET );
+    document = window.document;
+    contentDom = document.querySelector( '.content-1' );
+    transition = new AlphaTransition( contentDom );
+    transition.init();
+  } );
+
+  beforeEach( () => {
+    transition = new AlphaTransition( contentDom );
+    transition.init();
+  } );
+
+  after( () => this.jsdom() );
+
+  describe( '.fadeIn()', () => {
+    it( 'should return instance of AlphaTransition', () => {
+      expect( transition.fadeIn() ).to.be.instanceof( AlphaTransition );
+    } );
+
+    it( 'should apply u-alpha-100 class', () => {
+      transition.fadeIn();
+      const classes = 'content-1 u-alpha-transition u-alpha-100';
+      expect( contentDom.className ).to.equal( classes );
+    } );
+  } );
+
+  describe( '.fadeOut()', () => {
+    it( 'should return instance of AlphaTransition', () => {
+      expect( transition.fadeOut() ).to.be.instanceof( AlphaTransition );
+    } );
+
+    it( 'should apply u-alpha-0 class', () => {
+      transition.fadeOut();
+      const classes = 'content-1 u-alpha-transition u-alpha-0';
+      expect( contentDom.className ).to.equal( classes );
+    } );
+  } );
+} );

--- a/test/unit-test/cf-atomic-component/utilities/transition/BaseTransition-spec.js
+++ b/test/unit-test/cf-atomic-component/utilities/transition/BaseTransition-spec.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const srcPath = require( '../../src-path' );
+
+const chai = require( 'chai' );
+const expect = chai.expect;
+
+const BaseTransition =
+  require( '../' + srcPath + 'utilities/transition/BaseTransition' );
+
+describe( 'BaseTransition', () => {
+  let transition;
+
+  // DOM-related settings.
+  let document;
+  const HTML_SNIPPET = '<div class="content-1"></div>' +
+                       '<div class="content-2"></div>';
+  let contentDom;
+  let content2Dom;
+
+  beforeEach( () => {
+    this.jsdom = require( 'jsdom-global' )( HTML_SNIPPET );
+    document = window.document;
+    contentDom = document.querySelector( '.content-1' );
+    content2Dom = document.querySelector( '.content-2' );
+    transition =
+      new BaseTransition( contentDom, { BASE_CLASS: 'u-test-transition' } );
+  } );
+
+  describe( '.init()', () => {
+    it( 'should have public static methods', () => {
+      expect( BaseTransition.BEGIN_EVENT ).to.equal( 'transitionBegin' );
+      expect( BaseTransition.END_EVENT ).to.equal( 'transitionEnd' );
+      expect( BaseTransition.NO_ANIMATION_CLASS ).to.equal( 'u-no-animation' );
+    } );
+
+    it( 'should have correct state before initializing', () => {
+      expect( transition.isAnimated() ).to.be.false;
+      expect( transition.remove() ).to.be.false;
+      expect( transition.animateOn() instanceof BaseTransition ).to.be.true;
+      expect( transition.animateOff() instanceof BaseTransition ).to.be.true;
+    } );
+
+    it( 'should have correct state after initializing', () => {
+      expect( transition.init() instanceof BaseTransition ).to.be.true;
+    } );
+  } );
+
+  describe( '.setElement()', () => {
+    it( 'should move classes from old element to new element', () => {
+      var className = 'u-test-transition';
+      expect( contentDom.classList.contains( className ) ).to.be.false;
+      transition.init();
+      expect( contentDom.classList.contains( className ) ).to.be.true;
+      transition.setElement( content2Dom );
+      expect( contentDom.classList.contains( className ) ).to.be.false;
+      expect( content2Dom.classList.contains( className ) ).to.be.true;
+    } );
+  } );
+
+  describe( '.halt()', () => {
+    xit( 'should immediately fire transition end event', () => {
+      // TODO: To test halt() the transition needs to be started and
+      //       then halt() needs to be called before the transition
+      //       duration has completed.
+    } );
+  } );
+
+  describe( '.remove()', () => {
+    it( 'should remove transition classes from element', () => {
+      transition.init();
+      let hasClass = contentDom.classList.contains( 'u-test-transition' );
+      expect( hasClass ).to.be.true;
+      expect( transition.remove() ).to.be.true;
+      hasClass = contentDom.classList.contains( 'u-test-transition' );
+      expect( hasClass ).to.be.false;
+    } );
+  } );
+
+  describe( '.isAnimated()', () => {
+    beforeEach( () => {
+      transition.init();
+    } );
+
+    it( 'should be true after animation is initialized', () => {
+      expect( transition.isAnimated() ).to.be.true;
+    } );
+
+    it( 'should be true after animation is turned On', () => {
+      transition.animateOn();
+      expect( transition.isAnimated() ).to.be.true;
+    } );
+
+    it( 'should be false after animation is turned Off', () => {
+      transition.animateOff();
+      expect( transition.isAnimated() ).to.be.false;
+    } );
+  } );
+
+  describe( '.animateOff()', () => {
+    beforeEach( () => {
+      transition.init();
+    } );
+
+    it( 'should return an instance', () => {
+      expect( transition.animateOff() instanceof BaseTransition ).to.be.true;
+    } );
+
+    it( 'should set u-no-animation class when called', () => {
+      expect( contentDom.classList.contains( 'u-no-animation' ) ).to.be.false;
+      transition.animateOff();
+      expect( contentDom.classList.contains( 'u-no-animation' ) ).to.be.true;
+    } );
+  } );
+
+  describe( '.animateOn()', () => {
+    beforeEach( () => {
+      transition.init();
+    } );
+
+    it( 'should return an instance', () => {
+      expect( transition.animateOn() instanceof BaseTransition ).to.be.true;
+    } );
+
+    it( 'should remove u-no-animation class, if set', () => {
+      transition.animateOff();
+      transition.animateOn();
+      expect( contentDom.classList.contains( 'u-no-animation' ) ).to.be.false;
+    } );
+  } );
+
+  describe( '.applyClass()', () => {
+    it( 'should apply a class', () => {
+      expect( transition.applyClass( 'u-test-transition' ) ).to.be.false;
+      transition.init();
+      contentDom.classList.remove( 'u-test-transition' );
+      expect( transition.applyClass( 'u-test-transition' ) ).to.be.true;
+      expect( transition.applyClass( 'u-test-transition' ) ).to.be.false;
+    } );
+  } );
+} );

--- a/test/unit-test/cf-atomic-component/utilities/transition/MoveTransition-spec.js
+++ b/test/unit-test/cf-atomic-component/utilities/transition/MoveTransition-spec.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const srcPath = require( '../../src-path' );
+
+const chai = require( 'chai' );
+const expect = chai.expect;
+
+const MoveTransition =
+  require( '../' + srcPath + 'utilities/transition/MoveTransition' );
+
+describe( 'MoveTransition', () => {
+  let transition;
+
+  // DOM-related settings.
+  let document;
+  const HTML_SNIPPET = '<div class="content-1"></div>';
+  let contentDom;
+
+  beforeEach( () => {
+    this.jsdom = require( 'jsdom-global' )( HTML_SNIPPET );
+    document = window.document;
+    contentDom = document.querySelector( '.content-1' );
+    transition = new MoveTransition( contentDom );
+    transition.init();
+  } );
+
+  describe( '.moveToOrigin()', () => {
+    it( 'should return instance of MoveTransition', () => {
+      expect( transition.moveToOrigin() ).to.be.instanceof( MoveTransition );
+    } );
+
+    it( 'should apply u-move-to-origin class', () => {
+      transition.moveToOrigin();
+      const classes = 'content-1 u-move-transition u-move-to-origin';
+      expect( contentDom.className ).to.equal( classes );
+    } );
+  } );
+
+  describe( '.moveRight()', () => {
+    it( 'should return instance of MoveTransition', () => {
+      expect( transition.moveRight() ).to.be.instanceof( MoveTransition );
+    } );
+
+    it( 'should apply u-move-to-origin class', () => {
+      transition.moveRight();
+      const classes = 'content-1 u-move-transition u-move-right';
+      expect( contentDom.className ).to.equal( classes );
+    } );
+  } );
+
+  describe( '.moveUp()', () => {
+    it( 'should return instance of MoveTransition', () => {
+      expect( transition.moveUp() ).to.be.instanceof( MoveTransition );
+    } );
+
+    it( 'should apply u-move-to-origin class', () => {
+      transition.moveUp();
+      const classes = 'content-1 u-move-transition u-move-up';
+      expect( contentDom.className ).to.equal( classes );
+    } );
+  } );
+
+  describe( '.moveLeft()', () => {
+    it( 'should return instance of MoveTransition', () => {
+      expect( transition.moveUp() ).to.be.instanceof( MoveTransition );
+    } );
+
+    it( 'should apply u-move-left class', () => {
+      transition.moveLeft();
+      const classes = 'content-1 u-move-transition u-move-left';
+      expect( contentDom.className ).to.equal( classes );
+    } );
+
+    it( 'should apply u-move-left-2x class', () => {
+      transition.moveLeft( 2 );
+      const classes = 'content-1 u-move-transition u-move-left-2x';
+      expect( contentDom.className ).to.equal( classes );
+    } );
+
+    it( 'should apply u-move-left-3x class', () => {
+      transition.moveLeft( 3 );
+      const classes = 'content-1 u-move-transition u-move-left-3x';
+      expect( contentDom.className ).to.equal( classes );
+    } );
+
+    it( 'should throw error when move left range is out-of-range', () => {
+
+      function checkMoveLeftOutOfRange() {
+        return transition.moveLeft( 4 );
+      }
+      expect( checkMoveLeftOutOfRange ).to.throw( 'MoveTransition: moveLeft count is out of range!' );
+    } );
+  } );
+} );


### PR DESCRIPTION
Add transition tests from https://github.com/cfpb/cfgov-refresh/pull/3493

## Additions

- Adds unit test coverage for BaseTransition, MoveTransition, and AlphaTransition.

## Testing

- `gulp test:unit` should have increased coverage.

## Todos

- ExpandableTransition doesn't have a test, but https://github.com/cfpb/capital-framework/issues/669 should be reconciled first.
