### PR TITLE
Move ignored autoprefixer rule to its own block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Changed
 - **cf-forms:** [PATCH] Add transform to fix radio button Firefox rendering bug.
 - **cf-forms:** [MINOR] Add multi-line support to checkboxes/radio buttons.
+- **cf-forms:** [PATCH] Move autoprefixer ignored rule to its own block.
 
 ### Removed
 -

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -8,19 +8,22 @@
         margin-top: unit( 5px / @base-font-size-px, em );
     }
 
+    /*
+    We need to turn off autoprefixing for the inline-grid because
+    older IE does not handle an inline-grid like other browsers,
+    leading to an extremely narrow column of text for the label.
+     */
     &__checkbox,
     &__radio {
         .a-label {
-            /*
-            We need to turn off autoprefixing for the inline-grid because
-            older IE does not handle an inline-grid like other browsers,
-            leading to an extremely narrow column of text for the label.
-             */
-
             /* autoprefixer: off */
             display: inline-grid;
-            /* autoprefixer: on */
+        }
+    }
 
+    &__checkbox,
+    &__radio {
+        .a-label {
             // 30px is width of checkbox/radio button plus the needed padding.
             grid-template-columns: unit( 30px / @base-font-size-px, em ) auto;
             vertical-align: top;

--- a/src/cf-forms/src/molecules/form-fields.less
+++ b/src/cf-forms/src/molecules/form-fields.less
@@ -12,6 +12,9 @@
     We need to turn off autoprefixing for the inline-grid because
     older IE does not handle an inline-grid like other browsers,
     leading to an extremely narrow column of text for the label.
+    This ensures it's only picked up by browsers with standard support.
+    Also, autoprefixer ignores rules on a per block basis so that is why
+    this is placed in its own block. 
      */
     &__checkbox,
     &__radio {


### PR DESCRIPTION
Autoprefixer ignore comment applies to the whole block, so wasn't being re-enabled.

## Changes

- Move ignored autoprefixer rule to its own block

  