### PR TITLE
Fixes some linter errors and warning

### DIFF
--- a/scripts/gulp/scripts.js
+++ b/scripts/gulp/scripts.js
@@ -1,9 +1,7 @@
-const BROWSER_LIST = require( '../../config/browser-list-config' );
 const component = require( './parseComponentName' );
 const gulp = require( 'gulp' );
 const gulpIgnore = require( 'gulp-ignore' );
 const gulpRename = require( 'gulp-rename' );
-const UglifyWebpackPlugin = require( 'uglifyjs-webpack-plugin' );
 const vinylNamed = require( 'vinyl-named' );
 const webpack = require( 'webpack' );
 const webpackConfig = require( '../../config/webpack-config.js' );

--- a/scripts/gulp/test.js
+++ b/scripts/gulp/test.js
@@ -20,6 +20,7 @@ function testQUnit( cb ) {
 /**
  * Run JavaScript unit tests.
  * @param {Function} cb - Callback function to call on completion.
+ * @returns {ChildProcess} - Process to hand back to the gulp stream.
  */
 function testUnit( cb ) {
   const params = minimist( process.argv.slice( 3 ) ) || {};

--- a/scripts/npm/prepublish/lib/checkNpmAuth.js
+++ b/scripts/npm/prepublish/lib/checkNpmAuth.js
@@ -40,7 +40,7 @@ function checkAuth( component ) {
       process.exit( 1 );
     }
   } ).catch( err => {
-    if ( /ENEEDAUTH/.test( err ) ) {
+    if ( ( /ENEEDAUTH/ ).test( err ) ) {
       printLn.error(
         'You\'re not logged into npm. You need to authorize ' +
         'this machine using `npm login`.'

--- a/scripts/npm/prepublish/lib/print.js
+++ b/scripts/npm/prepublish/lib/print.js
@@ -20,13 +20,16 @@ const printLn = {};
 
 [ 'success', 'warning', 'error', 'info' ].forEach( function( type ) {
   printLn[type] = function( msg, indent ) {
-    options.silent ? function() {} : printMsg( type, msg, indent );
+    if ( !options.silent ) {
+      printMsg( type, msg, indent );
+    }
   };
 } );
 
 printLn.console = function( msg ) {
-  options.silent ? function() {} :
+  if ( !options.silent ) {
     console.log( chalk.dim( indentString( msg, 8 ) ) );
+  }
 };
 
 module.exports = printLn;

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -6,3 +6,4 @@ rules:
   wrap-iife: 0
   no-process-env: 0
   no-console: 0
+  max-lines-per-function: 0

--- a/test/unit-test/scripts/npm/prepublish/lib/confirm-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/confirm-spec.js
@@ -1,6 +1,5 @@
 process.env.CONTINUOUS_INTEGRATION = false;
 
-const childProcess = require( 'child-process-promise' );
 const path = require( 'path' );
 const rootPath = require( '../root-path' );
 const libPath = path.join( rootPath, 'scripts', 'npm', 'prepublish', 'lib' );
@@ -12,19 +11,19 @@ const opts = {
 };
 
 describe( 'confirm', () => {
-  xit( 'should continue if the user replies with "yes"', () =>
+  xit( 'should continue if the user replies with "yes"', () => {
     // TODO: Figure out how to pass user replies to the command line.
     util.confirm( opts ).then( () => {
       expect( true ).toBe( false );
-    } )
-  );
+    } );
+  } );
 
-  xit( 'should abort if the user replies with "no"', () =>
+  xit( 'should abort if the user replies with "no"', () => {
     // TODO: Figure out how to pass user replies to the command line.
     util.confirm( opts ).then( () => {
       expect( true ).toBe( false );
-    } )
-  );
+    } );
+  } );
 
   it( 'should continue if we’re in a CLI environment', () => {
     const processSpy = jest.spyOn( process, 'exit' );

--- a/test/unit-test/scripts/npm/prepublish/lib/getNpmVersion-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/getNpmVersion-spec.js
@@ -1,4 +1,3 @@
-const childProcess = require( 'child-process-promise' );
 const path = require( 'path' );
 const rootPath = require( '../root-path' );
 const libPath = path.join( rootPath, 'scripts', 'npm', 'prepublish', 'lib' );

--- a/test/unit-test/src/cf-atomic-component/src/mixins/Events-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/mixins/Events-spec.js
@@ -3,7 +3,6 @@ const Events = require( srcPath + '/mixins/Events' );
 
 const HTML_SNIPPET = '<!DOCTYPE html>';
 
-let dom;
 let mockEvent;
 let spy1;
 let spy2;

--- a/test/unit-test/src/cf-atomic-component/src/utilities/config-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/config-spec.js
@@ -8,6 +8,7 @@ describe( 'config', () => {
     expect( config.PREFIXES ).toBeInstanceOf( Object );
     expect( config.UNDEFINED ).toBeUndefined();
     expect( config.NO_OP_FUNCTION ).toBeInstanceOf( Function );
+    // eslint-disable-next-line new-cap
     expect( config.NO_OP_FUNCTION() ).toBeUndefined();
   } );
 } );

--- a/test/unit-test/src/cf-atomic-component/src/utilities/dom-class-list-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/dom-class-list-spec.js
@@ -5,8 +5,6 @@ let classListPath;
 let testBlockA;
 let testBlockB;
 let testBlockC;
-let testBlockD;
-let sandbox;
 
 const HTML_SNIPPET = `
   <div id="test-block-a" class="test-class test-class-a">

--- a/test/unit-test/src/cf-atomic-component/src/utilities/dom-closest-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/dom-closest-spec.js
@@ -1,7 +1,6 @@
 const srcPath = require( '../src-path' );
 
 let domClosest;
-let sandbox;
 
 let testBlockA;
 let testBlockB;
@@ -57,7 +56,7 @@ describe( 'dom-closest', () => {
 
   it( 'should use the native closest method if it exists', () => {
     const spy = testBlockD.closest = jest.fn();
-    const element = domClosest( testBlockD, 'section' );
+    domClosest( testBlockD, 'section' );
     expect( spy ).toHaveBeenCalled();
   }
   );

--- a/test/unit-test/src/cf-atomic-component/src/utilities/function-bind-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/function-bind-spec.js
@@ -4,9 +4,8 @@ const bind = require( srcPath + '/utilities/function-bind' ).bind;
 describe( 'function-bind', () => {
   it( 'should bind the proper context', () => {
     const context = { testing: true };
-    const mockFunction = function() { return this; };
+    function mockFunction() { return this; }
     const boundFunction = bind( mockFunction, context );
     expect( boundFunction() === context ).toBe( true );
-  }
-  );
+  } );
 } );

--- a/test/unit-test/src/cf-atomic-component/src/utilities/on-ready-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/on-ready-spec.js
@@ -45,13 +45,12 @@ describe( 'on-ready', function() {
   it( 'should add a function to the saved array and trigger it' +
       'when readyState completes', () => {
     let readyReturn;
-    let _readyFunctions;
 
     onReady( function() {
       readyReturn = 'foo';
     } );
 
-    _readyFunctions = onReady( function() {
+    const _readyFunctions = onReady( function() {
       readyReturn = 'foo';
     } );
 

--- a/test/unit-test/src/cf-atomic-component/src/utilities/type-checkers-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/type-checkers-spec.js
@@ -6,9 +6,9 @@ const aString = 'bar';
 const aNum = 42;
 const aDate = new Date( 2011, 7, 21 );
 
-const aFunction = function aFunction() {
+function aFunction() {
   return true;
-};
+}
 
 const anObject = {
   a: '1',


### PR DESCRIPTION
## Changes

- Ignore `max-lines-per-function` in tests.
- Fix some linter errors and warnings.
- Add some jsdocs.
- Remove unused references.

## Testing

1. Run `gulp lint` on `canary`.
2. Run `gulp lint` in this branch and see that some issues are fixed.
