### PR TITLE
cf-expandables: Update color of divider in groups to Gray 40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-expandables:** [PATCH] Update color of divider in groups to Gray 40
 
 ### Removed
 -

--- a/src/cf-expandables/src/cf-expandables.less
+++ b/src/cf-expandables/src/cf-expandables.less
@@ -24,7 +24,7 @@
 
 // .o-expandable-group
 @expandable-group-bg:           @white;
-@expandable-group-divider:      @gray-80;
+@expandable-group-divider:      @gray-40;
 
 // Sizing variables
 


### PR DESCRIPTION
Per guidance in https://[GHE]/CFPB/hubcap/issues/76, we had the wrong color here.