### PR TITLE
Fix a bug with unlinking locally linked packages

### DIFF
--- a/scripts/npm/unlink/index.js
+++ b/scripts/npm/unlink/index.js
@@ -13,7 +13,7 @@ function getDirectories( srcpath ) {
 }
 
 function npmUnlink( component ) {
-  exec( 'npm unlink ' + component + ' && npm install ' + component,
+  exec( 'npm unlink ' + component + ' --no-save',
     function( err, out ) {
       if ( err instanceof Error ) {
         throw err;


### PR DESCRIPTION
When unlinking the version was being changed in package.json. Updated to
use no-save flag to leave everything as it should be prior to linking.

## Changes

- Utilizes `--no-save` flag to avoid writing to `package.json`

## Testing

- Follow the instructions [to test components locally](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally)
- run `npm run cf-unlink`
- `git status` should show no changes

## Notes

- Fixes #642

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] FF
- [ ] IE10
- [ ] IE9
- [ ] IE8
- [ ] Opera
- [ ] iOS
- [ ] Android
- [ ] Blackberry Bold

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
