### PR TITLE
Prevent release scripts from being triggered by CFPBot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **capital-framework:** [PATCH] Prevent release scripts from being triggered by CFPBot.
 
 ### Removed
 -

--- a/scripts/travis/release.sh
+++ b/scripts/travis/release.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 set -e
 
-# Abort if this is a pull request OR if we're not on master
+export COMMIT_AUTHOR_NAME="$(git log -1 $TRAVIS_COMMIT --pretty="%aN")"
+
+# Echo some variables to make Travis CI debugging easier 
+echo "TRAVIS: ${TRAVIS}"
+echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+echo "GH_PROD_BRANCH: ${GH_PROD_BRANCH}"
+echo "GH_DEV_BRANCH: ${GH_DEV_BRANCH}"
+echo "TRAVIS_NODE_VERSION: ${TRAVIS_NODE_VERSION}"
+echo "COMMIT_AUTHOR_NAME: ${COMMIT_AUTHOR_NAME}"
+
+# If this is Travis CI AND
 if [[ -n "$TRAVIS" ]] &&
-   [[ "$TRAVIS_PULL_REQUEST" != "false" || "$TRAVIS_BRANCH" != "$GH_PROD_BRANCH" ]]; then
-  echo "TRAVIS: ${TRAVIS}"
-  echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
-  echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
-  echo "GH_PROD_BRANCH: ${GH_PROD_BRANCH}"
-  echo "GH_DEV_BRANCH: ${GH_DEV_BRANCH}"
-  echo "TRAVIS_NODE_VERSION: ${TRAVIS_NODE_VERSION}"
+      # This is a pull request OR 
+   [[ "$TRAVIS_PULL_REQUEST" != "false" ||
+      # This branch isn't master OR
+      "$TRAVIS_BRANCH" != "$GH_PROD_BRANCH" ||
+      # The commit author is CFPBot
+      "$COMMIT_AUTHOR_NAME" == "CFPBot" ]];
+# Then abort everything
+then
   echo "Abort!"
   exit 0;
 fi
@@ -18,7 +30,7 @@ fi
 if [[ -n "$TRAVIS" ]]; then
   echo "Adding git credentials..."
   git config user.name "CFPBot"
-  git config user.email "CFPBot@users.noreply.github.com"
+  git config user.email "cfpbot@users.noreply.github.com"
 fi
 
 node scripts/npm/prepublish $1


### PR DESCRIPTION
The echo'ing of environment variables was moved to the top of the
release script so that they'll be printed even if the script doesn't
abort.

The script now checks if the last git commit's username is CFPBot. If
so, it aborts. The git username is set in the same file (L32) so even
if someone changes the bot's GH username or an entirely different bot
is used, the conditional will still operate as expected.