### PR TITLE
Lints release and build scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "capital-framework",
-  "version": "4.19.0",
+  "version": "4.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -148,11 +148,38 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
       "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -163,6 +190,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "anymatch": {
@@ -246,6 +279,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
       "dev": true
     },
     "array-differ": {
@@ -1636,6 +1675,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -1707,6 +1752,16 @@
             "safe-buffer": "5.1.1"
           }
         }
+      }
+    },
+    "config-chain": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.4",
+        "proto-list": "1.2.4"
       }
     },
     "configstore": {
@@ -2251,6 +2306,36 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "editorconfig": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
+      "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "commander": "2.12.2",
+        "lru-cache": "3.2.0",
+        "semver": "5.4.1",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2"
+          }
+        }
       }
     },
     "ee-first": {
@@ -2806,6 +2891,23 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
+    },
+    "extend-shallow": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+      "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+      "dev": true,
+      "requires": {
+        "kind-of": "1.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
+      }
     },
     "external-editor": {
       "version": "2.1.0",
@@ -5170,6 +5272,40 @@
         }
       }
     },
+    "gulp-jsbeautifier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gulp-jsbeautifier/-/gulp-jsbeautifier-2.1.2.tgz",
+      "integrity": "sha512-tZUk4c11zF8xzCCTOEmktxGitv/H2vpAcflZNVU8nxL+G5XxQyLJUJVUKylz7/dax+FXb3YwQYByaJ+yxmo8iw==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "fancy-log": "1.3.2",
+        "js-beautify": "1.7.5",
+        "lodash": "4.17.4",
+        "plugin-error": "0.1.2",
+        "rc": "1.2.2",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "fancy-log": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+          "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+          "dev": true,
+          "requires": {
+            "ansi-gray": "0.1.1",
+            "color-support": "1.1.3",
+            "time-stamp": "1.1.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
     "gulp-json-format": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulp-json-format/-/gulp-json-format-1.0.0.tgz",
@@ -6244,6 +6380,18 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
       "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
       "dev": true
+    },
+    "js-beautify": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
+      "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
+      "dev": true,
+      "requires": {
+        "config-chain": "1.1.11",
+        "editorconfig": "0.13.3",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6"
+      }
     },
     "js-reporters": {
       "version": "1.2.0",
@@ -8406,6 +8554,37 @@
         "find-up": "2.1.0"
       }
     },
+    "plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "dev": true,
+      "requires": {
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
+          }
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+          "dev": true
+        }
+      }
+    },
     "plur": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
@@ -8689,6 +8868,12 @@
       "requires": {
         "nodegit-promise": "3.0.3"
       }
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
     },
     "protocolify": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gulp-foreach": "^0.1.0",
     "gulp-ignore": "^2.0.1",
     "gulp-istanbul": "^1.1.2",
-    "gulp-json-format": "^1.0.0",
+    "gulp-jsbeautifier": "^2.1.2",
     "gulp-less": "^3.3.2",
     "gulp-markdown": "^1.1.0",
     "gulp-mocha": "^3.0.1",

--- a/scripts/gulp/build.js
+++ b/scripts/gulp/build.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const gulp = require( 'gulp' );
 const runSequence = require( 'run-sequence' );
 

--- a/scripts/gulp/clean.js
+++ b/scripts/gulp/clean.js
@@ -1,10 +1,8 @@
-'use strict';
-
-const component = require('./parseComponentName');
+const component = require( './parseComponentName' );
 const gulp = require( 'gulp' );
 const gulpRimraf = require( 'gulp-rimraf' );
 
-gulp.task('clean:tmp', () => {
-  gulp.src('./tmp/' + (component || ''), { read: false })
-    .pipe(gulpRimraf());
-});
+gulp.task( 'clean:tmp', () => {
+  gulp.src( './tmp/' + ( component || '' ), { read: false } )
+    .pipe( gulpRimraf() );
+} );

--- a/scripts/gulp/copy.js
+++ b/scripts/gulp/copy.js
@@ -1,58 +1,88 @@
-'use strict';
-
-const component = require( './parseComponentName' );
+const parseComponentName = require( './parseComponentName' );
 const deepmerge = require( 'deepmerge' );
 const fs = require( 'fs' );
 const gulp = require( 'gulp' );
 const gulpData = require( 'gulp-data' );
 const gulpForeach = require( 'gulp-foreach' );
-const gulpJsonFormat = require( 'gulp-json-format' );
+const gulpJSBeautifier = require( 'gulp-jsbeautifier' );
 const gulpRename = require( 'gulp-rename' );
 
-let baseManifest = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+// eslint-disable-next-line no-sync
+const baseManifest = JSON.parse( fs.readFileSync( './package.json', 'utf8' ) );
 
