### PR TITLE
Switch to testing each test in series instead of async

### DIFF
--- a/scripts/gulp/lint.js
+++ b/scripts/gulp/lint.js
@@ -68,7 +68,7 @@ function lintStyles() {
       reporters: [ { formatter: 'string', console: true } ]
     } ) )
     .pipe( gulp.dest( 'src' ) );
-};
+}
 
 gulp.task( 'lint:build', lintBuild );
 gulp.task( 'lint:tests', lintTests );

--- a/scripts/gulp/test.js
+++ b/scripts/gulp/test.js
@@ -7,17 +7,19 @@ const gulpMocha = require( 'gulp-mocha' );
 
 /**
  * Test the JS components with qUnit
+ * @param {Function} cb - Callback function to call on completion
  */
-function qunitTest() {
+function testQUnit( cb ) {
   gulp.src( './test/' + ( component || '*' ) + '.html' )
-    .pipe( gulpQunit( { timeout: 20 } ) );
+    .pipe( gulpQunit( { timeout: 20 } ) )
+    .on( 'finish', cb );
 }
 
 /**
  * Run Mocha JavaScript unit tests.
  * @param {Function} cb - Callback function to call on completion.
  */
-function unitTest( cb ) {
+function testUnit( cb ) {
   gulp.src( [ './src/**/*.js',
     '!./src/**/node_modules/**/*.js',
     '!./src/**/src/cf-*',
@@ -43,7 +45,7 @@ function unitTest( cb ) {
  * Run Mocha JavaScript build tests.
  * @param {Function} cb - Callback function to call on completion.
  */
-function buildTest( cb ) {
+function testBuild( cb ) {
   gulp.src( [ './scripts/npm/prepublish/lib/**/*.js' ] )
     .pipe( gulpIstanbul( {
       includeUntested: true
@@ -62,11 +64,11 @@ function buildTest( cb ) {
 }
 
 // TODO: Add test commands to repo documentation.
-gulp.task( 'test:unit', unitTest );
-gulp.task( 'test:build', buildTest );
-gulp.task( 'test:qunit', qunitTest );
+gulp.task( 'test:qunit', testQUnit );
+gulp.task( 'test:unit', testUnit );
+gulp.task( 'test:build', testBuild );
 
-gulp.task( 'test', gulp.parallel(
+gulp.task( 'test', gulp.series(
   'test:unit',
   'test:build',
   'test:qunit'


### PR DESCRIPTION
Realized that qUnit has some issues when running async instead of in series with the other tests.

## Changes

- Converted `gulp test` array to series

## Testing

- run `gulp build`
- run `gulp test` and ensure it doesn't crash and burn.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

### Other

- [x] JavaScript tests are passing
