### PR TITLE
Minor demibold fixes for stacked table header and heading-6 mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Changed
 - **cf-core:** [MINOR] Updates u-webfont-demi and heading-5 classes to mimic demibold font weight without loading the demibold web font to improve performance.
 - **cf-table:** [PATCH] Updates th element to use heading-5 class instead of u-webfont-demi for proper font weight and hierarchy on small screens.
+- **cf-core:** [PATCH] Fixes missing text-shadow property on heading-6 mixin needed to apply demibold type style to h6 elements.
 
 ### Removed
 - **cf-typography:** [MINOR] Removes Avenir Next Italic web font to improve performance.
 - **cf-typography:** [MINOR] Removes Avenir Next Demibold web font to improve performance.
+- **cf-table:** [PATCH] Removes duplicate CSS properties based on heading-5 class from the stacked table header element.
 
 ## 4.21.1 - 2018-01-12
 

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -127,7 +127,7 @@ textarea {
     text-transform: uppercase;
 }
 
-.heading-6( @fs: @size-vi )  {
+.heading-6( @fs: @size-vi, @text-shadow: @text )  {
     @font-size: @fs;
 
     margin-bottom: unit( 15px / @font-size, em );
@@ -135,6 +135,7 @@ textarea {
     font-weight: bold;
     letter-spacing: 1px;
     line-height: 1.25;
+    text-shadow: 0px 0px @text-shadow;
     text-transform: uppercase;
 }
 

--- a/src/cf-tables/src/cf-tables.less
+++ b/src/cf-tables/src/cf-tables.less
@@ -147,9 +147,7 @@
             margin-top: 0;
             margin-bottom: .41666667em;
             content: attr(data-label);
-            font-size: .875em;
             line-height: 1.83333333;
-            text-transform: uppercase;
         }
 
         td:last-child {


### PR DESCRIPTION
Fixes for 2 elements that inherit demibold styles, these are corrections from changes made in #722 

## Additions

- add text-shadow argument and property to the heading-6 element to properly style it as demibold (uses same technique same as heading-5)

## Removals

- remove duplicate property declarations from the responsive/stacked table header style, which already inherits those properties and values from the heading-5 class

## Changes

- 

## Testing

-

## Screenshots

Heading 6, without demibold text-shadow applied: 
![screen shot 2018-01-17 at 5 16 19 pm](https://user-images.githubusercontent.com/702526/35070067-29fe977e-fbaa-11e7-84d4-ce27fcd4d1ec.png)


Heading 6, fixed: 
![screen shot 2018-01-17 at 5 11 34 pm](https://user-images.githubusercontent.com/702526/35069986-dbc2ec7c-fba9-11e7-8930-6bb796f5035c.png)



## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] FF
- [ ] IE10
- [ ] IE9
- [ ] IE8
- [ ] Opera
- [ ] iOS
- [ ] Android
- [ ] Blackberry Bold

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
