### PR TITLE
Fix a bug in cf-expandables that broke open by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - **cf-atomic-component:** [PATCH] Fix broken path to Events.js.
-
+- **cf-expandables:** [PATCH] Fix a bug in the order of operations.
 ### Removed
 -
 

--- a/src/cf-expandables/src/Expandable.js
+++ b/src/cf-expandables/src/Expandable.js
@@ -54,6 +54,12 @@ function initialize() {
     OPEN_DEFAULT: 'o-expandable_content__onload-open'
   };
 
+  if ( contains( this.ui.content, customClasses.OPEN_DEFAULT ) ) {
+    addClass( this.ui.target, this.classes.targetExpanded );
+  } else {
+    addClass( this.ui.target, this.classes.targetCollapsed );
+  }
+
   const transition = new ExpandableTransition( this.ui.content, customClasses );
   this.transition = transition.init();
 
@@ -61,12 +67,6 @@ function initialize() {
   if ( groupElement !== null ) {
     const fn = this.accordionClose.bind( this );
     Events.on( 'CFAccordionClose', fn );
-  }
-
-  if ( contains( this.ui.content, customClasses.OPEN_DEFAULT ) ) {
-    addClass( this.ui.target, this.classes.targetExpanded );
-  } else {
-    addClass( this.ui.target, this.classes.targetCollapsed );
   }
 }
 


### PR DESCRIPTION
Expandables that were open by default were not being tracked as such by
the script due to a bug in the order of operations. Relocated the
necessary code to fix the issue.

## Changes

- Reordered the operations to fix the bug.

## Testing

- I had to reclone the repo but try cleaning your npm_modules first
- Run `npm test` on `canary`, verify it fails, if not, reclone the repo
- Once you have the tests failing, checkout this branch
- Run `cf-link && gulp build`
- Run `npm test`. All tests should now pass.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] FF
- [ ] IE10
- [ ] IE9
- [ ] IE8
- [ ] Opera
- [ ] iOS
- [ ] Android
- [ ] Blackberry Bold

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
