### PR TITLE
Post-preview related m-meta-header whitespace tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Added
 - **cf-typography:** [PATCH] Add rule to make link lists be medium weight
+- **cf-typography:** [PATCH] Fix whitespace under m-meta-header elements to match vertical grid standards.
 
 ### Changed
 - **cf-expandables:** [PATCH] Update color of divider in groups to Gray 40

--- a/src/cf-typography/src/molecules/meta-header.less
+++ b/src/cf-typography/src/molecules/meta-header.less
@@ -21,7 +21,6 @@
     } );
 
     .a-heading {
-        display: inline;
         margin-bottom: 0;
     }
 }

--- a/src/cf-typography/src/molecules/meta-header.less
+++ b/src/cf-typography/src/molecules/meta-header.less
@@ -1,18 +1,7 @@
 .m-meta-header {
     padding-bottom: unit( 10px / @base-font-size-px, em );
     border-bottom: 1px solid @meta-header_border;
-    // TODO: Move margin to o-post-preview and other parent containers
-    margin-bottom: unit( 15px / @base-font-size-px, em );
     overflow: auto;
-
-    .respond-to-max(@bp-xs-max, {
-
-        &_right {
-            display: block;
-            margin-bottom: unit( 5px / 14px, em );
-        }
-
-    });
 
     .respond-to-min( @bp-sm-min, {
         .u-clearfix();

--- a/src/cf-typography/src/molecules/meta-header.less
+++ b/src/cf-typography/src/molecules/meta-header.less
@@ -1,8 +1,18 @@
 .m-meta-header {
-    padding-bottom: unit( 8px / @base-font-size-px, em );
+    padding-bottom: unit( 10px / @base-font-size-px, em );
     border-bottom: 1px solid @meta-header_border;
     // TODO: Move margin to o-post-preview and other parent containers
-    margin-bottom: unit( 10px / @base-font-size-px, em );
+    margin-bottom: unit( 15px / @base-font-size-px, em );
+    overflow: auto;
+
+    .respond-to-max(@bp-xs-max, {
+
+        &_right {
+            display: block;
+            margin-bottom: unit( 5px / 14px, em );
+        }
+
+    });
 
     .respond-to-min( @bp-sm-min, {
         .u-clearfix();
@@ -14,9 +24,15 @@
         &_right {
             float: right;
         }
+
+        .a-heading {
+            display: block;
+        }
+
     } );
 
     .a-heading {
+        display: inline;
         margin-bottom: 0;
     }
 }

--- a/src/cf-typography/src/molecules/meta-header.less
+++ b/src/cf-typography/src/molecules/meta-header.less
@@ -13,11 +13,6 @@
         &_right {
             float: right;
         }
-
-        .a-heading {
-            display: block;
-        }
-
     } );
 
     .a-heading {


### PR DESCRIPTION
Standardizes the whitespace for the meta-header element (used in post-preview on blog pages) to better match padding/margins/vertical grid standards elsewhere. Straight from @nataliafitzgerald via https://GHE/CFGOV/platform/issues/1089#issuecomment-148188

## Changes

- Padding is now 10px
- Margin was moved to parent element in cfgov-refresh `post-preview.less` - see https://github.com/cfpb/cfgov-refresh/pull/3785

## Testing

-

## Screenshots
![image](https://user-images.githubusercontent.com/702526/36051244-6d5b0a74-0db7-11e8-8c10-68baa4381499.png)


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Safari
- [ ] FF
- [ ] IE10
- [ ] IE9
- [ ] IE8
- [ ] Opera
- [ ] iOS
- [ ] Android
- [ ] Blackberry Bold

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
