### PR TITLE
Add support for family-linked webfonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,22 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-typography:** [MINOR] New `@font-face` rules for family-linked webfonts
 
 ### Changed
 - **cf-forms:** [PATCH] Add transform to fix radio button Firefox rendering bug.
 - **cf-forms:** [MINOR] Add multi-line support to checkboxes/radio buttons.
 - **cf-forms:** [PATCH] Move autoprefixer ignored rule to its own block.
 - **capital-framework:** [MINOR] Update build process to use Gulp 4.
+- **cf-core:** [MINOR] Replace use of `u-webfont-` mixins with standard properties.
+- **cf-buttons:** [MINOR] Replace use of `u-webfont-` mixins with standard properties.
+- **cf-expandables:** [MINOR] Replace use of `u-webfont-` mixins with standard properties.
+- **cf-forms:** [MINOR] Replace use of `u-webfont-` mixins with standard properties.
+- **cf-layout:** [MINOR] Replace use of `u-webfont-` mixins with standard properties.
+- **cf-notifications:** [MINOR] Replace use of `u-webfont-` mixins with standard properties.
+- **cf-pagination:** [MINOR] Replace use of `u-webfont-` mixins with standard properties.
+- **cf-tables:** [MINOR] Replace use of `u-webfont-` mixins with standard properties.
+- **cf-typography:** [MINOR] Replace use of `u-webfont-` mixins with standard properties.
 
 ### Removed
 -

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "author": {
     "name": "Consumer Financial Protection Bureau",
     "email": "tech@cfpb.gov",
-    "url": "https://consumerfinance.gov"
+    "url": "https://cfpb.github.io/"
   },
-  "license": "CC0-1.0",
+  "license": "SEE LICENSE IN TERMS.md",
   "keywords": [
     "capital-framework"
   ],

