### PR TITLE
Fix the height of select elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-forms:** [PATCH] Fixed the height of select elements to match the DM spec
 
 ### Removed
 -

--- a/src/cf-forms/src/atoms/select.less
+++ b/src/cf-forms/src/atoms/select.less
@@ -4,9 +4,8 @@
     border: 1px solid @select-border;
 
     select {
-        height: unit( @select-height / @base-font-size-px, em );
         width: 100%;
-        padding: unit( 4px / @base-font-size-px, em )
+        padding: unit( 8px / @base-font-size-px, em )
                  unit( 6px / @base-font-size-px, em );
         border: 0;
         appearance: none;


### PR DESCRIPTION
As reported in #795 the select elements were being displayed as 30px high instead of the [35px called out in the DM spec](https://cfpb.github.io/design-manual/page-components/form-fields.html#dropdowns). This patch corrects the padding to create the correct height and removes the static height to ensure the content is never cut off.

## Changes

- Update the `.a-select` padding to the correct values.

## Testing

1. Follow the [testing locally instructions](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally)
1. Run `gulp build` && `npm start`
1. Navigate to `http://localhost:3000/components/cf-forms/#select-dropdown`

## Screenshots

<img width="894" alt="screen shot 2018-07-03 at 9 33 17 am" src="https://user-images.githubusercontent.com/1280430/42226633-070ca214-7ea5-11e8-8826-cbc95aa453ba.png">

## Notes

- Fixes #795 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
