### PR TITLE
Remove text-shadow from h5 elements with demibold styling

### DIFF
--- a/src/cf-core/src/cf-base.less
+++ b/src/cf-core/src/cf-base.less
@@ -128,7 +128,6 @@ b {
     font-weight: 600;
     letter-spacing: 1px;
     line-height: 1.25;
-    text-shadow: 0px 0px @text-shadow;
     text-transform: uppercase;
 }
 
@@ -140,7 +139,6 @@ b {
     font-weight: 600;
     letter-spacing: 1px;
     line-height: 1.25;
-    text-shadow: 0px 0px @text-shadow;
     text-transform: uppercase;
 }
 


### PR DESCRIPTION
Fixes https://GHE/CFGOV/platform/issues/2484#issuecomment-153045

After the changes from #732 and #722 went live, differences in demibold h5 and h6 styles were noticed across browsers. Chrome and Firefox in particular showed funky extra weight in the demibold-styled fonts. This PR fixes that by removing the previous CSS hack (text-shadow) which adds extra weight. That extra weight is no longer needed because of the nice font-weight properties we can apply thanks to  #732.

## Removals

- text-shadow hack from h5 elements

## Changes

-

## Testing

1. follow the steps for testing in gh-pages 
1. confirm that h5 weights in chrome, safari, etc match the screenshots below and look more consistent across different browsers than the current live site.

## Screenshots

### Buggy before
![chrome design manual h5 screen shot 2018-03-06 at 5 56 45 pm](https://user-images.githubusercontent.com/702526/37063582-d36b6dcc-2167-11e8-83b4-51e1379f4e96.png)


### Consistent after
![chrome design manual h5](https://user-images.githubusercontent.com/702526/37063436-57bb4d6e-2167-11e8-8290-15b0f894d116.png)

### Cross-browser before/after
Here are various results across supported browsers tested in Sauce Labs and my machine within cfgov-refresh. Note that I did not include older IE, since the consistency of font-weight and visual design is less of a concern in those browsers.

The URL I tested was https://www.consumerfinance.gov/ask-cfpb/what-should-i-do-when-a-debt-collector-contacts-me-en-1695/ which has a variety of uses of h5/demibold elements.

| Browser | Before        | After  |
| ------------- |:-------------:| :-------------:| 
| Chrome | Before        | ![chrome screen shot 2018-03-01 at 6 47 35 pm](https://user-images.githubusercontent.com/702526/37063892-01f0439c-2169-11e8-9677-c20a3c202041.png)  |
| Desktop Safari | ![safari before screen shot 2018-03-06 at 6 11 42 pm](https://user-images.githubusercontent.com/702526/37064195-fda6b5d6-2169-11e8-84d9-814b168f0382.png)    | ![image](https://user-images.githubusercontent.com/702526/37063912-15583fc0-2169-11e8-813f-55f06b6912ce.png)  |
| Mobile Safari | Before        | After  |
| Android |![android screen shot 2018-03-01 at 6 37 14 pm](https://user-images.githubusercontent.com/702526/37064061-8fc98584-2169-11e8-8cda-74c339dfacb8.png)  | ![image](https://user-images.githubusercontent.com/702526/37063947-33c2e83e-2169-11e8-816e-c7113604e939.png)  |
| IE10 | ![ie10 screen shot 2018-03-01 at 6 31 22 pm](https://user-images.githubusercontent.com/702526/37064081-9721132e-2169-11e8-8b8b-213c2eeabf1e.png) | ![image](https://user-images.githubusercontent.com/702526/37063962-3c8f35c6-2169-11e8-94e8-bda0f39f7086.png)  |
| IE11 | ![ie11 screen shot 2018-03-01 at 6 28 10 pm](https://user-images.githubusercontent.com/702526/37064092-a1ceadea-2169-11e8-8a88-13336b4aecce.png)   | ![image](https://user-images.githubusercontent.com/702526/37063970-432b5978-2169-11e8-9f0b-56467dc59fa2.png)  |
| Firefox | ![firefox screen shot 2018-03-06 at 6 11 05 pm](https://user-images.githubusercontent.com/702526/37064180-f34659c0-2169-11e8-888e-3ef18c900307.png)   |![image](https://user-images.githubusercontent.com/702526/37063974-4b9e9930-2169-11e8-96a3-c160cfe53d38.png)  |




## Notes

-

## Todos

-

## Checklist

- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
