### PR TITLE
Lint the release scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **capital-framework:** [PATCH] Linted the release scripts
 
 ### Removed
-- 
+-
 
 ## 4.18.0 - 2017-12-05
 

--- a/scripts/gulp/lint.js
+++ b/scripts/gulp/lint.js
@@ -23,7 +23,6 @@ function _genericLintJs( src ) {
 /**
  * Lints the gulpfile for errors.
  */
-
 gulp.task( 'lint:build', () => {
   _genericLintJs( [
     'gulpfile.js',
@@ -51,9 +50,7 @@ gulp.task( 'lint:scripts', () => {
 /**
  * Lints the source LESS files for errors.
  */
-
 gulp.task( 'lint:styles', () => {
- 
   return gulp
     .src( ['!src/cf-grid/src-generated/*.less', 'src/**/*.less'] )
     .pipe( gulpStylelint( {
@@ -64,11 +61,22 @@ gulp.task( 'lint:styles', () => {
 } );
 
 /**
+ * Lints the release js for errors.
+ * TODO: After release files are tested, combine this task with the build one
+ */
+gulp.task( 'lint:release', () => {
+  _genericLintJs( [
+    'scripts/npm/prepublish/**/*.js'
+  ] );
+} );
+
+/**
  * Lints all the js files for errors
  */
 gulp.task( 'lint', [
   'lint:build',
   'lint:tests',
   'lint:scripts',
-  'lint:styles'
+  'lint:styles',
+  'lint:release'
 ] );

--- a/scripts/npm/prepublish/index.js
+++ b/scripts/npm/prepublish/index.js
@@ -1,256 +1,320 @@
-var path = require('path'),
-    fs = require('fs'),
-    readdir = require('fs-readdir-promise'),
-    Promise = require('bluebird'),
-    semver = require('semver'),
-    inPublish = require('in-publish').inPublish,
-    logSymbols = require('log-symbols'),
-    util = require('./lib'),
-    isTravis = require('is-travis'),
-    componentsDir = path.join(__dirname, '..', '..', '..', 'src'),
-    componentsToPublish = [];
+'use strict';
+
+var path = require( 'path' );
+var fs = require( 'fs' );
+var readdir = require( 'fs-readdir-promise' );
+var Promise = require( 'bluebird' );
+var semver = require( 'semver' );
+var inPublish = require( 'in-publish' ).inPublish;
+var logSymbols = require( 'log-symbols' );
+var util = require( './lib' );
+var isTravis = require( 'is-travis' );
+var componentsDir = path.join( __dirname, '..', '..', '..', 'src' );
+var componentsToPublish = [];
 
 // Check git's status.
-util.getGitStatus('./')
+util.getGitStatus( './' )
   // Abort if the working directory isn't clean.
-  .then(handleGitStatus)
+  .then( handleGitStatus )
   // Verify they're logged into npm.
-  .then(checkCredentials)
+  .then( checkCredentials )
   // Travis operates in a detached head state so checkout the master branch.
-  .then(checkoutMaster)
+  .then( checkoutMaster )
   // Get a list of CF components from the components/ dir.
-  .then(getComponents)
+  .then( getComponents )
   // Filter the components that have had their versions incremented.
-  .then(filterComponents)
+  .then( filterComponents )
   // Build the components.
-  .then(buildComponents)
+  .then( buildComponents )
   // Confirm that the user wants to publish them.
-  .then(confirmPublish)
+  .then( confirmPublish )
   // Write the new version to the master component's manifest.
-  .then(updateManifest)
+  .then( updateManifest )
   // Write the new version to the changelog.
-  .then(updateChangelog)
+  .then( updateChangelog )
   // Commit the change.
-  .then(commit)
+  .then( commit )
   // Tag the new version.
-  .then(tag)
+  .then( tag )
   // Push the change to GitHub.
-  .then(push)
+  .then( push )
   // Publish the components.
-  .then(publishComponents)
+  .then( publishComponents )
   // All done.
-  .then(finish)
+  .then( finish )
   // Report any errors that happen along the way.
-  .catch(handleError);
+  ['catch']( handleError );
 
-function handleError(msg) {
-  util.printLn.error(msg);
-  process.exit(1);
+/**
+ * Generic error handler
+ * @param {string} msg The message to print to terminal.
+ */
+function handleError( msg ) {
+  util.printLn.error( msg );
+  process.exit( 1 );
 }
 
-function handleGitStatus(result) {
-  if (!result.stdout && !result.stderr) {
-    util.printLn.info('Git working directory is clean.');
+function handleGitStatus( result ) {
+  if ( !result.stdout && !result.stderr ) {
+    util.printLn.info( 'Git working directory is clean.' );
   } else {
-    if (util.option.dryrun) {
-      return util.printLn.warning('Your working directory isn\'t clean but this is a dry run so I\'ll continue...');
+    if ( util.option.dryrun ) {
+      return util.printLn.warning(
+        'Your working directory isn\'t clean but this is a dry ' +
+        'run so I’ll continue...'
+      );
     }
-    util.printLn.error('Git working directory is not clean. Commit your work before publishing.');
-    process.exit(1);
+    util.printLn.error(
+      'Git working directory is not clean. Commit your work before publishing.'
+    );
+    process.exit( 1 );
   }
 }
 
-function checkCredentials(result) {
+function checkCredentials( result ) {
   // Travis gets its credentials from .travis.yml
-  if (isTravis) return;
-  if (util.option.dryrun) {
-    return util.printLn.warning('I\'m not verifying your npm permissions because this is a dry run.');
+  if ( isTravis ) return;
+  if ( util.option.dryrun ) {
+    return util.printLn.warning(
+      'I\'m not verifying your npm permissions because this is a dry run.'
+    );
   }
-  util.printLn.info('Checking npm credentials...');
-  return util.checkNpmAuth(util.pkg.name);
+  util.printLn.info( 'Checking npm credentials...' );
+  return util.checkNpmAuth( util.pkg.name );
 }
 
 function checkoutMaster() {
   // Travis operates in a detached head state so checkout the master branch.
-  if (isTravis) {
-    util.printLn.info('Checking out ' + process.env.GH_PROD_BRANCH + ' branch...');
+  if ( isTravis ) {
+    util.printLn.info(
+      'Checking out ' + process.env.GH_PROD_BRANCH + ' branch...'
+    );
     return util.git.checkoutMaster();
-  } else {
-    if (util.option.dryrun) {
-      return util.printLn.warning('You\'re not on the proper release branch but this is a dry run so I\'ll continue anyway.');
-    }
-    return util.git.checkBranch().then(function(result) {
-      if (!process.env.GH_PROD_BRANCH || !process.env.GH_DEV_BRANCH) {
-        util.printLn.error('Publishing to npm from you local machine isn\'t recommended but if you\'d like to do it anyway, define GH_PROD_BRANCH and GH_DEV_BRANCH env variables.');
-        process.exit(1);
-      }
-      if (result.stdout.trim() !== process.env.GH_PROD_BRANCH) {
-        util.printLn.error('You\'re not on the ' + process.env.GH_PROD_BRANCH + ' branch. Merge your changes into ' + process.env.GH_PROD_BRANCH + ' before publishing.');
-        process.exit(1);
-      }
-    });
   }
+  if ( util.option.dryrun ) {
+    return util.printLn.warning(
+      'You’re not on the proper release branch but this is a dry run so ' +
+      'I’ll continue anyway.'
+    );
+  }
+  return util.git.checkBranch().then( function( result ) {
+    if ( !process.env.GH_PROD_BRANCH || !process.env.GH_DEV_BRANCH ) {
+      util.printLn.error(
+        'Publishing to npm from you local machine isn’t recommended but if ' +
+        'you’d like to do it anyway, define GH_PROD_BRANCH and ' +
+        'GH_DEV_BRANCH env variables.'
+      );
+      process.exit( 1 );
+    }
+    if ( result.stdout.trim() !== process.env.GH_PROD_BRANCH ) {
+      util.printLn.error(
+        'You’re not on the ' + process.env.GH_PROD_BRANCH +
+        ' branch. Merge your changes into ' + process.env.GH_PROD_BRANCH +
+        ' before publishing.'
+      );
+      process.exit( 1 );
+    }
+  } );
+
 }
 
 function getComponents() {
-  return readdir(componentsDir);
+  return readdir( componentsDir );
 }
 
-function filterComponents(components) {
-  var promises = components.map(compareVersionNumber);
-  promises.push(compareMasterVersionNumber());
-  util.printLn.info('Checking which components need to be published to npm...');
-  return Promise.all(promises);
+function filterComponents( components ) {
+  var promises = components.map( compareVersionNumber );
+  promises.push( compareMasterVersionNumber() );
+  util.printLn.info(
+    'Checking which components need to be published to npm...'
+  );
+  return Promise.all( promises );
 }
 
-function compareVersionNumber(component) {
-  if (component.indexOf('cf-') !== 0) return;
+function compareVersionNumber( component ) {
+  if ( component.indexOf( 'cf-' ) !== 0 ) return;
 
   var manifest = componentsDir + '/' + component + '/package.json',
-      localVersion = JSON.parse(fs.readFileSync(manifest, 'utf8')).version;
+      localVersion = JSON.parse(
+        fs.readFileSync( manifest, 'utf8' )
+      ).version;
 
-  return util.getNpmVersion(component).then(function(data) {
+  return util.getNpmVersion( component ).then( function( data ) {
     var npmVersion = data['dist-tags'].latest;
-    if (semver.gt(localVersion, npmVersion)) {
-      util.printLn.success(component + ': ' + npmVersion + ' -> ' + localVersion, true);
+    if ( semver.gt( localVersion, npmVersion ) ) {
+      util.printLn.success(
+        component + ': ' + npmVersion + ' -> ' + localVersion, true
+      );
       return {
-        name: component,
+        name:       component,
         newVersion: localVersion,
         oldVersion: npmVersion
       };
-    } else if (semver.lt(localVersion, npmVersion)) {
-      util.printLn.error('Error: ' + component + ' was bumped to ' + localVersion + ' locally but the latest version on npm is ' + npmVersion + '.', true);
+    } else if ( semver.lt( localVersion, npmVersion ) ) {
+      util.printLn.error(
+        'Error: ' + component + ' was bumped to ' + localVersion +
+        ' locally but the latest version on npm is ' + npmVersion + '.',
+        true
+      );
     } else {
-      util.printLn.info(component + ' remains ' + npmVersion, true);
+      util.printLn.info( component + ' remains ' + npmVersion, true );
     }
-  }).catch(function(err) {
-    if (/returned 404/.test(err)) {
-      util.printLn.success(component + ': ' + localVersion, true);
+  } )['catch']( function( err ) {
+    if ( /returned 404/.test( err ) ) {
+      util.printLn.success( component + ': ' + localVersion, true );
       return {
-        name: component,
+        name:       component,
         newVersion: localVersion,
         oldVersion: undefined
       };
     }
-    util.printLn.error(err);
-    process.exit(1);
-  });
+    util.printLn.error( err );
+    process.exit( 1 );
+  } );
 }
 
 function compareMasterVersionNumber() {
-  return util.getNpmVersion(util.pkg.name).then(function(data) {
+  return util.getNpmVersion( util.pkg.name ).then( function( data ) {
     return {
-      new: util.pkg.version,
-      old: data['dist-tags'].latest
+      'new': util.pkg.version,
+      'old': data['dist-tags'].latest
     };
-  });
+  } );
 }
 
-function buildComponents(components) {
-  var newVersion,
-      diffs = [],
-      masterComponent = components.pop();
+function buildComponents( components ) {
+  var newVersion;
+  var diffs = [];
+  var masterComponent = components.pop();
 
   // TODO: Fix bug that results in some entries in the components array to be
   // blank. For now, filter them out.
-  componentsToPublish = components.filter(function(component) {
+  componentsToPublish = components.filter( function( component ) {
     var diff;
-    if (component) {
+    if ( component ) {
       // While we're iterating, keep track of each component's semver diff.
       // If there's no old version it means it's a new component and CF should
       // get a minor bump instead of whatever the actual diff is.
-      diff = !component.oldVersion ? 'minor' : semver.diff(component.oldVersion, component.newVersion);
-      diffs.push(diff);
+      diff = !component.oldVersion ? 'minor' : semver.diff(
+        component.oldVersion, component.newVersion
+      );
+      diffs.push( diff );
       return component.name !== undefined;
     }
-  });
+  } );
 
   // If no components were updated, check if the master component was updated.
-  if (!componentsToPublish.length) {
-    util.printLn.error('No components\' versions were updated.');
-    if (semver.gt(masterComponent.new, masterComponent.old)) {
-      util.printLn.success(util.pkg.name + '\'s version was manually updated: ' + masterComponent.old + ' -> ' + masterComponent.new + '.');
-      util.printLn.info('Building components now...');
+  if ( !componentsToPublish.length ) {
+    util.printLn.error( 'No components\' versions were updated.' );
+    if ( semver.gt( masterComponent['new'], masterComponent.old ) ) {
+      util.printLn.success(
+        util.pkg.name + '\'s version was manually updated: ' +
+        masterComponent.old + ' -> ' + masterComponent['new'] + '.'
+      );
+      util.printLn.info( 'Building components now...' );
       return util.build();
     }
-    if (util.option.dryrun) {
-      return util.printLn.warning('There\'s nothing to publish (no component versions have been incremented) but this is a dry run so I\'ll continue anyway.');
+    if ( util.option.dryrun ) {
+      return util.printLn.warning(
+        'There’s nothing to publish (no component versions have been ' +
+        'incremented) but this is a dry run so I’ll continue anyway.'
+      );
     }
-    util.printLn.error(util.pkg.name + '\'s version also wasn\'t updated. Nothing to publish. Abort.');
-    process.exit(1);
+    util.printLn.error(
+      util.pkg.name +
+      '’s version also wasn’t updated. Nothing to publish. Abort.'
+    );
+    process.exit( 1 );
   }
 
-  // Sort the diffs and increment CF by whatever the first (largest) increment is
-  newVersion = semver.inc(masterComponent.old, diffs.sort().shift());
-  util.printLn.success(util.pkg.name + ' will be published: ' + masterComponent.old + ' -> ' + newVersion + '. See https://goo.gl/cZvnnL.');
+  // Sort the diffs and increment CF by whatever the first (largest)
+  // increment is
+  newVersion = semver.inc( masterComponent.old, diffs.sort().shift() );
+  util.printLn.success(
+    util.pkg.name + ' will be published: ' + masterComponent.old + ' -> ' +
+    newVersion + '. See https://goo.gl/cZvnnL.'
+  );
   util.pkg.version = newVersion;
-  util.printLn.info('Building components now...');
+  util.printLn.info( 'Building components now...' );
   return util.build();
 }
 
 function confirmPublish() {
-  util.printLn.info('Components have been built to tmp/.');
-  return util.confirm({
-    prompt: '    Publish the above components marked with a ' + logSymbols.success + ' ?',
-    yes: 'Publishing the components to npm...',
-    no: 'Aborting. See ya!'
-  });
+  util.printLn.info( 'Components have been built to tmp/. ' );
+  return util.confirm( {
+    prompt: 'Publish the above components marked with a ' +
+            logSymbols.success + ' ?',
+    yes:    'Publishing the components to npm...',
+    no:     'Aborting. See ya!'
+  } );
 }
 
 function updateManifest() {
-  if (util.option.dryrun) {
-    return util.printLn.warning('I did not update package.json because this is a dry run.');
+  if ( util.option.dryrun ) {
+    return util.printLn.warning(
+      'I did not update package.json because this is a dry run.'
+    );
   }
-  fs.writeFileSync('package.json', JSON.stringify(util.pkg, null, 2));
+  fs.writeFileSync( 'package.json', JSON.stringify( util.pkg, null, 2 ) );
 }
 
 function updateChangelog() {
-  if (util.option.dryrun) {
-    return util.printLn.warning('I did not update the changelog because this is a dry run.');
+  if ( util.option.dryrun ) {
+    return util.printLn.warning(
+      'I did not update the changelog because this is a dry run.'
+    );
   }
-  return util.changelog(util.pkg.version);
+  return util.changelog( util.pkg.version );
 }
 
 function commit() {
-  if (util.option.dryrun) {
-    return util.printLn.warning('I did not commit any changes because this is a dry run.');
+  if ( util.option.dryrun ) {
+    return util.printLn.warning(
+      'I did not commit any changes because this is a dry run.'
+    );
   }
-  util.printLn.info('Committing change to manifest...');
-  return util.git.commit(util.pkg.version);
+  util.printLn.info( 'Committing change to manifest...' );
+  return util.git.commit( util.pkg.version );
 }
 
-function tag(result) {
-  if (result && result.stdout) util.printLn.console(result.stdout);
-  if (util.option.dryrun) {
-    return util.printLn.warning('I did not create a new tag because this is a dry run.');
+function tag( result ) {
+  if ( result && result.stdout ) util.printLn.console( result.stdout );
+  if ( util.option.dryrun ) {
+    return util.printLn.warning(
+      'I did not create a new tag because this is a dry run.'
+    );
   }
-  util.printLn.info('Tagging version ' + util.pkg.version + '...');
-  return util.git.tag(util.pkg.version);
+  util.printLn.info( 'Tagging version ' + util.pkg.version + '...' );
+  return util.git.tag( util.pkg.version );
 }
 
-function push(result) {
-  if (result && result.stdout) util.printLn.console(result.stdout);
-  if (util.option.dryrun) {
-    return util.printLn.warning('I did not push to GitHub because this is a dry run.');
+function push( result ) {
+  if ( result && result.stdout ) util.printLn.console( result.stdout );
+  if ( util.option.dryrun ) {
+    return util.printLn.warning(
+      'I did not push to GitHub because this is a dry run.'
+    );
   }
-  util.printLn.info('Pushing commit to GitHub...');
-  return util.git.push(util.pkg.repository.url);
+  util.printLn.info( 'Pushing commit to GitHub...' );
+  return util.git.push( util.pkg.repository.url );
 }
 
-function publishComponents(result) {
-  if (result && result.stdout) util.printLn.console(result.stdout);
-  if (util.option.dryrun) {
-    return util.printLn.warning('I did not publish anything to npm because this is a dry run.');
+function publishComponents( result ) {
+  if ( result && result.stdout ) util.printLn.console( result.stdout );
+  if ( util.option.dryrun ) {
+    return util.printLn.warning(
+      'I did not publish anything to npm because this is a dry run.'
+    );
   }
-  if (!componentsToPublish.length) return;
-  var components = componentsToPublish.map(function(component) {
+  if ( !componentsToPublish.length ) return;
+  var components = componentsToPublish.map( function( component ) {
     return component.name;
-  });
-  util.printLn.info('Publishing ' + components.join(', ') + ' to npm...');
-  return Promise.all(components.map(util.publish));
+  } );
+  util.printLn.info( 'Publishing ' + components.join( ', ' ) + ' to npm...' );
+  return Promise.all( components.map( util.publish ) );
 }
 
-function finish(result) {
-  if (result && result.stdout) util.printLn.console(result.stdout);
-  util.printLn.success('Hooray! All done!');
+function finish( result ) {
+  if ( result && result.stdout ) util.printLn.console( result.stdout );
+  util.printLn.success( 'Hooray! All done!' );
 }

--- a/scripts/npm/prepublish/lib/build.js
+++ b/scripts/npm/prepublish/lib/build.js
@@ -1,11 +1,13 @@
-var exec = require('child-process-promise').exec;
+'use strict';
 
-function build(component) {
-  if (component) {
-    return exec('gulp build --component=' + component.name);
+var exec = require( 'child-process-promise' ).exec;
+
+function build( component ) {
+  if ( component ) {
+    return exec( 'gulp build --component=' + component.name );
   }
   // If no component is specified, build all of CF.
-  return exec('gulp build');
+  return exec( 'gulp build' );
 }
 
 module.exports = build;

--- a/scripts/npm/prepublish/lib/changelog.js
+++ b/scripts/npm/prepublish/lib/changelog.js
@@ -1,16 +1,20 @@
-var fs = require('fs'),
-    path = require('path'),
-    promisify = require('promisify-node');
+'use script';
 
-promisify(fs.writeFile);
+var fs = require( 'fs' );
+var path = require( 'path' );
+var promisify = require( 'promisify-node' );
 
-function updateChangelog(version) {
-  var file = path.join(__dirname, '..', '..', '..', '..', 'CHANGELOG.md'),
-      date = new Date().toJSON().slice(0, 10),
-      latest = '## Unreleased\n\n### Added\n- \n\n### Changed\n- \n\n### Removed\n- \n\n## ' + version + ' - ' + date;
-  changelog = fs.readFileSync(file, 'utf8');
-  changelog = changelog.replace(/## Unreleased/g, latest);
-  return fs.writeFile(file, changelog, 'utf8', function() { return; });
+promisify( fs.writeFile );
+
+function updateChangelog( version ) {
+  var file = path.join( __dirname, '..', '..', '..', '..', 'CHANGELOG.md' );
+  var date = new Date().toJSON().slice( 0, 10 );
+  var latest = '## Unreleased\n\n### Added\n- \n\n### Changed\n- ' +
+               '\n\n### Removed\n- \n\n## ' + version + ' - ' + date;
+  var changelog = fs.readFileSync( file, 'utf8' );
+
+  changelog = changelog.replace( /## Unreleased/g, latest );
+  return fs.writeFile( file, changelog, 'utf8', function() { return; } );
 }
 
 module.exports = updateChangelog;

--- a/scripts/npm/prepublish/lib/checkNpmAuth.js
+++ b/scripts/npm/prepublish/lib/checkNpmAuth.js
@@ -1,38 +1,47 @@
-var RegClient = require('silent-npm-registry-client'),
-    client = new RegClient(),
-    promisify = require('promisify-node'),
-    exec = require('child-process-promise').exec,
-    printLn = require('./print');
+'use strict';
 
-promisify(client);
+var RegClient = require( 'silent-npm-registry-client' );
+var client = new RegClient();
+var promisify = require( 'promisify-node' );
+var exec = require( 'child-process-promise' ).exec;
+var printLn = require( './print' );
 
-function checkAuth(component) {
+promisify( client );
+
+function checkAuth( component ) {
   var uri = 'https://registry.npmjs.org/' + component;
 
-  var getOwners = client.get(uri, {timeout: 10000}).then(function(data) {
+  var getOwners = client.get( uri, { timeout: 10000 } ).then( function( data ) {
     return data.maintainers;
-  });
-  var getCurrentUser = exec('npm whoami');
+  } );
+  var getCurrentUser = exec( 'npm whoami' );
 
-  return Promise.all([getOwners, getCurrentUser]).then(function(data) {
-    var authorized = false,
-        currentUser = data[1].stdout.trim();
-    printLn.info('Logged into npm as ' + currentUser);
-    data[0].forEach(function(maintainer) {
-      authorized = maintainer.name == currentUser;
-    });
-    if (!authorized) {
-      printLn.error('You\'re not listed as a maintainer in npm. Talk to a node-ledgable coworker for assistance.');
-      process.exit(1);
+  return Promise.all( [ getOwners, getCurrentUser ] ).then( function( data ) {
+    var authorized = false;
+    var currentUser = data[1].stdout.trim();
+
+    printLn.info( 'Logged into npm as ' + currentUser );
+    data[0].forEach( function( maintainer ) {
+      authorized = maintainer.name === currentUser;
+    } );
+    if ( !authorized ) {
+      printLn.error(
+        'You\'re not listed as a maintainer in npm. ' +
+        'Talk to a node-ledgable coworker for assistance.'
+      );
+      process.exit( 1 );
     }
-  }).catch(function(err) {
-    if (/ENEEDAUTH/.test(err)) {
-      printLn.error('You\'re not logged into npm. You need to authorize this machine using `npm login`.');
-      process.exit(1);
+  } )['catch']( function( err ) {
+    if ( /ENEEDAUTH/.test( err ) ) {
+      printLn.error(
+        'You\'re not logged into npm. You need to authorize ' +
+        'this machine using `npm login`.'
+      );
+      process.exit( 1 );
     }
-    console.error(err);
-    process.exit(1);
-  });
+    console.error( err );
+    process.exit( 1 );
+  } );
 }
 
 module.exports = checkAuth;

--- a/scripts/npm/prepublish/lib/commit.js
+++ b/scripts/npm/prepublish/lib/commit.js
@@ -1,8 +1,10 @@
-var exec = require('child-process-promise').exec;
+'use strict';
 
-function commit(version) {
-  var msg = version || "Auto-incrementing version";
-  return exec('git commit -am "' + msg + '"');
+var exec = require( 'child-process-promise' ).exec;
+
+function commit( version ) {
+  var msg = version || 'Auto-incrementing version';
+  return exec( 'git commit -am "' + msg + '"' );
 }
 
 module.exports = commit;

--- a/scripts/npm/prepublish/lib/confirm.js
+++ b/scripts/npm/prepublish/lib/confirm.js
@@ -1,34 +1,40 @@
-var Promise = require('bluebird'),
-    readline = require('readline'),
-    options = require('./getArgs'),
-    printLn = require('./print');
+'use strict';
 
-function confirm(opts) {
+var Promise = require( 'bluebird' );
+var readline = require( 'readline' );
+var options = require( './getArgs' );
+var printLn = require( './print' );
+
+function confirm( opts ) {
   opts = opts || {};
   var prompt = opts.prompt + ' [Y/n] ';
-  return new Promise(function (resolve, reject) {
-    // If the silent or dryrun option is passed or we're in a CI, don't prompt the user.
-    if (options.silent || options.dryrun || process.env.CONTINUOUS_INTEGRATION) {
-      return resolve(opts.data);
+  return new Promise( function( resolve, reject ) {
+    // If the silent or dryrun option is passed or we're in a CI,
+    // don't prompt the user.
+    if ( options.silent ||
+         options.dryrun ||
+         process.env.CONTINUOUS_INTEGRATION
+    ) {
+      return resolve( opts.data );
     }
-    var rl = readline.createInterface({
-      input: process.stdin,
+    var rl = readline.createInterface( {
+      input:  process.stdin,
       output: process.stdout
-    });
-    rl.question(prompt, function(answer) {
-      if (!answer || /^y$|^yes$/.test(answer.trim().toLowerCase())) {
-        printLn.info(opts.yes);
-        resolve(opts.data);
+    } );
+    rl.question( prompt, function( answer ) {
+      if ( !answer || ( /^y$|^yes$/ ).test( answer.trim().toLowerCase() ) ) {
+        printLn.info( opts.yes );
+        resolve( opts.data );
       } else {
-        reject(opts.no);
+        reject( opts.no );
       }
       rl.close();
-    });
-    rl.on('SIGINT', function() {
-      printLn.error('OMG ABORT EVERYTHING.');
-      process.exit(1);
-    });
-  });
+    } );
+    rl.on( 'SIGINT', function() {
+      printLn.error( 'OMG ABORT EVERYTHING.' );
+      process.exit( 1 );
+    } );
+  } );
 }
 
 module.exports = confirm;

--- a/scripts/npm/prepublish/lib/getArgs.js
+++ b/scripts/npm/prepublish/lib/getArgs.js
@@ -1,8 +1,10 @@
-var argv = require('minimist')(process.argv.slice(2));
+'use strict';
+
+var argv = require( 'minimist' )( process.argv.slice( 2 ) );
 
 module.exports = {
   component: argv.component,
-  silent: (argv.s || argv.silent),
-  dryrun: (argv.dryrun),
-  force: (argv.f || argv.force)
-}
+  silent: 	 argv.s || argv.silent,
+  dryrun: 	 argv.dryrun,
+  force: 	 argv.f || argv.force
+};

--- a/scripts/npm/prepublish/lib/getNpmVersion.js
+++ b/scripts/npm/prepublish/lib/getNpmVersion.js
@@ -1,12 +1,14 @@
-var RegClient = require('silent-npm-registry-client'),
-    client = new RegClient(),
-    promisify = require('promisify-node');
+'use strict';
 
-promisify(client);
+var RegClient = require( 'silent-npm-registry-client' );
+var client = new RegClient();
+var promisify = require( 'promisify-node' );
 
-function getVersion(component) {
+promisify( client );
+
+function getVersion( component ) {
   var uri = 'https://registry.npmjs.org/' + component;
-  return client.get(uri, {timeout: 1000});
+  return client.get( uri, { timeout: 1000 } );
 }
 
 module.exports = getVersion;

--- a/scripts/npm/prepublish/lib/git.js
+++ b/scripts/npm/prepublish/lib/git.js
@@ -1,34 +1,48 @@
-var exec = require('child-process-promise').exec;
+'use strict';
+
+var exec = require( 'child-process-promise' ).exec;
 
 var git = {
   checkoutMaster: function() {
-    return exec('git checkout ' + process.env.GH_PROD_BRANCH);
+    return exec( 'git checkout ' + process.env.GH_PROD_BRANCH );
   },
   checkBranch: function() {
-    return exec('git rev-parse --abbrev-ref HEAD');
+    return exec( 'git rev-parse --abbrev-ref HEAD' );
   },
-  commit: function(version) {
+  commit: function( version ) {
     var msg = version || 'Auto-incrementing version';
-    return exec('git commit -am "' + msg + '"');
+    return exec( 'git commit -am "' + msg + '"' );
   },
-  tag: function(version) {
-    return exec('git tag -a ' + version + ' -m "' + version + '"');
+  tag: function( version ) {
+    return exec( 'git tag -a ' + version + ' -m "' + version + '"' );
   },
-  push: function(remote) {
-    if (process.env.GH_TOKEN) {
-      remote = remote.match(/github\.com.+/)[0];
-      return Promise.all([
-        exec('git push "https://' + process.env.GH_TOKEN + '@' + remote + '" ' + process.env.GH_PROD_BRANCH),
-        exec('git push "https://' + process.env.GH_TOKEN + '@' + remote + '" ' + process.env.GH_PROD_BRANCH + ':' + process.env.GH_DEV_BRANCH),
-        exec('git push "https://' + process.env.GH_TOKEN + '@' + remote + '" --tags')
-      ]);
+  push: function( remote ) {
+    if ( process.env.GH_TOKEN ) {
+      remote = remote.match( /github\.com.+/ )[0];
+      return Promise.all( [
+        exec(
+          'git push "https://' + process.env.GH_TOKEN + '@' + remote + '" ' +
+          process.env.GH_PROD_BRANCH
+        ),
+        exec(
+          'git push "https://' + process.env.GH_TOKEN + '@' + remote + '" ' +
+          process.env.GH_PROD_BRANCH + ':' + process.env.GH_DEV_BRANCH
+        ),
+        exec(
+          'git push "https://' + process.env.GH_TOKEN + '@' + remote +
+          '" --tags'
+        )
+      ] );
     }
-    return Promise.all([
-      exec('git push ' + remote + ' ' + process.env.GH_PROD_BRANCH),
-      exec('git push ' + remote + ' ' + process.env.GH_PROD_BRANCH + ':' + process.env.GH_DEV_BRANCH),
-      exec('git push ' + remote + ' --tags')
-    ]);
+    return Promise.all( [
+      exec( 'git push ' + remote + ' ' + process.env.GH_PROD_BRANCH ),
+      exec(
+        'git push ' + remote + ' ' + process.env.GH_PROD_BRANCH + ':' +
+        process.env.GH_DEV_BRANCH
+      ),
+      exec( 'git push ' + remote + ' --tags' )
+    ] );
   }
-}
+};
 
 module.exports = git;

--- a/scripts/npm/prepublish/lib/gitStatus.js
+++ b/scripts/npm/prepublish/lib/gitStatus.js
@@ -1,7 +1,9 @@
-var exec = require('child-process-promise').exec;
+'use strict';
 
-function status(path) {
-  return exec('git status -s ' + path);
+var exec = require( 'child-process-promise' ).exec;
+
+function status( path ) {
+  return exec( 'git status -s ' + path );
 }
 
 module.exports = status;

--- a/scripts/npm/prepublish/lib/index.js
+++ b/scripts/npm/prepublish/lib/index.js
@@ -1,20 +1,22 @@
-var fs = require('fs');
+'use strict';
+
+var fs = require( 'fs' );
 
 module.exports = {
-  printLn: require('./print'),
-  confirm: require('./confirm'),
-  getGitStatus: require('./gitStatus'),
-  build: require('./build'),
-  publish: require('./publish'),
-  git: require('./git'),
-  changelog: require('./changelog'),
-  getNpmVersion: require('./getNpmVersion'),
-  checkNpmAuth: require('./checkNpmAuth'),
-  pkg: JSON.parse(fs.readFileSync('package.json', 'utf8')),
-  option: require('./getArgs')
-}
+  printLn:       require( './print' ),
+  confirm:       require( './confirm' ),
+  getGitStatus:  require( './gitStatus' ),
+  build:         require( './build' ),
+  publish:       require( './publish' ),
+  git:           require( './git' ),
+  changelog:     require( './changelog' ),
+  getNpmVersion: require( './getNpmVersion' ),
+  checkNpmAuth:  require( './checkNpmAuth' ),
+  pkg:           JSON.parse( fs.readFileSync( 'package.json', 'utf8' ) ),
+  option:        require( './getArgs' )
+};
 
-process.on('SIGINT', function() {
-  module.exports.printLn.error('OMG ABORT EVERYTHING.');
-  process.exit(1);
-});
+process.on( 'SIGINT', function() {
+  module.exports.printLn.error( 'OMG ABORT EVERYTHING.' );
+  process.exit( 1 );
+} );

--- a/scripts/npm/prepublish/lib/print.js
+++ b/scripts/npm/prepublish/lib/print.js
@@ -1,22 +1,27 @@
-var logSymbols = require('log-symbols'),
-    chalk = require('chalk'),
-    indentString = require('indent-string');
-    options = require('./getArgs');
+'use strict';
 
-function printMsg(type, msg, indent) {
-  return console.log(indentString(logSymbols[type] + ' ' + msg, ' ', indent ? 4 : 2));
+var logSymbols = require( 'log-symbols' );
+var chalk = require( 'chalk' );
+var indentString = require( 'indent-string' );
+var options = require( './getArgs' );
+
+function printMsg( type, msg, indent ) {
+  return console.log(
+    indentString( logSymbols[type] + ' ' + msg, ' ', indent ? 4 : 2 )
+  );
 }
 
 var printLn = {};
 
-['success', 'warning', 'error', 'info'].forEach(function(type) {
-  printLn[type] = function(msg, indent) {
-    options.silent ? function(){} : printMsg(type, msg, indent);
-  }
-});
+[ 'success', 'warning', 'error', 'info' ].forEach( function( type ) {
+  printLn[type] = function( msg, indent ) {
+    options.silent ? function() {} : printMsg( type, msg, indent );
+  };
+} );
 
-printLn.console = function(msg) {
-  options.silent ? function(){} : console.log(chalk.dim(indentString(msg, ' ', 8)));
-}
+printLn.console = function( msg ) {
+  options.silent ? function() {} :
+  console.log( chalk.dim( indentString( msg, ' ', 8 ) ) );
+};
 
 module.exports = printLn;

--- a/scripts/npm/prepublish/lib/publish.js
+++ b/scripts/npm/prepublish/lib/publish.js
@@ -1,9 +1,11 @@
-var exec = require('child-process-promise').exec;
+'use strict';
 
-function publish(component) {
-  return exec('npm publish', {
+var exec = require( 'child-process-promise' ).exec;
+
+function publish( component ) {
+  return exec( 'npm publish', {
     cwd: './tmp/' + component
-  });
+  } );
 }
 
 module.exports = publish;


### PR DESCRIPTION
The deployment scripts have never been linted. This takes on the easy fixes prior to writing tests for these files (that PR is coming).

## Additions

- Added `gulp lint:release` to the available tasks

## Changes

- Updated the `prepublish` scripts to reduce the problems from 737 to 94

## Testing

- run `gulp lint:release` and confirm there are only 94 problems

## Todos

- Write tests to ensure any further changes don't break things
- Fix the rest of the linting issues.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)