### PR TITLE
Update the language around the animated updating icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Changed
 - **capital-framework:** [MINOR] Updated to ESLint 5.
 - **cf-forms:** [PATCH] Fixed the height of select elements to match the DM spec
+- **cf-icons:** [PATCH] Update the language around the animated updating icon
 
 ### Removed
 -

--- a/src/cf-icons/usage.md
+++ b/src/cf-icons/usage.md
@@ -189,7 +189,7 @@ the cancanonical name or any of its aliases.
 | {% include icons/error.svg %} | {% include icons/error-round.svg %} | error | delete, close, remove, multiply, multiplication, x |
 | {% include icons/warning.svg %} | {% include icons/warning-round.svg %} | warning | alert, exclamation-mark |
 | {% include icons/help.svg %} | {% include icons/help-round.svg %} | help | question, question-mark |
-| {% include icons/update.svg %} | {% include icons/update-round.svg %} | update | updating(animated) |
+| {% include icons/update.svg %} | {% include icons/update-round.svg %} | update | updating _(used for animated state)_ |
 | {% include icons/dollar.svg %} | {% include icons/dollar-round.svg %} | dollar |  |
 | {% include icons/plus.svg %} | {% include icons/plus-round.svg %} | plus | add, addition, expand |
 | {% include icons/minus.svg %} | {% include icons/minus-round.svg %} | minus | subtract, subtraction, collapse |


### PR DESCRIPTION
It wasn't quite clear that the (animated) note was about the state of
the icon and not necessarily the name of the alias. Updated to match
suggested language from Marteki [in the DM PR](https://github.com/cfpb/design-manual/pull/609#pullrequestreview-133975162).

## Changes

- Update the language around the animated updating icon
