### PR TITLE
Fix the versions of cf-sibling dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - **cf-core:** [PATCH] Fix OL `padding-left` so numbers aren't cut off in IE
+- **cf-forms:** [PATCH] Updated cf-buttons dependency to v5.0.0
+- **cf-pagination:** [PATCH] Updated cf-buttons dependency to v5.0.0
 
 ### Removed
 -

--- a/src/cf-forms/package.json
+++ b/src/cf-forms/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "cf-core": "^4.0.0",
-    "cf-buttons": "^4.0.0",
+    "cf-buttons": "^5.0.0",
     "cf-grid": "^4.0.0",
     "cf-icons": "^4.0.0"
   },

--- a/src/cf-pagination/package.json
+++ b/src/cf-pagination/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "cf-core": "^4.0.0",
-    "cf-buttons": "^4.0.0",
+    "cf-buttons": "^5.0.0",
     "cf-icons": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
When v5.0.0 of cf-icons and cf-buttons were released, the other
components that depended on them needed to have their manifests updated
to match the new major version. Right now the bot doesn't know anything
about this and doesn't take it into account with major releases. For the
time being, any time we publish a major release, we'll need to follow it
up with a patch to update any sibling packages. Long term we should look
into upgrading the bot to figure it out and automate it.

## Changes

Updated CF dependencies for:
- cf-buttons
- cf-expandables
- cf-forms
- cf-notifications
- cf-pagination
- cf-typography

## Testing

1. When you run `npm install` or `npm list` you should not see errors like this:

<img width="491" alt="screen shot 2018-03-01 at 1 29 10 pm" src="https://user-images.githubusercontent.com/1280430/36865867-5b222c9e-1d56-11e8-86fb-79e9df2b4e85.png">

## Todos

- Figure out how to automate this with the bot

## Checklist

- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: