### PR TITLE
Updated gulp-markdown to update marked package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2621,12 +2621,6 @@
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
-    "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-      "dev": true
-    },
     "domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
@@ -4705,6 +4699,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4713,14 +4715,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5849,13 +5843,13 @@
       }
     },
     "gulp-markdown": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gulp-markdown/-/gulp-markdown-1.2.0.tgz",
-      "integrity": "sha1-N83GE3n7A5hB+myrSYSo55Eop3I=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-markdown/-/gulp-markdown-2.0.1.tgz",
+      "integrity": "sha512-pZiJAchQwpb1grmbQ1naFHMYOFZBgNkcl4pO449dUVXt7IZA0jxD8dy5t7rvyjk6uF9QliLlZqXu97UWKY3HbQ==",
       "dev": true,
       "requires": {
-        "gulp-util": "3.0.8",
-        "marked": "0.3.9",
+        "marked": "0.3.12",
+        "plugin-error": "0.1.2",
         "through2": "2.0.3"
       }
     },
@@ -8130,9 +8124,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
-      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
       "dev": true
     },
     "matcher-collection": {
@@ -11629,6 +11623,12 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -11664,12 +11664,6 @@
           }
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "stringify-entities": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "gulp-istanbul": "^1.1.2",
     "gulp-jsbeautifier": "^2.1.2",
     "gulp-less": "^3.3.2",
-    "gulp-markdown": "^1.1.0",
+    "gulp-markdown": "^2.0.1",
     "gulp-mocha": "^3.0.1",
     "gulp-qunit": "^1.5.2",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
Marked had a security threat warning, updating `gulp-markdown` fixes it.

## Changes

- Updated `gulp-markdown` package

## Testing

- Run `npm install`
- Run `gulp template:usage` and ensure there are no changes

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] FF
- [ ] IE10
- [ ] IE9
- [ ] IE8
- [ ] Opera
- [ ] iOS
- [ ] Android
- [ ] Blackberry Bold

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
