### PR TITLE
Add transform to fix radio button Firefox rendering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
-- 
+-
 
 ### Changed
-- 
+- **cf-forms:** [PATCH] Add transform to fix radio button Firefox rendering bug.
 
 ### Removed
-- 
+-
 
 ## 4.20.0 - 2017-12-18
 

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -119,6 +119,9 @@
         .a-label {
             &:before {
                 border-radius: 50%;
+                /* The rotate is needed to fix a bug in Firefox where radio
+                   button was not centered. */
+                transform: rotate(0deg);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/cfpb/capital-framework/issues/720

## Changes

- Adds a `transform: rotate(0deg)` to fix alignment of circle in radio buttons in Firefox.

## Testing

- Open canary branch in Firefox and visit http://localhost:3000/components/cf-forms/ and look at the radio buttons hover state.
- Open this PR in Firefox and visit http://localhost:3000/components/cf-forms/ and compare to the above.

## Screenshots

Before:
![screen shot 2017-12-26 at 11 18 32 am](https://user-images.githubusercontent.com/704760/34360456-10c585d8-ea2f-11e7-980d-693c3bae6da6.png)

After:
![screen shot 2017-12-26 at 11 17 49 am](https://user-images.githubusercontent.com/704760/34360455-10625828-ea2f-11e7-9844-cb9036b59ec8.png)