-gulp.task( 'copy:components:boilerplate', () => {
-  gulp.src(['./src/' + (component || '*'), '!./src/*.js', '!./src/*.less'])
-    .pipe(gulpForeach(function(stream, file) {
-      var component = file.path.split('/').pop();
+/**
+ * TODO: Add description of what this task does.
+ * @returns {Object} An output stream from gulp.
+ */
+function copyComponentsBoilerplate() {
+  return gulp.src( [
+    './src/' + ( parseComponentName || '*' ),
+    '!./src/*.js',
+    '!./src/*.less'
+  ] )
+    .pipe( gulpForeach( function( stream, file ) {
+      const component = file.path.split( '/' ).pop();
       gulp.src( './scripts/templates/component-boilerplate/*' )
-          .pipe( gulp.dest('./tmp/' + component) );
+        .pipe( gulp.dest( './tmp/' + component ) );
       return stream;
-    }))
-} );
+    } ) );
+}
 
-gulp.task( 'copy:components:source', () => {
-  gulp.src(['./src/' + (component || '*'), '!./src/*.js', '!./src/*.less'])
-    .pipe(gulpForeach(function(stream, file) {
-      var component = file.path.split('/').pop(),
-          src = [
-                  file.path + '/**',
-                  '!' + file.path + '/package.json',
-                  '!' + file.path + '/node_modules',
-                  '!' + file.path + '/node_modules/**',
-                  '!' + file.path + '/npm-*'
-                ];
+/**
+ * TODO: Add description of what this task does.
+ * @returns {Object} An output stream from gulp.
+ */
+function copyComponentsSource() {
+  return gulp.src( [
+    './src/' + ( parseComponentName || '*' ),
+    '!./src/*.js',
+    '!./src/*.less'
+  ] )
+    .pipe( gulpForeach( function( stream, file ) {
+      const component = file.path.split( '/' ).pop();
+      const src = [
+        file.path + '/**',
+        '!' + file.path + '/package.json',
+        '!' + file.path + '/node_modules',
+        '!' + file.path + '/node_modules/**',
+        '!' + file.path + '/npm-*'
+      ];
       gulp.src( src )
-          .pipe( gulp.dest('./tmp/' + component) );
+        .pipe( gulp.dest( './tmp/' + component ) );
       return stream;
-    }))
-} );
+    } ) );
+}
 
-gulp.task( 'copy:components:manifest', () => {
-  gulp.src('./src/' + (component || '*') + '/package.json')
-    .pipe(gulpData(function(file) {
-      // Remove any dependencies from CF's package.json,
-      // we don't want components to have them.
+/**
+ * TODO: Add description of what this task does.
+ * @returns {Object} An output stream from gulp.
+ */
+function copyComponentsManifest() {
+  return gulp.src( './src/' + ( parseComponentName || '*' ) + '/package.json' )
+    .pipe( gulpData( file => {
+
+      /* Remove any dependencies from CF's package.json,
+         we don't want components to have them. */
       delete baseManifest.dependencies;
-      var manifest = deepmerge(baseManifest, JSON.parse(String(file.contents)));
+      const manifest = deepmerge(
+        baseManifest,
+        JSON.parse( String( file.contents ) )
+      );
       // After the merge, remove any scripts and dev deps.
       delete manifest.scripts;
       delete manifest.devDependencies;
-      file.contents = new Buffer(JSON.stringify(manifest));
-    }))
-    .pipe(gulpRename(function(path) {
-      path.dirname = component || path.dirname;
-    }))
-    .pipe(gulpJsonFormat(2))
-    .pipe(gulp.dest('./tmp'));
-} );
+      file.contents = new Buffer( JSON.stringify( manifest ) );
+    } ) )
+    .pipe( gulpRename( path => {
+      path.dirname = parseComponentName || path.dirname;
+    } ) )
+    .pipe( gulpJSBeautifier( {
+      // eslint-disable-next-line camelcase
+      indent_size: 2
+    } ) )
+    .pipe( gulp.dest( './tmp' ) );
+}
+
+gulp.task( 'copy:components:boilerplate', copyComponentsBoilerplate );
+gulp.task( 'copy:components:source', copyComponentsSource );
+gulp.task( 'copy:components:manifest', copyComponentsManifest );

--- a/scripts/gulp/default.js
+++ b/scripts/gulp/default.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const gulp = require( 'gulp' );
 const runSequence = require( 'run-sequence' );
 

--- a/scripts/gulp/lint.js
+++ b/scripts/gulp/lint.js
@@ -25,9 +25,9 @@ function _genericLintJs( src ) {
 function lintBuild() {
   return _genericLintJs( [
     'gulpfile.js',
-    'gulp/**/*.js'
+    'scripts/gulp/**/*.js'
   ] );
-};
+}
 
 /**
  * Lints the test js files for errors.
@@ -38,7 +38,7 @@ function lintTests() {
     'test/accessibility/*.js',
     'test/*.js'
   ] );
-};
+}
 
 /**
  * Lints the source js files for errors.
@@ -46,7 +46,7 @@ function lintTests() {
  */
 function lintScripts() {
   return _genericLintJs( [ 'src/**/src/*.js' ] );
-};
+}
 
 /**
  * Lints the release js for errors.
@@ -57,21 +57,21 @@ function lintRelease() {
   return _genericLintJs( [
     'scripts/npm/prepublish/**/*.js'
   ] );
-};
+}
 
 
 /**
  * Lints the source LESS files for errors.
  * @returns {Object} An output stream from gulp.
  */
