### PR TITLE
Reduce H4 size on extra-small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-core:** [PATCH] Reduce size of `h4` and `.h4` on extra-small screens.
 
 ### Removed
 -

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -291,6 +291,14 @@ h4,
     .h6 + & {
         margin-top: unit( 30px / @font-size, em );
     }
+
+    .respond-to-max( @bp-xs-max, {
+        @h4-font-size-on-xs: 16px;
+
+        margin-bottom: unit( 10 / @h4-font-size-on-xs, em );
+        font-size: unit( @h4-font-size-on-xs / @base-font-size-px, em );
+        line-height: unit( 18 / @h4-font-size-on-xs );
+    } );
 }
 
 h5,

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -293,11 +293,11 @@ h4,
     }
 
     .respond-to-max( @bp-xs-max, {
-        @h4-font-size-on-xs: 16px;
+        @h4-font-size-on-xs: @base-font-size-px;
 
-        margin-bottom: unit( 10 / @h4-font-size-on-xs, em );
+        margin-bottom: unit( 10px / @h4-font-size-on-xs, em );
         font-size: unit( @h4-font-size-on-xs / @base-font-size-px, em );
-        line-height: unit( 18 / @h4-font-size-on-xs );
+        line-height: unit( 18px / @h4-font-size-on-xs );
     } );
 }
 

--- a/src/cf-core/usage.md
+++ b/src/cf-core/usage.md
@@ -792,7 +792,7 @@ _Responsive heading. At small screen sizes, displays as heading level 4._
 
 #### Heading level 4
 
-_Not a responsive heading._
+_Responsive heading. At small screen sizes, displays at same size as body copy._
 
 <h4>Example heading element</h4>
 <p class="h4">A non-heading element</p>


### PR DESCRIPTION
Per discussion and decision in https://[GHE]/CFPB/hubcap/issues/65

@nataliafitzgerald @huetingj 

## Changes

- **cf-core:** [PATCH] Reduce size of `h4` and `.h4` on extra-small screens.

## Testing

1. See https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally

## Screenshots

![screen shot 2018-02-05 at 11 28 24](https://user-images.githubusercontent.com/1044670/35815995-c544b936-0a67-11e8-95c7-a644589e1530.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
