### PR TITLE
Remove unused expandable group variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Removed
 - **cf-expandables:** [PATCH] Remove on-ready check.
+- **cf-expandables:** [PATCH] Remove unused expandable group variables.
 
 
 ## 4.14.1 - 2017-10-17

--- a/src/cf-expandables/src/cf-expandables.less
+++ b/src/cf-expandables/src/cf-expandables.less
@@ -23,8 +23,6 @@
 @expandable__padded-divider:    @gray-40;
 
 // .o-expandable-group
-@expandable-group_header-text:  @gray;
-@expandable-group_header-bg:    @gray-10;
 @expandable-group-bg:           @white;
 @expandable-group-divider:      @gray-80;
 


### PR DESCRIPTION
I couldn't find anywhere that these variables were used.

## Removals

- `@expandable-group_header-text`
- `@expandable-group_header-bg`
