### PR TITLE
cf-atomic-component: minor code formatting updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-atomic-component:** [PATCH] Remove "use strict" from modules.
 
 ### Removed
 -

--- a/src/cf-atomic-component/src/components/Atom.js
+++ b/src/cf-atomic-component/src/components/Atom.js
@@ -5,8 +5,6 @@
 
    ========================================================================== */
 
-'use strict';
-
 const AtomicComponent = require( './AtomicComponent' );
 const TYPES = require( '../utilities/config' ).TYPES;
 

--- a/src/cf-atomic-component/src/components/AtomicComponent.js
+++ b/src/cf-atomic-component/src/components/AtomicComponent.js
@@ -10,8 +10,6 @@
 
    ========================================================================== */
 
-'use strict';
-
 const assign = require( '../utilities/object-assign' ).assign;
 const bind = require( '../utilities/function-bind' ).bind;
 const classList = require( '../utilities/dom-class-list' );
@@ -26,7 +24,7 @@ const isFunction = require( '../utilities/type-checkers' ).isFunction;
  * necessary methods to properly instantiatie component.
  *
  * @param {HTMLElement} element - The element to set as the base element.
- * @param {Object} attributes -  Hash of attributes to set on base element.
+ * @param {Object} attributes - Hash of attributes to set on base element.
  */
 function AtomicComponent( element, attributes ) {
   this.element = element;
@@ -52,8 +50,8 @@ assign( AtomicComponent.prototype, Events, classList, {
    * Function used to process class modifiers. These should
    * correspond with BEM modifiers.
    *
-   * @param {Object} attributes -  Hash of attributes to set on base element.
-   * @param {Object} atomicComponent -  Base component.
+   * @param {Object} attributes - Hash of attributes to set on base element.
+   * @param {Object} atomicComponent - Base component.
    */
   processModifiers: function() {
     if ( !this.modifiers ) {
@@ -159,7 +157,7 @@ assign( AtomicComponent.prototype, Events, classList, {
   /**
    * Function used to set the attributes on an element.
    *
-   * @param {Object} attributes -  Hash of attributes to set on base element.
+   * @param {Object} attributes - Hash of attributes to set on base element.
    */
   setElementAttributes: function( attributes ) {
     let property;
@@ -203,7 +201,7 @@ assign( AtomicComponent.prototype, Events, classList, {
   /**
    * Function used to set the attributes on an element.
    *
-   * @param {string} eventName -  Event in which to listen for.
+   * @param {string} eventName - Event in which to listen for.
    * @param {string} selector - CSS selector.
    * @param {Function} listener - Callback for event.
    * @returns {AtomicComponent} An instance.
@@ -247,7 +245,7 @@ assign( AtomicComponent.prototype, Events, classList, {
  * Function used to set the attributes on an element.
  * and unbind events.
  *
- * @param {Object} attributes -  Hash of attributes to set on base element.
+ * @param {Object} attributes - Hash of attributes to set on base element.
  * @returns {Function} Extended child constructor function.
  */
 AtomicComponent.extend = function( attributes ) {

--- a/src/cf-atomic-component/src/components/Molecule.js
+++ b/src/cf-atomic-component/src/components/Molecule.js
@@ -5,8 +5,6 @@
 
    ========================================================================== */
 
-'use strict';
-
 const AtomicComponent = require( './AtomicComponent' );
 const TYPES = require( '../utilities/config' ).TYPES;
 

--- a/src/cf-atomic-component/src/components/Organism.js
+++ b/src/cf-atomic-component/src/components/Organism.js
@@ -5,8 +5,6 @@
 
    ========================================================================== */
 
-'use strict';
-
 const AtomicComponent = require( './AtomicComponent' );
 const TYPES = require( '../utilities/config' ).TYPES;
 

--- a/src/cf-atomic-component/src/components/Page.js
+++ b/src/cf-atomic-component/src/components/Page.js
@@ -5,8 +5,6 @@
 
    ========================================================================== */
 
-'use strict';
-
 const AtomicComponent = require( './AtomicComponent' );
 const TYPES = require( '../utilities/config' ).TYPES;
 

--- a/src/cf-atomic-component/src/components/_Template.js
+++ b/src/cf-atomic-component/src/components/_Template.js
@@ -5,8 +5,6 @@
 
    ========================================================================== */
 
-'use strict';
-
 const AtomicComponent = require( './AtomicComponent' );
 const TYPES = require( '../utilities/config' ).TYPES;
 

--- a/src/cf-atomic-component/src/mixins/Events.js
+++ b/src/cf-atomic-component/src/mixins/Events.js
@@ -4,8 +4,6 @@
    Mixin to add basic event callback functionality.
    ========================================================================== */
 
-'use strict';
-
 const Events = {
 
   /**

--- a/test/unit-test/src/cf-atomic-component/src/components/AtomicComponent-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/components/AtomicComponent-spec.js
@@ -33,8 +33,7 @@ describe( 'AtomicComponent', () => {
     expect( initialize ).toHaveBeenCalledTimes( 1 );
     expect( atomicComponent.uId.indexOf( 'ac' ) > -1 ).toBe( true );
     expect( atomicComponent.render() === atomicComponent ).toBe( true );
-  }
-  );
+  } );
 
   it( 'should correctly attach an element', () => {
     let atomicComponent = new AtomicComponent();
@@ -47,20 +46,17 @@ describe( 'AtomicComponent', () => {
     );
     expect( atomicComponent.element.id === 'test_id' ).toBe( true );
     expect( atomicComponent.element.className === 'test_class_name' ).toBe( true );
-  }
-  );
+  } );
 
   it( 'should correctly create sub classes', () => {
     const subComponent = new ( AtomicComponent.extend( {} ) )();
     expect( subComponent._super === AtomicComponent.prototype ).toBe( true );
     expect( subComponent instanceof AtomicComponent ).toBe( true );
-  }
-  );
+  } );
 
   it( 'should add the bound attribute to passed elements', () => {
     const element = document.getElementById( 'test-block-a' );
     const atomicComponent = new AtomicComponent( element );
     expect( element.hasAttribute( 'data-bound' ) ).toBe( true );
-  }
-  );
+  } );
 } );

--- a/test/unit-test/src/cf-atomic-component/src/mixins/Events-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/mixins/Events-spec.js
@@ -21,8 +21,7 @@ describe( 'Events', () => {
     expect( mockEvent.on ).toBeInstanceOf( Function );
     expect( mockEvent.off ).toBeInstanceOf( Function );
     expect( mockEvent.trigger ).toBeInstanceOf( Function );
-  }
-  );
+  } );
 
   it( 'should correctly add event listeners', () => {
     mockEvent.on( 'click', spy1 );
@@ -30,8 +29,7 @@ describe( 'Events', () => {
     mockEvent.on( 'click', spy2 );
     expect( mockEvent.events['click'][1] === spy2 ).toBe( true );
     expect( mockEvent.events.hasOwnProperty( 'click' ) ).toBe( true );
-  }
-  );
+  } );
 
   it( 'should correctly trigger event listeners', () => {
     mockEvent = Object.assign( mockEvent, Events );
@@ -39,8 +37,7 @@ describe( 'Events', () => {
     mockEvent.trigger( 'click' );
     expect( spy1 ).toHaveBeenCalled();
     expect( spy1 ).toHaveBeenCalled();
-  }
-  );
+  } );
 
   it( 'should correctly remove event listeners', () => {
     mockEvent.on( 'click', spy1 );
@@ -52,6 +49,5 @@ describe( 'Events', () => {
     mockEvent.trigger( 'click' );
     expect( spy1 ).toHaveBeenCalledTimes( 0 );
     expect( spy2 ).toHaveBeenCalledTimes( 0 );
-  }
-  );
+  } );
 } );

--- a/test/unit-test/src/cf-atomic-component/src/utilities/data-set-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/data-set-spec.js
@@ -32,6 +32,5 @@ describe( 'data-set', () => {
     const dataset = dataSet( baseDom );
     expect( JSON.stringify( dataset ) === JSON.stringify( datasetLookup ) )
       .toBe( true );
-  }
-  );
+  } );
 } );

--- a/test/unit-test/src/cf-atomic-component/src/utilities/dom-class-list-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/dom-class-list-spec.js
@@ -30,8 +30,7 @@ describe( 'dom-class-list', () => {
 
   it( 'should determine if the browser supports class list', () => {
     expect( classList.hasClassList ).toBe( true );
-  }
-  );
+  } );
 
   it( 'should determine if an element has a particular class', () => {
     const _createElement = global.document.createElement;
@@ -48,8 +47,7 @@ describe( 'dom-class-list', () => {
     expect( classList.contains( testBlockA, 'test-class-a' ) ).toBe( true );
     expect( classList.contains( testBlockA, 'test-class' ) ).toBe( true );
     document.createElement = _createElement;
-  }
-  );
+  } );
 
   it( 'should correctly add classes to the class list', () => {
     document.body.innerHTML = HTML_SNIPPET;
@@ -61,8 +59,7 @@ describe( 'dom-class-list', () => {
     classList.addClass( testBlockB, 'test-class', 'test-class-new' );
     expect( testBlockB.className.indexOf( 'test-class-new' ) > -1 )
       .toBe( true );
-  }
-  );
+  } );
 
   it( 'should correctly remove classes to the class list', () => {
     expect( testBlockC.className.indexOf( 'test-class-c' ) > -1 )
@@ -73,8 +70,7 @@ describe( 'dom-class-list', () => {
     testBlockC.className = 'test-class-c test-class';
     classList.removeClass( testBlockC, 'test-class-c', 'test-class' );
     expect( testBlockC.className === '' ).toBe( true );
-  }
-  );
+  } );
 
   it( 'should correctly toggle classes', () => {
     expect( testBlockA.className.indexOf( 'test-class-a' ) > -1 )
@@ -86,6 +82,5 @@ describe( 'dom-class-list', () => {
     classList.toggleClass( testBlockC, 'test-class-c', true );
     expect( testBlockC.className === 'test-class-a test-class-c' )
       .toBe( true );
-  }
-  );
+  } );
 } );

--- a/test/unit-test/src/cf-atomic-component/src/utilities/dom-closest-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/dom-closest-spec.js
@@ -43,23 +43,20 @@ describe( 'dom-closest', () => {
     expect( element === null ).toBe( true );
     element = domClosest( testBlockA, 'div.test' );
     expect( element === null ).toBe( true );
-  }
-  );
+  } );
 
   it( 'should return the correct parent node', () => {
     let element = domClosest( testBlockD, 'section' );
     expect( element === testBlockA ).toBe( true );
     element = domClosest( testBlockC, 'section > div' );
     expect( element === testBlockB ).toBe( true );
-  }
-  );
+  } );
 
   it( 'should use the native closest method if it exists', () => {
     const spy = testBlockD.closest = jest.fn();
     domClosest( testBlockD, 'section' );
     expect( spy ).toHaveBeenCalled();
-  }
-  );
+  } );
 
   it( 'should use the correct matches method', () => {
     const spy = jest.fn();
@@ -80,6 +77,5 @@ describe( 'dom-closest', () => {
     testBlockD.msMatchesSelector = spy;
     domClosest( testBlockD, 'section' );
     expect( spy ).toHaveBeenCalled();
-  }
-  );
+  } );
 } );

--- a/test/unit-test/src/cf-atomic-component/src/utilities/on-ready-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/utilities/on-ready-spec.js
@@ -61,8 +61,7 @@ describe( 'on-ready', function() {
         expect( _readyFunctions ).toBeInstanceOf( Object );
         expect( _readyFunctions.length ).toBe( 0 );
       } );
-  }
-  );
+  } );
 
   it( 'should add a function to the saved array but not trigger it' +
       'if state is loading', () => {
@@ -84,8 +83,7 @@ describe( 'on-ready', function() {
         expect( _readyFunctions ).toBeInstanceOf( Object );
         expect( _readyFunctions.length ).toBe( 2 );
       } );
-  }
-  );
+  } );
 
   it( 'should run the function if the page readyState has already completed',
     () => {


### PR DESCRIPTION
## Removals

- Remove `use strict` from modules.
- Remove extra whitespace in code comments.

## Changes

- Nest test functions consistently.
