### PR TITLE
cf-notifications: Remove unnecessary icon positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - **cf-core:** [PATCH] Changed heading mixins to prevent heading element styles from leaking into classes.
+- **cf-notifications:** [PATCH] Removed unnecessary icon positioning; fix mistake in usage file.
 
 ### Removed
 -

--- a/src/cf-notifications/src/molecules/notification.less
+++ b/src/cf-notifications/src/molecules/notification.less
@@ -13,10 +13,7 @@
 
    .cf-icon-svg {
       position: absolute;
-      top: @notification-padding__px;
-      left: @notification-padding__px;
       font-size: unit( 18px / 16px, em );
-      float: left;
       fill: @notification-icon;
    }
 

--- a/src/cf-notifications/usage.md
+++ b/src/cf-notifications/usage.md
@@ -118,7 +118,7 @@ such as a search that returned no results.
 <div class="m-notification
             m-notification__visible
             m-notification__warning">
-    {% include icons/error-round.svg %}
+    {% include icons/warning-round.svg %}
     <div class="m-notification_content">
         <div class="h4 m-notification_message">No results found.</div>
     </div>
@@ -128,7 +128,7 @@ such as a search that returned no results.
 <div class="m-notification
             m-notification__visible
             m-notification__warning">
-    {% raw %}{% include icons/error-round.svg %}{% endraw %}
+    {% raw %}{% include icons/warning-round.svg %}{% endraw %}
     <div class="m-notification_content">
         <div class="h4 m-notification_message">No results found.</div>
     </div>


### PR DESCRIPTION
This positioning was superfluous, and removing it simplifies the alternate usage in the email popup, too.

## Removals

- Unnecessary notification icon positioning

## Changes

- Corrected icon in cf-notifications `usage.md`

## Testing

https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
