### PR TITLE
Lint release scripts

### DIFF
--- a/scripts/npm/prepublish/lib/build.js
+++ b/scripts/npm/prepublish/lib/build.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var exec = require( 'child-process-promise' ).exec;
+const exec = require( 'child-process-promise' ).exec;
 
 function build( component ) {
   if ( component ) {

--- a/scripts/npm/prepublish/lib/changelog.js
+++ b/scripts/npm/prepublish/lib/changelog.js
@@ -1,20 +1,21 @@
 'use script';
 
-var fs = require( 'fs' );
-var path = require( 'path' );
-var promisify = require( 'promisify-node' );
+const fs = require( 'fs' );
+const path = require( 'path' );
+const promisify = require( 'promisify-node' );
 
 promisify( fs.writeFile );
 
 function updateChangelog( version ) {
-  var file = path.join( __dirname, '..', '..', '..', '..', 'CHANGELOG.md' );
-  var date = new Date().toJSON().slice( 0, 10 );
-  var latest = '## Unreleased\n\n### Added\n- \n\n### Changed\n- ' +
+  const file = path.join( __dirname, '..', '..', '..', '..', 'CHANGELOG.md' );
+  const date = new Date().toJSON().slice( 0, 10 );
+  const latest = '## Unreleased\n\n### Added\n- \n\n### Changed\n- ' +
                '\n\n### Removed\n- \n\n## ' + version + ' - ' + date;
-  var changelog = fs.readFileSync( file, 'utf8' );
+  // eslint-disable-next-line no-sync
+  let changelog = fs.readFileSync( file, 'utf8' );
 
   changelog = changelog.replace( /## Unreleased/g, latest );
-  return fs.writeFile( file, changelog, 'utf8', function() { return; } );
+  return fs.writeFile( file, changelog, 'utf8', function() { } );
 }
 
 module.exports = updateChangelog;

--- a/scripts/npm/prepublish/lib/checkNpmAuth.js
+++ b/scripts/npm/prepublish/lib/checkNpmAuth.js
@@ -1,24 +1,22 @@
-'use strict';
-
-var RegClient = require( 'silent-npm-registry-client' );
-var client = new RegClient();
-var promisify = require( 'promisify-node' );
-var exec = require( 'child-process-promise' ).exec;
-var printLn = require( './print' );
+const RegClient = require( 'silent-npm-registry-client' );
+const client = new RegClient();
+const promisify = require( 'promisify-node' );
+const exec = require( 'child-process-promise' ).exec;
+const printLn = require( './print' );
 
 promisify( client );
 
 function checkAuth( component ) {
-  var uri = 'https://registry.npmjs.org/' + component;
+  const uri = 'https://registry.npmjs.org/' + component;
 
-  var getOwners = client.get( uri, { timeout: 10000 } ).then( function( data ) {
+  const getOwners = client.get( uri, { timeout: 10000 } ).then( function( data ) {
     return data.maintainers;
   } );
-  var getCurrentUser = exec( 'npm whoami' );
+  const getCurrentUser = exec( 'npm whoami' );
 
   return Promise.all( [ getOwners, getCurrentUser ] ).then( function( data ) {
-    var authorized = false;
-    var currentUser = data[1].stdout.trim();
+    let authorized = false;
+    const currentUser = data[1].stdout.trim();
 
     printLn.info( 'Logged into npm as ' + currentUser );
     data[0].forEach( function( maintainer ) {
@@ -31,7 +29,7 @@ function checkAuth( component ) {
       );
       process.exit( 1 );
     }
-  } )['catch']( function( err ) {
+  } ).catch( function( err ) {
     if ( /ENEEDAUTH/.test( err ) ) {
       printLn.error(
         'You\'re not logged into npm. You need to authorize ' +

--- a/scripts/npm/prepublish/lib/commit.js
+++ b/scripts/npm/prepublish/lib/commit.js
@@ -1,9 +1,7 @@
-'use strict';
-
-var exec = require( 'child-process-promise' ).exec;
+const exec = require( 'child-process-promise' ).exec;
 
 function commit( version ) {
-  var msg = version || 'Auto-incrementing version';
+  const msg = version || 'Auto-incrementing version';
   return exec( 'git commit -am "' + msg + '"' );
 }
 

--- a/scripts/npm/prepublish/lib/confirm.js
+++ b/scripts/npm/prepublish/lib/confirm.js
@@ -1,23 +1,22 @@
-'use strict';
-
-var Promise = require( 'bluebird' );
-var readline = require( 'readline' );
-var options = require( './getArgs' );
-var printLn = require( './print' );
+const Promise = require( 'bluebird' );
+const readline = require( 'readline' );
+const options = require( './getArgs' );
+const printLn = require( './print' );
 
 function confirm( opts ) {
   opts = opts || {};
-  var prompt = opts.prompt + ' [Y/n] ';
+  const prompt = opts.prompt + ' [Y/n] ';
   return new Promise( function( resolve, reject ) {
-    // If the silent or dryrun option is passed or we're in a CI,
-    // don't prompt the user.
+
+    /* If the silent or dryrun option is passed or we're in a CI,
+       don't prompt the user. */
     if ( options.silent ||
          options.dryrun ||
          process.env.CONTINUOUS_INTEGRATION
     ) {
       return resolve( opts.data );
     }
-    var rl = readline.createInterface( {
+    const rl = readline.createInterface( {
       input:  process.stdin,
       output: process.stdout
     } );

--- a/scripts/npm/prepublish/lib/getArgs.js
+++ b/scripts/npm/prepublish/lib/getArgs.js
@@ -1,10 +1,8 @@
-'use strict';
-
-var argv = require( 'minimist' )( process.argv.slice( 2 ) );
+const argv = require( 'minimist' )( process.argv.slice( 2 ) );
 
 module.exports = {
   component: argv.component,
-  silent: 	 argv.s || argv.silent,
-  dryrun: 	 argv.dryrun,
-  force: 	 argv.f || argv.force
+  silent:    argv.s || argv.silent,
+  dryrun:    argv.dryrun,
+  force:     argv.f || argv.force
 };

--- a/scripts/npm/prepublish/lib/getNpmVersion.js
+++ b/scripts/npm/prepublish/lib/getNpmVersion.js
@@ -1,13 +1,11 @@
-'use strict';
-
-var RegClient = require( 'silent-npm-registry-client' );
-var client = new RegClient();
-var promisify = require( 'promisify-node' );
+const RegClient = require( 'silent-npm-registry-client' );
+const client = new RegClient();
+const promisify = require( 'promisify-node' );
 
 promisify( client );
 
 function getVersion( component ) {
-  var uri = 'https://registry.npmjs.org/' + component;
+  const uri = 'https://registry.npmjs.org/' + component;
   return client.get( uri, { timeout: 1000 } );
 }
 

--- a/scripts/npm/prepublish/lib/git.js
+++ b/scripts/npm/prepublish/lib/git.js
@@ -1,8 +1,6 @@
-'use strict';
+const exec = require( 'child-process-promise' ).exec;
 
-var exec = require( 'child-process-promise' ).exec;
-
-var git = {
+const git = {
   checkoutMaster: function() {
     return exec( 'git checkout ' + process.env.GH_PROD_BRANCH );
   },
@@ -10,7 +8,7 @@ var git = {
     return exec( 'git rev-parse --abbrev-ref HEAD' );
   },
   commit: function( version ) {
-    var msg = version || 'Auto-incrementing version';
+    const msg = version || 'Auto-incrementing version';
     return exec( 'git commit -am "' + msg + '"' );
   },
   tag: function( version ) {

--- a/scripts/npm/prepublish/lib/gitStatus.js
+++ b/scripts/npm/prepublish/lib/gitStatus.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var exec = require( 'child-process-promise' ).exec;
+const exec = require( 'child-process-promise' ).exec;
 
 function status( path ) {
   return exec( 'git status -s ' + path );

--- a/scripts/npm/prepublish/lib/index.js
+++ b/scripts/npm/prepublish/lib/index.js
@@ -1,22 +1,33 @@
-'use strict';
+const build = require( './build' );
+const changelog = require( './changelog' );
+const checkNpmAuth = require( './checkNpmAuth' );
+const confirm = require( './confirm' );
+const fs = require( 'fs' );
+const getArgs = require( './getArgs' );
+const getNpmVersion = require( './getNpmVersion' );
+const git = require( './git' );
+const gitStatus = require( './gitStatus' );
+const print = require( './print' );
+const publish = require( './publish' );
 
-var fs = require( 'fs' );
+// eslint-disable-next-line no-sync
+const pkg = JSON.parse( fs.readFileSync( 'package.json', 'utf8' ) );
 
 module.exports = {
-  printLn:       require( './print' ),
-  confirm:       require( './confirm' ),
-  getGitStatus:  require( './gitStatus' ),
-  build:         require( './build' ),
-  publish:       require( './publish' ),
-  git:           require( './git' ),
-  changelog:     require( './changelog' ),
-  getNpmVersion: require( './getNpmVersion' ),
-  checkNpmAuth:  require( './checkNpmAuth' ),
-  pkg:           JSON.parse( fs.readFileSync( 'package.json', 'utf8' ) ),
-  option:        require( './getArgs' )
+  printLn:       print,
+  confirm:       confirm,
+  getGitStatus:  gitStatus,
+  build:         build,
+  publish:       publish,
+  git:           git,
+  changelog:     changelog,
+  getNpmVersion: getNpmVersion,
+  checkNpmAuth:  checkNpmAuth,
+  pkg:           pkg,
+  option:        getArgs
 };
 
-process.on( 'SIGINT', function() {
+process.on( 'SIGINT', () => {
   module.exports.printLn.error( 'OMG ABORT EVERYTHING.' );
   process.exit( 1 );
 } );

--- a/scripts/npm/prepublish/lib/print.js
+++ b/scripts/npm/prepublish/lib/print.js
@@ -1,9 +1,7 @@
-'use strict';
-
-var logSymbols = require( 'log-symbols' );
-var chalk = require( 'chalk' );
-var indentString = require( 'indent-string' );
-var options = require( './getArgs' );
+const logSymbols = require( 'log-symbols' );
+const chalk = require( 'chalk' );
+const indentString = require( 'indent-string' );
+const options = require( './getArgs' );
 
 function printMsg( type, msg, indent ) {
   return console.log(
@@ -11,7 +9,7 @@ function printMsg( type, msg, indent ) {
   );
 }
 
-var printLn = {};
+const printLn = {};
 
 [ 'success', 'warning', 'error', 'info' ].forEach( function( type ) {
   printLn[type] = function( msg, indent ) {
@@ -21,7 +19,7 @@ var printLn = {};
 
 printLn.console = function( msg ) {
   options.silent ? function() {} :
-  console.log( chalk.dim( indentString( msg, ' ', 8 ) ) );
+    console.log( chalk.dim( indentString( msg, ' ', 8 ) ) );
 };
 
 module.exports = printLn;

--- a/scripts/npm/prepublish/lib/publish.js
+++ b/scripts/npm/prepublish/lib/publish.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var exec = require( 'child-process-promise' ).exec;
+const exec = require( 'child-process-promise' ).exec;
 
 function publish( component ) {
   return exec( 'npm publish', {


### PR DESCRIPTION
Run of `gulp lint:release --fix`

## Changes

- Autofixes linter errors.
- Manually remove tabs.
- Manually ignore some no-sync rule violations.

## Testing

- I guess we need a release to properly test these.

## Note

- Spun out of https://github.com/cfpb/capital-framework/pull/726