--- a/src/cf-buttons/src/atoms/buttons.less
+++ b/src/cf-buttons/src/atoms/buttons.less
@@ -3,8 +3,6 @@
 //
 
 .a-btn {
-  .u-webfont-medium();
-
   appearance: none;
 
   display: inline-block;
@@ -19,6 +17,7 @@
   border-radius: unit( @btn-border-radius-size / @btn-font-size, em );
   cursor: pointer;
   font-size: unit( @btn-font-size / @base-font-size-px, em );
+  font-weight: 500;
   line-height: normal;
   text-align: center;
   text-decoration: none;

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -11,6 +11,8 @@
 // Projects should update themselves to use standard CSS font-style and
 // font-weight properties from now on.
 //
+// TODO: Remove in CFv5.
+//
 
 .u-webfont-regular() {
     font-family: @webfont-regular, Arial, sans-serif;

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -4,7 +4,12 @@
    ========================================================================== */
 
 //
-// Webfonts
+// Webfont mixins
+//
+// WARNING: These mixins are deprecated and will be removed in CFv5 due to
+// the implementation of family-linked webfonts in licensed-fonts.less.
+// Projects should update themselves to use standard CSS font-style and
+// font-weight properties from now on.
 //
 
 .u-webfont-regular() {
@@ -58,55 +63,63 @@
 //
 
 body {
-    .u-webfont-regular();
-
     color: @text;
+    font-family: 'Avenir Next', Arial, sans-serif;
     font-size: unit( @base-font-size-px / 16 * 100, % );
     line-height: @base-line-height;
 }
 
+button,
+input,
+select,
+textarea {
+    // Must set these explicitly to override Normalize.css's provided default:
+    // font-family: sans-serif;
+    font-family: 'Avenir Next', Arial, sans-serif;
+}
+
 .heading-1( @fs: @size-i ) {
     @font-size: @fs;
-    .u-webfont-regular();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
+    font-weight: normal;
     line-height: 1.25;
 }
 
 .heading-2( @fs: @size-ii ) {
     @font-size: @fs;
-    .u-webfont-regular();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
+    font-weight: normal;
     line-height: 1.25;
 }
 
 .heading-3( @fs: @size-iii )  {
     @font-size: @fs;
-    .u-webfont-regular();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
+    font-weight: normal;
     line-height: 1.25;
 }
 
 .heading-4( @fs: @size-iv )  {
     @font-size: @fs;
-    .u-webfont-medium();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
+    font-weight: 500;
     line-height: 1.25;
 }
 
 .heading-5( @fs: @size-v )  {
     @font-size: @fs;
-    .u-webfont-demi();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
+    font-weight: bold;
     letter-spacing: 1px;
     line-height: 1.25;
     text-transform: uppercase;
@@ -114,10 +127,10 @@ body {
 
 .heading-6( @fs: @size-vi )  {
     @font-size: @fs;
-    .u-webfont-demi();
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
+    font-weight: bold;
     letter-spacing: 1px;
     line-height: 1.25;
     text-transform: uppercase;
@@ -345,10 +358,10 @@ h6,
 .superheading {
     // For when you want a heading that's bigger than a normal H1
     @font-size: @size-xl;
-    .u-webfont-regular();
 
     margin-bottom: unit( 20px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
+    font-weight: normal;
     line-height: 1.25;
 }
 
@@ -491,8 +504,7 @@ tbody tr {
 }
 
 th {
-    .u-webfont-demi();
-
+    font-weight: bold;
     text-align: left;
 }
 

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -75,8 +75,8 @@ button,
 input,
 select,
 textarea {
-    // Must set these explicitly to override Normalize.css's provided default:
-    // font-family: sans-serif;
+    // Must set these explicitly to override Normalize.css's provided default
+    // of `font-family: sans-serif;`
     font-family: 'Avenir Next', Arial, sans-serif;
 }
 

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -711,7 +711,7 @@ Sets the element to `14px` (in `em`s) based on the text size passed as
 #### :warning: These mixins are deprecated and will be removed in CFv5 :warning:
 
 Our
-[`@font-face` syntax](https://github.com/cfpb/capital-framework/blob/canary/src/cf-typography/src/licensed-fonts.less)
+[`@font-face` syntax](https://github.com/cfpb/capital-framework/blob/master/src/cf-typography/src/licensed-fonts.less)
 is transitioning to a family-linked model,
 which eliminates the need for these old mixins.
 Style and weight should now be set with the traditional CSS properties.

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -706,7 +706,17 @@ Sets the element to `14px` (in `em`s) based on the text size passed as
 
 ## Base typography
 
-### Webfonts
+### Webfont mixins
+
+#### :warning: These mixins are deprecated and will be removed in CFv5 :warning:
+
+Our
+[`@font-face` syntax](https://github.com/cfpb/capital-framework/blob/canary/src/cf-typography/src/licensed-fonts.less)
+is transitioning to a family-linked model,
+which eliminates the need for these old mixins.
+Style and weight should now be set with the traditional CSS properties.
+
+---
 
 Sets the font-stack, weight, and style of an element.
 

--- a/src/cf-expandables/src/cf-expandables.less
+++ b/src/cf-expandables/src/cf-expandables.less
@@ -102,12 +102,11 @@
 
     &_label {
         color: @expandable_label-text;
-        .u-webfont-medium();
+        font-weight: 500;
     }
 
     &_link {
         color: @expandable_link-text;
-        .u-webfont-regular();
         font-size: unit(@expandable_link-font-size / @base-font-size-px, em);
         line-height: unit(@base-line-height-px / @expandable_link-font-size);
     }

--- a/src/cf-forms/src/atoms/label.less
+++ b/src/cf-forms/src/atoms/label.less
@@ -2,7 +2,6 @@
     display: inline-block;
 
     &_helper {
-        .u-webfont-regular();
         color: @label-helper;
         font-size: unit( @size-v / @base-font-size-px, em );
 
@@ -24,6 +23,7 @@
 
         .a-label_helper {
             font-size: unit( @base-font-size-px / @font-size, em );
+            font-weight: normal;
 
             &__block {
                 // Add a gap between the label helper and label.

--- a/src/cf-forms/src/atoms/text-input.less
+++ b/src/cf-forms/src/atoms/text-input.less
@@ -1,6 +1,4 @@
 .a-text-input {
-    .u-webfont-regular();
-
     // Reset the browser's default styling.
     appearance: none;
 

--- a/src/cf-layout/src/molecules/heroes.less
+++ b/src/cf-layout/src/molecules/heroes.less
@@ -51,8 +51,6 @@
     &_subhead {
         // Not using the `.heading-3()` mixin here because we want the weight
         // to remain Regular on smaller screens.
-        .u-webfont-regular();
-
         font-size: @size-iii;
         line-height: 1.25;
 

--- a/src/cf-layout/src/organisms/featured-content-module.less
+++ b/src/cf-layout/src/organisms/featured-content-module.less
@@ -1,6 +1,5 @@
 .o-featured-content-module {
   .u-clearfix();
-  .u-webfont-regular();
 
   position: relative;
 

--- a/src/cf-notifications/src/molecules/notification.less
+++ b/src/cf-notifications/src/molecules/notification.less
@@ -74,8 +74,11 @@
    }
 
    &_explanation {
-       .u-webfont-regular();
        font-size: 1em;
+       // This is necessary because the standard markup pattern uses an h4
+       // class for, presumably, just sizing.
+       // TODO: Refactor standard markup pattern to stop using h4 classes.
+       font-weight: normal;
        margin-top: unit( 5px / @base-font-size-px, em );
        margin-bottom: 0;
 

--- a/src/cf-pagination/src/molecules/pagination.less
+++ b/src/cf-pagination/src/molecules/pagination.less
@@ -14,8 +14,6 @@
     }
 
     &_current-page {
-        .u-webfont-medium();
-
         // 45px is a magic number to provide enough room for three digits
         // and the number spinners for type="number" inputs on desktop
         width: unit( 45px / @base-font-size-px, em );
@@ -24,6 +22,7 @@
         margin-right: unit( 10px / @base-font-size-px, em );
         margin-left: unit( 10px / @base-font-size-px, em );
 
+        font-weight: 500;
         text-align: right;
     }
 

--- a/src/cf-tables/src/cf-tables.less
+++ b/src/cf-tables/src/cf-tables.less
@@ -142,12 +142,12 @@
         }
 
         td[data-label]:before {
-            .u-webfont-demi();
             display: block;
             margin-top: 0;
             margin-bottom: .41666667em;
             content: attr(data-label);
             font-size: .875em;
+            font-weight: bold;
             line-height: 1.83333333;
             text-transform: uppercase;
         }

--- a/src/cf-typography/src/atoms/links.less
+++ b/src/cf-typography/src/atoms/links.less
@@ -28,7 +28,7 @@
 //
 
 .a-link__jump {
-    .u-webfont-medium();
+    font-weight: 500;
 
     &.a-link__large {
         font-size: unit( @size-iv / @base-font-size-px, em );

--- a/src/cf-typography/src/licensed-fonts.less
+++ b/src/cf-typography/src/licensed-fonts.less
@@ -10,7 +10,7 @@
              url( '//fast.fonts.net/dv2/3/1e9892c0-6927-4412-9874-1b82801ba47a.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
         font-style: normal;
         font-weight: normal;
-        font-display: fallback
+        font-display: fallback;
     }
     @font-face {
         font-family: 'AvenirNextLTW01-Medium';
@@ -18,7 +18,7 @@
              url( '//fast.fonts.net/dv2/3/f26faddb-86cc-4477-a253-1e1287684336.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
         font-style: normal;
         font-weight: 500;
-        font-display: fallback
+        font-display: fallback;
     }
     @font-face {
         font-family: 'AvenirNextLTW01-Demi';
@@ -26,7 +26,31 @@
              url( '//fast.fonts.net/dv2/3/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
         font-style: normal;
         font-weight: 700;
-        font-display: fallback
+        font-display: fallback;
+    }
+    @font-face {
+        font-family: 'Avenir Next';
+        src: url( '//fast.fonts.net/dv2/14/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
+             url( '//fast.fonts.net/dv2/3/1e9892c0-6927-4412-9874-1b82801ba47a.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
+        font-style: normal;
+        font-weight: normal;
+        font-display: fallback;
+    }
+    @font-face {
+        font-family: 'Avenir Next';
+        src: url( '//fast.fonts.net/dv2/14/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
+             url( '//fast.fonts.net/dv2/3/f26faddb-86cc-4477-a253-1e1287684336.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
+        font-style: normal;
+        font-weight: 500;
+        font-display: fallback;
+    }
+    @font-face {
+        font-family: 'Avenir Next';
+        src: url( '//fast.fonts.net/dv2/14/aad99a1f-7917-4dd6-bbb5-b07cedbff64f.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
+             url( '//fast.fonts.net/dv2/3/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
+        font-style: normal;
+        font-weight: 700;
+        font-display: fallback;
     }
 }
 
@@ -49,6 +73,30 @@
     }
     @font-face {
         font-family: 'AvenirNextLTW01-Demi';
+        src: url( '@{cf-fonts-path}/aad99a1f-7917-4dd6-bbb5-b07cedbff64f.woff2' ) format( 'woff2' ),
+             url( '@{cf-fonts-path}/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff' ) format( 'woff' );
+        font-style: normal;
+        font-weight: 700;
+        font-display: fallback
+    }
+    @font-face {
+        font-family: 'Avenir Next';
+        src: url( '@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2' ) format( 'woff2' ),
+             url( '@{cf-fonts-path}/1e9892c0-6927-4412-9874-1b82801ba47a.woff' ) format( 'woff' );
+        font-style: normal;
+        font-weight: normal;
+        font-display: fallback
+    }
+    @font-face {
+        font-family: 'Avenir Next';
+        src: url( '@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2' ) format( 'woff2' ),
+             url( '@{cf-fonts-path}/f26faddb-86cc-4477-a253-1e1287684336.woff' ) format( 'woff' );
+        font-style: normal;
+        font-weight: 500;
+        font-display: fallback
+    }
+    @font-face {
+        font-family: 'Avenir Next';
         src: url( '@{cf-fonts-path}/aad99a1f-7917-4dd6-bbb5-b07cedbff64f.woff2' ) format( 'woff2' ),
              url( '@{cf-fonts-path}/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff' ) format( 'woff' );
         font-style: normal;

--- a/src/cf-typography/src/licensed-fonts.less
+++ b/src/cf-typography/src/licensed-fonts.less
@@ -25,7 +25,7 @@
         src: url( '//fast.fonts.net/dv2/14/aad99a1f-7917-4dd6-bbb5-b07cedbff64f.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
              url( '//fast.fonts.net/dv2/3/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
         font-style: normal;
-        font-weight: 700;
+        font-weight: bold;
         font-display: fallback;
     }
     @font-face {
@@ -45,11 +45,14 @@
         font-display: fallback;
     }
     @font-face {
+        // This actually loads the demibold weight (600) of Avenir Next
+        // and assigns it to the bold CSS weight, because we feel that
+        // Avenir Next Bold is too heavy.
         font-family: 'Avenir Next';
         src: url( '//fast.fonts.net/dv2/14/aad99a1f-7917-4dd6-bbb5-b07cedbff64f.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
              url( '//fast.fonts.net/dv2/3/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
         font-style: normal;
-        font-weight: 700;
+        font-weight: bold;
         font-display: fallback;
     }
 }
@@ -76,7 +79,7 @@
         src: url( '@{cf-fonts-path}/aad99a1f-7917-4dd6-bbb5-b07cedbff64f.woff2' ) format( 'woff2' ),
              url( '@{cf-fonts-path}/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff' ) format( 'woff' );
         font-style: normal;
-        font-weight: 700;
+        font-weight: bold;
         font-display: fallback
     }
     @font-face {
@@ -96,11 +99,14 @@
         font-display: fallback
     }
     @font-face {
+        // This actually loads the demibold weight (600) of Avenir Next
+        // and assigns it to the bold CSS weight, because we feel that
+        // Avenir Next Bold is too heavy.
         font-family: 'Avenir Next';
         src: url( '@{cf-fonts-path}/aad99a1f-7917-4dd6-bbb5-b07cedbff64f.woff2' ) format( 'woff2' ),
              url( '@{cf-fonts-path}/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff' ) format( 'woff' );
         font-style: normal;
-        font-weight: 700;
+        font-weight: bold;
         font-display: fallback
     }
 }


### PR DESCRIPTION
Step one in tackling #700. Step two will be removing the deprecated mixins in the CFv5 release.

## Additions

- New `@font-face` rules for family-linked webfonts

## Changes

- Replace use of `u-webfont-` mixins with standard properties in all CF components

## Testing

1. Pull branch
1. Run `gulp` to see successful build and tests
1. [Test with the docs site](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-in-the-documentation-site)
  - Note that you'll have to inspect something that isn't explicitly set to use one of the old mixins in the docs' Less, or wait to test with my corresponding docs PR that is forthcoming.

## Screenshots

![screen shot 2018-01-05 at 17 08 43](https://user-images.githubusercontent.com/1044670/34630660-21f75b10-f23b-11e7-9be2-a1f2dfbd4ec0.png)

## Notes

- I set these all as `[MINOR]`, since we're not deprecating the mixins until CFv5, however, it's a little fuzzy, since styles in CF components that previously relied on them could get faux italic or faux bold if a component is updated without _also_ updating cf-core and cf-typography. If folks strongly object to calling that a minor update, let me know. 

## Todos

- [x] Submit corresponding docs PR

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [x] Chrome
- [x] Safari
- [x] FF
- [ ] ~~IE~~ _Note: IE was unable to be tested because I couldn't get Fonts.com to serve the fonts to an IE VM. It always returns 403 Forbidden, even after adding the IP address to the whitelist. We'll test it live on the docs site._

  