### PR TITLE
Moves fonts.net tracker to its own file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-typography:** [MINOR] Move fonts.net tracker to its own file.
 
 ### Removed
-- 
+-
 
 ## 4.15.3 - 2017-11-29
 

--- a/src/cf-typography/src/font-tracker.css
+++ b/src/cf-typography/src/font-tracker.css
@@ -1,0 +1,14 @@
+/* ==========================================================================
+   Capital Framework
+   Licensed font URLs – for CFPB use only.
+   ========================================================================== */
+
+/*
+   Must be used even when self-hosting the fonts.
+   Capital Framework can be installed and this file linked locally from a
+   <link> element in the implementing site, such as:
+   <link rel="stylesheet" href="/font-tracker.css">
+   or the site can call the fonts.net URL directly with
+   <link rel="stylesheet" href="//fast.fonts.net/t/1.css?apiType=css&projectid=44e8c964-4684-44c6-a6e3-3f3da8787b50">
+*/
+@import url(//fast.fonts.net/t/1.css?apiType=css&projectid=44e8c964-4684-44c6-a6e3-3f3da8787b50);

--- a/src/cf-typography/src/licensed-fonts.less
+++ b/src/cf-typography/src/licensed-fonts.less
@@ -3,10 +3,6 @@
    Licensed font URLs – for CFPB use only.
    ========================================================================== */
 
-// Pings fonts.net for pageview tracking.
-// Must be used even when self-hosting the fonts.
-@import url(//fast.fonts.net/t/1.css?apiType=css&projectid=44e8c964-4684-44c6-a6e3-3f3da8787b50);
-
 .generate-font-face-rules( @use-font-cdn ) when ( @use-font-cdn = 'true' ) {
     @font-face {
         font-family: 'AvenirNextLTW01-Regular';


### PR DESCRIPTION
## Changes

- Moves fonts.net tracker to its own file so that the `@import` is not a blocker for loading locally hosted fonts.

## Testing

- Run cfgov-refresh locally.
- Open the Performance dev tool and reload the page and view the network pane.
- Note where fonts.net CSS loads before the webfonts.
- Check out https://github.com/cfpb/cfgov-refresh/tree/move_tracker branch.
- Go into cfgov-refresh `node_modules/cf-typography/src/licensed-fonts.less` and remove the tracking code like in this PR.
- Rebuild the assets with `gulp build`
- Reload the page and look in the performance dev tools and view the network pane.
- Note where fonts.net CSS loads before the webfonts. fonts.net and webfont requests should happen earlier.

## Screenshots

Before
![screen shot 2017-12-01 at 6 31 21 pm](https://user-images.githubusercontent.com/704760/33508372-eafe4300-d6c7-11e7-9ca4-d208fa71ca91.png)

After
![screen shot 2017-12-01 at 6 38 37 pm](https://user-images.githubusercontent.com/704760/33508373-eb156422-d6c7-11e7-8834-973895df2b19.png)
