### PR TITLE
Fix OL left padding so numbers aren't cut off in IE and Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-typography:** [PATCH] Note in usage docs about unused italic and demi fonts.
 
 ### Changed
--
+- **cf-core:** [PATCH] Fix OL `padding-left` so numbers aren't cut off in IE
 
 ### Removed
 -

--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -493,16 +493,19 @@ nav a {
 // Lists
 //
 
-ul, ol {
-    padding-left: unit( 18px / @base-font-size-px, em );
-}
-
 ul {
+    padding-left: unit( 18px / @base-font-size-px, em );
     list-style: square;
 }
 
 ul ul {
     list-style-type: circle;
+}
+
+ol {
+    // Slightly larger than necessary, but this is the minimum value
+    // for numbers to not be partially in the margin in Internet Explorer.
+    padding-left: unit( 21px / @base-font-size-px, em );
 }
 
 //


### PR DESCRIPTION
Fixes GHE/CFGOV/platform#1290

We apparently fixed this at one point within cfgov-refresh, but never in capital-framework.

## Changes

- Fix OL `padding-left` so numbers aren't cut off in IE and Safari

## Testing

1. https://www.consumerfinance.gov/about-us/blog/eclosing-and-buying-home-technologys-role-closing-mortgage/ in IE and see the list items being cut off. _(The list items NOT being cut off in the 2nd list is because it's just paragraphs with numbers in front of them.)_
1. Fire up your [local CF docs environment](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-in-the-documentation-site) and go to the cf-core page in IE in a VM: http://10.0.2.2:3000/components/cf-core/#ordered-list
1. Observe that the numbers hanging into the left margin, not cut off because `overflow` is not `hidden` on this page.
1. Pull this branch in your main capital-framework repo
1. `gulp` in capital-framework repo (Maybe not necessary? Can't hurt.)
1. `gulp` in your docs site repo
1. Refresh docs page and see adjusted list positioning
1. Check it in Safari, too

## Screenshots

Before:

![screen shot 2018-02-26 at 16 08 32](https://user-images.githubusercontent.com/1044670/36695438-5e2910b8-1b0f-11e8-92e6-2d5396ca8f0d.png)

After: 

![screen shot 2018-02-26 at 16 10 55](https://user-images.githubusercontent.com/1044670/36695566-b102494e-1b0f-11e8-921a-1716082ad5cb.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Testing checklist

### Browsers

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
- [x] IE11
- [x] IE10
- [x] IE9
- [x] IE8
