### PR TITLE
Fix run-sequence so default Gulp task works again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-tables:** [PATCH] Update to ES6 syntax.
 - **cf-atomic-component:** [PATCH] Reference cf-atomic-component locally.
 - **capital-framework:** [PATCH] Use uglifyjs-webpack-plugin.
+- **capital-framework:** [PATCH] Fixed the default Gulp task.
 
 ### Removed
 - **cf-expandables:** [PATCH] Remove on-ready check.

--- a/scripts/gulp/build.js
+++ b/scripts/gulp/build.js
@@ -3,11 +3,12 @@
 const gulp = require( 'gulp' );
 const runSequence = require( 'run-sequence' );
 
-gulp.task('build', () => {
+gulp.task( 'build', callback => {
   runSequence(
-    ['styles:cf', 'scripts:cf', 'clean:tmp'],
-    ['template:readmes', 'copy:components:boilerplate'],
-    ['copy:components:source', 'template:usage', 'copy:components:manifest'],
-    ['styles:components', 'scripts:components', 'styles:grid']
+    [ 'styles:cf', 'scripts:cf', 'clean:tmp' ],
+    [ 'template:readmes', 'copy:components:boilerplate' ],
+    [ 'copy:components:source', 'template:usage', 'copy:components:manifest' ],
+    [ 'styles:components', 'scripts:components', 'styles:grid' ],
+    callback
   );
-});
+} );

--- a/scripts/gulp/default.js
+++ b/scripts/gulp/default.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const gulp = require( 'gulp' );
-const runSequence = require('run-sequence');
+const runSequence = require( 'run-sequence' );
 
-gulp.task('default', () => {
+gulp.task( 'default', callback => {
   runSequence(
-    ['build'],
-    ['test']
+    'build',
+    'test',
+    callback
   );
-});
+} );


### PR DESCRIPTION
The default Gulp task (i.e., just running `gulp`) wasn't working because `build` was prematurely reporting completion and `test` was running before it should.

The fix is to restore the callback parameter to the `default` and `build` tasks and pass that to `runSequence` after the sequence of tasks.

I paired with @jimmynotjim on fixing this.

## Testing

1. Before pulling this branch, run `gulp` and see that it fails.
1. Pull this branch
1. Run `gulp` and see that it works

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