-function lintStyles(){
-  return gulp.src( ['!src/cf-grid/src-generated/*.less', 'src/**/*.less'] )
+function lintStyles() {
+  return gulp.src( [ '!src/cf-grid/src-generated/*.less', 'src/**/*.less' ] )
     .pipe( gulpStylelint( {
       reporters: [
         { formatter: 'string', console: true }
       ]
     } ) );
-};
+}
 
 gulp.task( 'lint:build', lintBuild );
 gulp.task( 'lint:tests', lintTests );

--- a/scripts/gulp/lint.js
+++ b/scripts/gulp/lint.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const gulp = require( 'gulp' );
 const gulpEslint = require( 'gulp-eslint' );
 const gulpStylelint = require( 'gulp-stylelint' );
@@ -22,53 +20,64 @@ function _genericLintJs( src ) {
 
 /**
  * Lints the gulpfile for errors.
+ * @returns {Object} An output stream from gulp.
  */
-gulp.task( 'lint:build', () => {
-  _genericLintJs( [
+function lintBuild() {
+  return _genericLintJs( [
     'gulpfile.js',
     'gulp/**/*.js'
   ] );
-} );
+};
 
 /**
  * Lints the test js files for errors.
+ * @returns {Object} An output stream from gulp.
  */
-gulp.task( 'lint:tests', () => {
-  _genericLintJs( [
+function lintTests() {
+  return _genericLintJs( [
     'test/accessibility/*.js',
     'test/*.js'
   ] );
-} );
+};
 
 /**
  * Lints the source js files for errors.
+ * @returns {Object} An output stream from gulp.
  */
-gulp.task( 'lint:scripts', () => {
-  _genericLintJs( [ 'src/**/src/*.js' ] );
-} );
+function lintScripts() {
+  return _genericLintJs( [ 'src/**/src/*.js' ] );
+};
+
+/**
+ * Lints the release js for errors.
+ * TODO: After release files are tested, combine this task with the build one
+ * @returns {Object} An output stream from gulp.
+ */
+function lintRelease() {
+  return _genericLintJs( [
+    'scripts/npm/prepublish/**/*.js'
+  ] );
+};
+
 
 /**
  * Lints the source LESS files for errors.
+ * @returns {Object} An output stream from gulp.
  */
-gulp.task( 'lint:styles', () => {
-  return gulp
-    .src( ['!src/cf-grid/src-generated/*.less', 'src/**/*.less'] )
+function lintStyles(){
+  return gulp.src( ['!src/cf-grid/src-generated/*.less', 'src/**/*.less'] )
     .pipe( gulpStylelint( {
       reporters: [
         { formatter: 'string', console: true }
       ]
     } ) );
-} );
+};
 
-/**
- * Lints the release js for errors.
- * TODO: After release files are tested, combine this task with the build one
- */
-gulp.task( 'lint:release', () => {
-  _genericLintJs( [
-    'scripts/npm/prepublish/**/*.js'
-  ] );
-} );
+gulp.task( 'lint:build', lintBuild );
+gulp.task( 'lint:tests', lintTests );
+gulp.task( 'lint:scripts', lintScripts );
+gulp.task( 'lint:release', lintRelease );
+gulp.task( 'lint:styles', lintStyles );
 
 /**
  * Lints all the js files for errors
@@ -77,6 +86,6 @@ gulp.task( 'lint', [
   'lint:build',
   'lint:tests',
   'lint:scripts',
-  'lint:styles',
-  'lint:release'
+  'lint:release',
+  'lint:styles'
 ] );

--- a/scripts/gulp/parseComponentName.js
+++ b/scripts/gulp/parseComponentName.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const minimalist = require( 'minimist' );
 const argv = minimalist( process.argv.slice( 2 ) );
 const component = argv.component || argv.c;

--- a/scripts/gulp/scripts.js
+++ b/scripts/gulp/scripts.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const BROWSER_LIST = require( '../../config/browser-list-config' );
 const component = require( './parseComponentName' );
 const gulp = require( 'gulp' );
@@ -10,8 +8,8 @@ const webpackStream = require( 'webpack-stream' );
 const UglifyWebpackPlugin = require( 'uglifyjs-webpack-plugin' );
 const vinylNamed = require( 'vinyl-named' );
 
- // Set warnings to true to show linter-style warnings.
- // Set mangle to false and beautify to true to debug the output code.
+/* Set warnings to true to show linter-style warnings.
+   Set mangle to false and beautify to true to debug the output code. */
 const COMMON_UGLIFY_CONFIG = new UglifyWebpackPlugin( {
   parallel: true,
   uglifyOptions: {
@@ -26,54 +24,53 @@ const COMMON_UGLIFY_CONFIG = new UglifyWebpackPlugin( {
   }
 } );
 
-// TODO: Add a webpack-config file to handle sharing of redundant webpack
-//       configurations. Also, add a production and dev flag to generate
-//       a minified and un-minified version of the assets.
+/* TODO: Add a webpack-config file to handle sharing of redundant webpack
+   configurations. Also, add a production and dev flag to generate
+   a minified and un-minified version of the assets. */
 
 // Compile the master capital-framework.less file.
-gulp.task( 'scripts:cf', () => {
-  return gulp.src('./src/capital-framework.js')
-    .pipe( webpackStream( {
-      module: {
-        rules: [ {
-          use: [ {
-            loader: 'babel-loader?cacheDirectory=true',
-            options: {
-              presets: [ [ 'env', {
-                targets: {
-                  browsers: BROWSER_LIST.LAST_2_PLUS_IE_9_AND_UP
-                },
-                debug: true
-              } ] ]
-            }
-          } ]
+gulp.task( 'scripts:cf', () => gulp.src( './src/capital-framework.js' )
+  .pipe( webpackStream( {
+    module: {
+      rules: [ {
+        use: [ {
+          loader: 'babel-loader?cacheDirectory=true',
+          options: {
+            presets: [ [ 'env', {
+              targets: {
+                browsers: BROWSER_LIST.LAST_2_PLUS_IE_9_AND_UP
+              },
+              debug: true
+            } ] ]
+          }
         } ]
-      },
-      output: {
-        filename: '[name].js'
-      },
-      plugins: [ COMMON_UGLIFY_CONFIG ]
-    }, webpack ) )
-    .pipe(gulpRename({
-      basename: 'capital-framework',
-      extname: '.min.js'
-    } ) )
-    .pipe( gulp.dest( './dist' ) );
-} );
+      } ]
+    },
+    output: {
+      filename: '[name].js'
+    },
+    plugins: [ COMMON_UGLIFY_CONFIG ]
+  }, webpack ) )
+  .pipe( gulpRename( {
+    basename: 'capital-framework',
+    extname: '.min.js'
+  } ) )
+  .pipe( gulp.dest( './dist' ) ) );
 
-// Compile all the individual component files so that users can `npm install`
-// a single component if they desire.
+/* Compile all the individual component files so that users can `npm install`
+   a single component if they desire. */
 gulp.task( 'scripts:components', () => {
-  let tmp = {};
-  return gulp.src( './src/' + (component || '*') + '/src/*.js' )
-    .pipe(gulpIgnore.exclude( (vf) => {
-      // Exclude JS files that don't share the same name as the directory
-      // they're in. This filters out utility files.
-      var matches = vf.path.match( /\/([\w-]*)\/src\/([\w-]*)\.js/ );
+  const tmp = {};
+  return gulp.src( './src/' + ( component || '*' ) + '/src/*.js' )
+    .pipe( gulpIgnore.exclude( vf => {
+
+      /* Exclude JS files that don't share the same name as the directory
+         they're in. This filters out utility files. */
+      const matches = vf.path.match( /\/([\w-]*)\/src\/([\w-]*)\.js/ );
       return matches[1] !== matches[2];
     } ) )
-    .pipe(vinylNamed())
-    .pipe(gulpRename( path => {
+    .pipe( vinylNamed() )
+    .pipe( gulpRename( path => {
       tmp[path.basename] = path;
     } ) )
     .pipe( webpackStream( {

--- a/scripts/gulp/styles.js
+++ b/scripts/gulp/styles.js
@@ -1,8 +1,6 @@
-'use strict';
-
 const BROWSER_LIST = require( '../../config/browser-list-config' );
-const component = require('./parseComponentName');
-const gulp = require('gulp');
+const component = require( './parseComponentName' );
+const gulp = require( 'gulp' );
 const gulpAutoprefixer = require( 'gulp-autoprefixer' );
 const gulpCssmin = require( 'gulp-cssmin' );
 const gulpIgnore = require( 'gulp-ignore' );
@@ -14,19 +12,19 @@ const gulpRename = require( 'gulp-rename' );
  * @returns {PassThrough} A source stream.
  */
 function stylesCf() {
-  return gulp.src('./src/capital-framework-with-grid.less')
-    .pipe(gulpLess({
-      paths: ['node_modules/cf-*/src/']
-    }))
+  return gulp.src( './src/capital-framework-with-grid.less' )
+    .pipe( gulpLess( {
+      paths: [ 'node_modules/cf-*/src/' ]
+    } ) )
     .pipe( gulpAutoprefixer( {
       browsers: BROWSER_LIST.LAST_2_PLUS_IE_8_AND_UP
     } ) )
-    .pipe(gulpCssmin())
-    .pipe(gulpRename({
+    .pipe( gulpCssmin() )
+    .pipe( gulpRename( {
       basename: 'capital-framework',
       extname: '.min.css'
-    }))
-    .pipe(gulp.dest('./dist'))
+    } ) )
+    .pipe( gulp.dest( './dist' ) );
 }
 
 /**
@@ -35,28 +33,29 @@ function stylesCf() {
  * @returns {PassThrough} A source stream.
  */
 function stylesComponents() {
-  return gulp.src('./src/' + (component || '*') + '/src/*.less')
-    .pipe(gulpIgnore.exclude( (vf) => {
-      // Exclude Less files that don't share the same name as the directory
-      // they're in. This filters out things like cf-vars.less but still
-      // includes cf-core.less.
-      var matches = vf.path.match(/\/([\w-]*)\/src\/([\w-]*)\.less/);
+  return gulp.src( './src/' + ( component || '*' ) + '/src/*.less' )
+    .pipe( gulpIgnore.exclude( vf => {
+
+      /* Exclude Less files that don't share the same name as the directory
+         they're in. This filters out things like cf-vars.less but still
+         includes cf-core.less. */
+      const matches = vf.path.match( /\/([\w-]*)\/src\/([\w-]*)\.less/ );
       // We also exclude cf-grid. It needs its own special task. See below.
       return matches[2] === 'cf-grid' || matches[1] !== matches[2];
-    } ))
-    .pipe( gulpLess({
-      paths: ['node_modules/cf-*/src/']
-    }))
+    } ) )
+    .pipe( gulpLess( {
+      paths: [ 'node_modules/cf-*/src/' ]
+    } ) )
     .pipe( gulpAutoprefixer( {
       browsers: BROWSER_LIST.LAST_2_PLUS_IE_8_AND_UP
     } ) )
-    .pipe(gulpCssmin())
-    .pipe(gulpRename( (path) => {
+    .pipe( gulpCssmin() )
+    .pipe( gulpRename( path => {
       path.dirname = component || path.dirname;
-      path.dirname = path.dirname.replace('/src','');
+      path.dirname = path.dirname.replace( '/src', '' );
       path.extname = '.min.css';
-    } ))
-    .pipe(gulp.dest('./tmp'))
+    } ) )
+    .pipe( gulp.dest( './tmp' ) );
 }
 
 /**
@@ -64,19 +63,19 @@ function stylesComponents() {
  * @returns {PassThrough} A source stream.
  */
 function stylesGrid() {
-  return gulp.src('./src/cf-grid/src-generated/*.less')
-    .pipe(gulpLess({
-      paths: ['node_modules/cf-*/src/']
-    }))
+  return gulp.src( './src/cf-grid/src-generated/*.less' )
+    .pipe( gulpLess( {
+      paths: [ 'node_modules/cf-*/src/' ]
+    } ) )
     .pipe( gulpAutoprefixer( {
       browsers: BROWSER_LIST.LAST_2_PLUS_IE_8_AND_UP
     } ) )
-    .pipe(gulpCssmin())
-    .pipe(gulpRename({
+    .pipe( gulpCssmin() )
+    .pipe( gulpRename( {
       basename: 'cf-grid',
       extname: '.min.css'
-    }))
-    .pipe(gulp.dest('./tmp/cf-grid'))
+    } ) )
+    .pipe( gulp.dest( './tmp/cf-grid' ) );
 }
 
 gulp.task( 'styles:cf', stylesCf );

--- a/scripts/gulp/template.js
+++ b/scripts/gulp/template.js
@@ -1,59 +1,68 @@
-'use strict';
-
-const component = require('./parseComponentName');
-const fs = require('fs');
+const parseComponentName = require( './parseComponentName' );
+const fs = require( 'fs' );
 const gulp = require( 'gulp' );
 const gulpApplyTemplate = require( 'gulp-apply-template' );
 const gulpData = require( 'gulp-data' );
 const gulpRename = require( 'gulp-rename' );
 const gulpMarkdown = require( 'gulp-markdown' );
 
-gulp.task('template:readmes', () => {
-  var pkgs = './src/' + (component || '*') + '/package.json';
-  return gulp.src(pkgs)
-    .pipe(gulpData(function(file) {
-      const content = String(file.contents);
-      return JSON.parse(content);
-    }))
-    .pipe(gulpApplyTemplate({
+/**
+ * Copy a readme template into tmp/cf-* by replacing the name variable
+ * with the component's name.
+ * @returns {Object} An output stream from gulp.
+ */
+function templateReadmes() {
+  const pkgs = './src/' + ( parseComponentName || '*' ) + '/package.json';
+  return gulp.src( pkgs )
+    .pipe( gulpData( function( file ) {
+      const content = String( file.contents );
+      return JSON.parse( content );
+    } ) )
+    .pipe( gulpApplyTemplate( {
       engine: 'lodash',
       template: './scripts/templates/README.md.tmpl',
-      props: ['contents', 'data'],
-      context: (file) => {
-        return file.data;
-      }
-    }))
-    .pipe(gulpRename( (path) => {
-      path.dirname = component || path.dirname;
+      props: [ 'contents', 'data' ],
+      context: file => file.data
+    } ) )
+    .pipe( gulpRename( path => {
+      path.dirname = parseComponentName || path.dirname;
       path.basename = 'README';
       path.extname = '.md';
-    } ))
-    .pipe(gulp.dest('tmp'));
-} );
+    } ) )
+    .pipe( gulp.dest( 'tmp' ) );
+}
 
-gulp.task('template:usage', () => {
-  return gulp.src('./src/' + (component || '*') + '/usage.md')
-    .pipe(gulpMarkdown())
-    .pipe(gulpData( (file) => {
-      const content = String(file.contents);
-      let component = file.path.split('/');
+/**
+ * Copy the files that are the same for every component into tmp/cf-*.
+ * @returns {Object} An output stream from gulp.
+ */
+function templateUsage() {
+  return gulp.src( './src/' + ( parseComponentName || '*' ) + '/usage.md' )
+    .pipe( gulpMarkdown() )
+    .pipe( gulpData( file => {
+      const content = String( file.contents );
+      let component = file.path.split( '/' );
       component = component[component.length - 2];
       return {
         name: component,
         body: content,
-        hasJS: fs.existsSync('./src/' + component + '/src/' + component + '.js')
+        // eslint-disable-next-line no-sync
+        hasJS: fs.existsSync( './src/' + component + '/src/' + component + '.js' )
       };
-    } ))
-    .pipe(gulpApplyTemplate({
+    } ) )
+    .pipe( gulpApplyTemplate( {
       engine: 'lodash',
       template: './scripts/templates/preview.html.tmpl',
-      props: ['contents', 'data'],
-      context: function (file) {
+      props: [ 'contents', 'data' ],
+      context: function( file ) {
         return file.data;
       }
-    }))
-    .pipe(gulpRename( (path) => {
-      path.dirname = component || path.dirname;
-    } ))
-    .pipe(gulp.dest('tmp'));
-} );
+    } ) )
+    .pipe( gulpRename( path => {
+      path.dirname = parseComponentName || path.dirname;
+    } ) )
+    .pipe( gulp.dest( 'tmp' ) );
+}
+
+gulp.task( 'template:readmes', templateReadmes );
+gulp.task( 'template:usage', templateUsage );

--- a/scripts/gulp/test.js
+++ b/scripts/gulp/test.js
@@ -1,10 +1,8 @@
-'use strict';
+const component = require( './parseComponentName' );
+const gulp = require( 'gulp' );
+const gulpQunit = require( 'gulp-qunit' );
 
-const component = require('./parseComponentName');
-const gulp = require('gulp');
-const gulpQunit = require('gulp-qunit');
-
-//const configTest = require( '../config' ).tests;
+// const configTest = require( '../config' ).tests;
 const gulpIstanbul = require( 'gulp-istanbul' );
 const gulpMocha = require( 'gulp-mocha' );
 
@@ -13,30 +11,28 @@ const gulpMocha = require( 'gulp-mocha' );
  * @param {Function} cb - Callback function to call on completion.
  */
 function unitTest( cb ) {
-  gulp.src( ['./src/**/*.js',
-             '!./src/**/node_modules/**/*.js',
-             '!./src/**/src/cf-*',
-             '!./src/capital-framework.js'] )
-  .pipe( gulpIstanbul( {
-    includeUntested: true
-  } ) )
-  .pipe( gulpIstanbul.hookRequire() )
-  .on( 'finish', () => {
-    gulp.src( 'test/unit-test/**/*.js' )
-    .pipe( gulpMocha( {
-      reporter: 'nyan'
+  gulp.src( [ './src/**/*.js',
+    '!./src/**/node_modules/**/*.js',
+    '!./src/**/src/cf-*',
+    '!./src/capital-framework.js' ] )
+    .pipe( gulpIstanbul( {
+      includeUntested: true
     } ) )
-    .pipe( gulpIstanbul.writeReports( {
-      dir: 'test/unit-test-coverage'
-    } ) )
-    .on( 'end', cb );
-  } );
+    .pipe( gulpIstanbul.hookRequire() )
+    .on( 'finish', () => {
+      gulp.src( 'test/unit-test/**/*.js' )
+        .pipe( gulpMocha( {
+          reporter: 'nyan'
+        } ) )
+        .pipe( gulpIstanbul.writeReports( {
+          dir: 'test/unit-test-coverage'
+        } ) )
+        .on( 'end', cb );
+    } );
 }
 
 // TODO: Add test commands to repo documentation.
 gulp.task( 'test:unit', unitTest );
 
-gulp.task( 'test', () => {
-  return gulp.src( './test/' + ( component || '*' ) + '.html' )
-  	.pipe( gulpQunit( { timeout: 20 } ) );
-} );
+gulp.task( 'test', () => gulp.src( './test/' + ( component || '*' ) + '.html' )
+  .pipe( gulpQunit( { timeout: 20 } ) ) );

--- a/scripts/npm/prepublish/lib/build.js
+++ b/scripts/npm/prepublish/lib/build.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var exec = require( 'child-process-promise' ).exec;
+const exec = require( 'child-process-promise' ).exec;
 
 function build( component ) {
   if ( component ) {

--- a/scripts/npm/prepublish/lib/changelog.js
+++ b/scripts/npm/prepublish/lib/changelog.js
@@ -1,20 +1,21 @@
 'use script';
 
-var fs = require( 'fs' );
-var path = require( 'path' );
-var promisify = require( 'promisify-node' );
+const fs = require( 'fs' );
+const path = require( 'path' );
+const promisify = require( 'promisify-node' );
 
 promisify( fs.writeFile );
 
 function updateChangelog( version ) {
-  var file = path.join( __dirname, '..', '..', '..', '..', 'CHANGELOG.md' );
-  var date = new Date().toJSON().slice( 0, 10 );
-  var latest = '## Unreleased\n\n### Added\n- \n\n### Changed\n- ' +
+  const file = path.join( __dirname, '..', '..', '..', '..', 'CHANGELOG.md' );
+  const date = new Date().toJSON().slice( 0, 10 );
+  const latest = '## Unreleased\n\n### Added\n- \n\n### Changed\n- ' +
                '\n\n### Removed\n- \n\n## ' + version + ' - ' + date;
-  var changelog = fs.readFileSync( file, 'utf8' );
+  // eslint-disable-next-line no-sync
+  let changelog = fs.readFileSync( file, 'utf8' );
 
   changelog = changelog.replace( /## Unreleased/g, latest );
-  return fs.writeFile( file, changelog, 'utf8', function() { return; } );
+  return fs.writeFile( file, changelog, 'utf8', function() { } );
 }
 
 module.exports = updateChangelog;

--- a/scripts/npm/prepublish/lib/checkNpmAuth.js
+++ b/scripts/npm/prepublish/lib/checkNpmAuth.js
@@ -1,24 +1,22 @@
-'use strict';
-
-var RegClient = require( 'silent-npm-registry-client' );
-var client = new RegClient();
-var promisify = require( 'promisify-node' );
-var exec = require( 'child-process-promise' ).exec;
-var printLn = require( './print' );
+const RegClient = require( 'silent-npm-registry-client' );
+const client = new RegClient();
+const promisify = require( 'promisify-node' );
+const exec = require( 'child-process-promise' ).exec;
+const printLn = require( './print' );
 
 promisify( client );
 
 function checkAuth( component ) {
-  var uri = 'https://registry.npmjs.org/' + component;
+  const uri = 'https://registry.npmjs.org/' + component;
 
-  var getOwners = client.get( uri, { timeout: 10000 } ).then( function( data ) {
+  const getOwners = client.get( uri, { timeout: 10000 } ).then( function( data ) {
     return data.maintainers;
   } );
-  var getCurrentUser = exec( 'npm whoami' );
+  const getCurrentUser = exec( 'npm whoami' );
 
   return Promise.all( [ getOwners, getCurrentUser ] ).then( function( data ) {
-    var authorized = false;
-    var currentUser = data[1].stdout.trim();
+    let authorized = false;
+    const currentUser = data[1].stdout.trim();
 
     printLn.info( 'Logged into npm as ' + currentUser );
     data[0].forEach( function( maintainer ) {
@@ -31,7 +29,7 @@ function checkAuth( component ) {
       );
       process.exit( 1 );
     }
-  } )['catch']( function( err ) {
+  } ).catch( function( err ) {
     if ( /ENEEDAUTH/.test( err ) ) {
       printLn.error(
         'You\'re not logged into npm. You need to authorize ' +

--- a/scripts/npm/prepublish/lib/commit.js
+++ b/scripts/npm/prepublish/lib/commit.js
@@ -1,9 +1,7 @@
-'use strict';
-
-var exec = require( 'child-process-promise' ).exec;
+const exec = require( 'child-process-promise' ).exec;
 
 function commit( version ) {
-  var msg = version || 'Auto-incrementing version';
+  const msg = version || 'Auto-incrementing version';
   return exec( 'git commit -am "' + msg + '"' );
 }
 

--- a/scripts/npm/prepublish/lib/confirm.js
+++ b/scripts/npm/prepublish/lib/confirm.js
@@ -1,23 +1,22 @@
-'use strict';
-
-var Promise = require( 'bluebird' );
-var readline = require( 'readline' );
-var options = require( './getArgs' );
-var printLn = require( './print' );
+const Promise = require( 'bluebird' );
+const readline = require( 'readline' );
+const options = require( './getArgs' );
+const printLn = require( './print' );
 
 function confirm( opts ) {
   opts = opts || {};
-  var prompt = opts.prompt + ' [Y/n] ';
+  const prompt = opts.prompt + ' [Y/n] ';
   return new Promise( function( resolve, reject ) {
-    // If the silent or dryrun option is passed or we're in a CI,
-    // don't prompt the user.
+
+    /* If the silent or dryrun option is passed or we're in a CI,
+       don't prompt the user. */
     if ( options.silent ||
          options.dryrun ||
          process.env.CONTINUOUS_INTEGRATION
     ) {
       return resolve( opts.data );
     }
-    var rl = readline.createInterface( {
+    const rl = readline.createInterface( {
       input:  process.stdin,
       output: process.stdout
     } );

--- a/scripts/npm/prepublish/lib/getArgs.js
+++ b/scripts/npm/prepublish/lib/getArgs.js
@@ -1,10 +1,8 @@
-'use strict';
-
-var argv = require( 'minimist' )( process.argv.slice( 2 ) );
+const argv = require( 'minimist' )( process.argv.slice( 2 ) );
 
 module.exports = {
   component: argv.component,
-  silent: 	 argv.s || argv.silent,
-  dryrun: 	 argv.dryrun,
-  force: 	 argv.f || argv.force
+  silent:    argv.s || argv.silent,
+  dryrun:    argv.dryrun,
+  force:     argv.f || argv.force
 };

--- a/scripts/npm/prepublish/lib/getNpmVersion.js
+++ b/scripts/npm/prepublish/lib/getNpmVersion.js
@@ -1,13 +1,11 @@
-'use strict';
-
-var RegClient = require( 'silent-npm-registry-client' );
-var client = new RegClient();
-var promisify = require( 'promisify-node' );
+const RegClient = require( 'silent-npm-registry-client' );
+const client = new RegClient();
+const promisify = require( 'promisify-node' );
 
 promisify( client );
 
 function getVersion( component ) {
-  var uri = 'https://registry.npmjs.org/' + component;
+  const uri = 'https://registry.npmjs.org/' + component;
   return client.get( uri, { timeout: 1000 } );
 }
 

--- a/scripts/npm/prepublish/lib/git.js
+++ b/scripts/npm/prepublish/lib/git.js
@@ -1,8 +1,6 @@
-'use strict';
+const exec = require( 'child-process-promise' ).exec;
 
-var exec = require( 'child-process-promise' ).exec;
-
-var git = {
+const git = {
   checkoutMaster: function() {
     return exec( 'git checkout ' + process.env.GH_PROD_BRANCH );
   },
@@ -10,7 +8,7 @@ var git = {
     return exec( 'git rev-parse --abbrev-ref HEAD' );
   },
   commit: function( version ) {
-    var msg = version || 'Auto-incrementing version';
+    const msg = version || 'Auto-incrementing version';
     return exec( 'git commit -am "' + msg + '"' );
   },
   tag: function( version ) {

--- a/scripts/npm/prepublish/lib/gitStatus.js
+++ b/scripts/npm/prepublish/lib/gitStatus.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var exec = require( 'child-process-promise' ).exec;
+const exec = require( 'child-process-promise' ).exec;
 
 function status( path ) {
   return exec( 'git status -s ' + path );

--- a/scripts/npm/prepublish/lib/index.js
+++ b/scripts/npm/prepublish/lib/index.js
@@ -1,22 +1,30 @@
-'use strict';
-
-var fs = require( 'fs' );
+const build = require( './build' );
+const changelog = require( './changelog' );
+const checkNpmAuth = require( './checkNpmAuth' );
+const confirm = require( './confirm' );
+const fs = require( 'fs' );
+const getArgs = require( './getArgs' );
+const getNpmVersion = require( './getNpmVersion' );
+const git = require( './git' );
+const gitStatus = require( './gitStatus' );
+const print = require( './print' );
+const publish = require( './publish' );
 
 module.exports = {
-  printLn:       require( './print' ),
-  confirm:       require( './confirm' ),
-  getGitStatus:  require( './gitStatus' ),
-  build:         require( './build' ),
-  publish:       require( './publish' ),
-  git:           require( './git' ),
-  changelog:     require( './changelog' ),
-  getNpmVersion: require( './getNpmVersion' ),
-  checkNpmAuth:  require( './checkNpmAuth' ),
+  printLn:       print,
+  confirm:       confirm,
+  getGitStatus:  gitStatus,
+  build:         build,
+  publish:       publish,
+  git:           git,
+  changelog:     changelog,
+  getNpmVersion: getNpmVersion,
+  checkNpmAuth:  checkNpmAuth,
   pkg:           JSON.parse( fs.readFileSync( 'package.json', 'utf8' ) ),
-  option:        require( './getArgs' )
+  option:        getArgs
 };
 
-process.on( 'SIGINT', function() {
+process.on( 'SIGINT', () => {
   module.exports.printLn.error( 'OMG ABORT EVERYTHING.' );
   process.exit( 1 );
 } );

--- a/scripts/npm/prepublish/lib/print.js
+++ b/scripts/npm/prepublish/lib/print.js
@@ -1,9 +1,7 @@
-'use strict';
-
-var logSymbols = require( 'log-symbols' );
-var chalk = require( 'chalk' );
-var indentString = require( 'indent-string' );
-var options = require( './getArgs' );
+const logSymbols = require( 'log-symbols' );
+const chalk = require( 'chalk' );
+const indentString = require( 'indent-string' );
+const options = require( './getArgs' );
 
 function printMsg( type, msg, indent ) {
   return console.log(
@@ -11,7 +9,7 @@ function printMsg( type, msg, indent ) {
   );
 }
 
-var printLn = {};
+const printLn = {};
 
 [ 'success', 'warning', 'error', 'info' ].forEach( function( type ) {
   printLn[type] = function( msg, indent ) {
@@ -21,7 +19,7 @@ var printLn = {};
 
 printLn.console = function( msg ) {
   options.silent ? function() {} :
-  console.log( chalk.dim( indentString( msg, ' ', 8 ) ) );
+    console.log( chalk.dim( indentString( msg, ' ', 8 ) ) );
 };
 
 module.exports = printLn;

--- a/scripts/npm/prepublish/lib/publish.js
+++ b/scripts/npm/prepublish/lib/publish.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var exec = require( 'child-process-promise' ).exec;
+const exec = require( 'child-process-promise' ).exec;
 
 function publish( component ) {
   return exec( 'npm publish', {


### PR DESCRIPTION
## Changes

- Runs autolinting on release and build scripts.
- Restructures lint task to have defined methods for tasks.
- Fixes issue where build scripts weren't being linted because path was wrong.
- Replace `gulp-json-format` with `gulp-jsbeautifier`.
## Testing

- `npm install`
- `gulp lint:build && gulp lint:tests && gulp lint:scripts && gulp lint:release` should run and will have errors for the tests (which are deprecated) and for the release scripts, which will need to be incrementally updated in the future.

## Notes

- Spun out of https://github.com/cfpb/capital-framework/pull/724

  
  