### PR TITLE
Fix the indentation of error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-forms:** [MINOR] Added styles for error message atom to ensure the proper indentation.
 
 ### Changed
 -

--- a/src/cf-forms/src/atoms/error-message.less
+++ b/src/cf-forms/src/atoms/error-message.less
@@ -1,0 +1,11 @@
+.a-error-message {
+    .cf-icon-svg {
+        color: @input-icon__error;
+        float: left;
+    }
+
+    &_text {
+        display: block;
+        margin-left: unit(20px / @base-font-size-px, em);
+    }
+}

--- a/src/cf-forms/src/cf-forms.less
+++ b/src/cf-forms/src/cf-forms.less
@@ -64,6 +64,7 @@
 // Import atoms
 //
 
+@import (less) 'atoms/error-message.less';
 @import (less) 'atoms/label.less';
 @import (less) 'atoms/legend.less';
 @import (less) 'atoms/multiselect.less';

--- a/src/cf-forms/usage.md
+++ b/src/cf-forms/usage.md
@@ -28,6 +28,7 @@ Capital Framework.
     - [Large target area checkboxes](#large-target-area-checkboxes)
     - [Large target area radio buttons](#large-target-area-radio-buttons)
     - [Inputs helper text](#inputs-helper-text)
+    - [Inline Form Validation](#inline-form-validation)
 - [Buttons](#buttons)
     - [Simple input with a button](#simple-input-with-a-button)
     - [Button inside an input](#button-inside-an-input)
@@ -756,7 +757,9 @@ have helper text that appears below the main label text.
            aria-describedby="form-input-error_message">
     <div class="a-error-message" id="form-input-error_message" role="alert">
         {% include icons/error-round.svg %}
-        This is a required question, please answer.
+        <span class="a-error-message_text">
+            This is a required question, please answer.
+        </span>
     </div>
 </div>
 


### PR DESCRIPTION
As reported in #626 the error messages should indent when they break onto two lines. This patch corrects the indentation and moves the icon color styles into the new error message atom file.

## Additions

- Added styles for error message atom to ensure the proper indentation.

## Changes

- Moved existing error message icon styles to the new atom file.
- Updated the markup in the documentation

## Testing

1. Follow the [testing locally instructions](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally)
1. Run `gulp build` && `npm start`
1. Navigate to `http://localhost:3000/components/cf-forms/#select-dropdown`

## Screenshots

Before

<img width="764" alt="screen shot 2018-07-03 at 10 23 26 am" src="https://user-images.githubusercontent.com/1280430/42229450-1f301914-7eac-11e8-98ef-842460e57077.png">

After

<img width="754" alt="screen shot 2018-07-03 at 10 23 09 am" src="https://user-images.githubusercontent.com/1280430/42229457-2281d92c-7eac-11e8-80c5-4f9d9fde9103.png">

## Notes

- Fixes #626 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
