### PR TITLE
cf-typography: Add rule to make link lists be medium weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-typography:** [PATCH] Add rule to make link lists be medium weight
 
 ### Changed
 -

--- a/src/cf-typography/src/molecules/list.less
+++ b/src/cf-typography/src/molecules/list.less
@@ -58,6 +58,8 @@
     }
 
     .m-list_link {
+        font-weight: 500;
+
         .respond-to-max( @bp-xs-max, {
             .a-link__block();
         } );


### PR DESCRIPTION
A long overdue migration from cfgov-refresh's enhancements. Couldn't believe we hadn't done this yet.