### PR TITLE
Initial list of default reviewers in alpha order

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Uses the same pattern rules for gitignore files
+# https://git-scm.com/docs/gitignore#_pattern_format
+# For more info about CODEOWNERS, visit
+# https://help.github.com/articles/about-codeowners/
+
+#
+# These are the default owners for everything in the repo.
+#
+* @anselmbradford @cfarm @contolini @jimmynotjim @Scotchester @sebworks
+
+# To add owners of a specific file type or directory, prepend the line with
+# the pattern to match. The last matching pattern takes the most precedence.
+# Example:
+# *.js @js-owner
+
+#
+# These are the owners of the deployment process
+#
+/scripts/npm/prepublish/ @contolini @jimmynotjim


### PR DESCRIPTION
Lets see how this goes for PRs going forward. If it gets too noisy maybe we can divvy up sections of the project.

## Additions

- Adds GitHub codeowners file.


## Notes

- https://help.github.com/articles/about-codeowners/
