### PR TITLE
Demibold fix for Safari

### DIFF
--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -120,7 +120,7 @@ textarea {
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
-    font-weight: bold;
+    font-weight: 600;
     letter-spacing: 1px;
     line-height: 1.25;
     text-shadow: 0px 0px @text-shadow;
@@ -132,7 +132,7 @@ textarea {
 
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
-    font-weight: bold;
+    font-weight: 600;
     letter-spacing: 1px;
     line-height: 1.25;
     text-shadow: 0px 0px @text-shadow;

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -70,6 +70,11 @@ body {
     line-height: @base-line-height;
 }
 
+strong,
+b {
+    font-weight: 600;
+}
+
 button,
 input,
 select,

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -70,11 +70,6 @@ body {
     line-height: @base-line-height;
 }
 
-strong,
-b {
-    font-weight: 600;
-}
-
 button,
 input,
 select,
@@ -82,6 +77,11 @@ textarea {
     // Must set these explicitly to override Normalize.css's provided default
     // of `font-family: sans-serif;`
     font-family: 'Avenir Next', Arial, sans-serif;
+}
+
+strong,
+b {
+    font-weight: 600;
 }
 
 .heading-1( @fs: @size-i ) {
@@ -520,7 +520,7 @@ tbody tr {
 }
 
 th {
-    font-weight: bold;
+    font-weight: 600;
     text-align: left;
 }
 

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -53,7 +53,7 @@
 .u-webfont-demi() {
     font-family: @webfont-medium, Arial, sans-serif;
     font-style: normal;
-    font-weight: bold;
+    font-weight: 600;
     .lt-ie9 & {
         font-weight: normal !important;
     }


### PR DESCRIPTION
Builds on changes from #722 but adjusts the font-weight so that it appears the same as Demibold in all browsers, including Safari.

## Additions

- 

## Removals

-

## Changes

- `font-weight: bold` was changed to `600` after @Scotchester noticed the bold was too heavy in Safari (both desktop and Mobile Safari showed this issue). After making this change, it was tested and visually QA'ed in all of our supported browsers, and I've confirmed the change appears as expected, with the faux-Demibold now very closely matching the appearance of the web font across our supported browsers.

## Testing

You can test this on the CF docs and check out the following pages to confirm the heading-5 and inline bold elements look as expected:
- http://localhost:3000/components/cf-typography/
- http://localhost:3000/components/cf-core/

I've also tested this extensively in cfgov-refresh using npm link and Sauce labs, see screenshots below. If you test in cfgov-refresh, here's a good URL that contains a lot of the elements that use this style: http://localhost:3000/ask-cfpb/how-can-i-get-a-refund-on-a-product-or-service-i-purchased-with-my-credit-card-en-1969/

## Screenshots

### Here's the bug in desktop Safari:

![screen shot  demibold safari bug](https://user-images.githubusercontent.com/702526/35999121-b8f82578-0cec-11e8-940e-ca3e8090ca2d.png)

![screen shot 2018-02-08 at 4 44 56 pm](https://user-images.githubusercontent.com/702526/36000039-af7dee6c-0cef-11e8-9a2a-708e0977bb11.png)


### Here it is fixed

With screenshots from a variety of browsers. Not all browsers are included here, this is just a smattering to give you the idea - it's consistent.
### Desktop Safari, Capital Framework
![screen shot  demibold safari fixed](https://user-images.githubusercontent.com/702526/35999122-b9093f7a-0cec-11e8-899e-627182632f94.png)

### Desktop Safari, cfgov-refresh
 The demibold elements are the date, the "Answer" heading, the inline bolded text like where it says "Note:" and the slug headers in the sidebar ("Related questions").

![screen shot 2018-02-08 at 4 46 15 pm](https://user-images.githubusercontent.com/702526/36000038-af62d10e-0cef-11e8-8655-71cb6e5f3377.png)

### Mobile Safari on iPhone:
![screenshot demibold mobile safari iphone fixed](https://user-images.githubusercontent.com/702526/35999120-b8d1d292-0cec-11e8-94f1-7f2d3557d27a.png)

### Windows Firefox:
![screenshot demibold windows firefox fixed](https://user-images.githubusercontent.com/702526/35999118-b8aae268-0cec-11e8-8478-3b6e18d94e3c.png)

### Windows Edge:
![screenshot demibold windows edge fixed](https://user-images.githubusercontent.com/702526/35999119-b8bccdac-0cec-11e8-961d-969cb65a7f02.png)



## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [x] Chrome
- [x] Safari
- [x] FF
- [x] IE10
- [x] IE9
- [x] IE8
- [ ] Opera
- [x] iOS
- [x] Android
- [ ] Blackberry Bold

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
