### PR TITLE
Remove the cues when JS is disabled or the component does not finish initializing.

### DIFF
--- a/src/cf-expandables/src/cf-expandables.less
+++ b/src/cf-expandables/src/cf-expandables.less
@@ -57,18 +57,18 @@
             outline-offset: 1px;
         }
 
-        &__expanded .o-expandable_cue-open {
+        .o-expandable_cue-close,
+        .o-expandable_cue-open {
             display: none;
         }
 
-        &__collapsed .o-expandable_cue-close {
-            display: none;
+        &__expanded .o-expandable_cue-close {
+            display: block;
         }
 
-        .lt-ie9 & .o-expandable_cue {
-            display: none;
+        &__collapsed .o-expandable_cue-open {
+            display: block;
         }
-
     }
 
     &_content {


### PR DESCRIPTION
Currently both cues are shown when JS is not available or the component does not finish initializing. Hiding them by default and then swapping the display none for block fixes this issue.

## Additions

- Added default style to hide cues.

## Changes

- Swapped display none for display block and inverted the modifiers for the cues.

## Testing

1. Follow the [testing locally instructions](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally)
1. Run `gulp build` && `npm start`
1. Navigate to `http://localhost:3000/components/cf-expandables/#default-state`
1. Turn off JS in the inspector, it should show no cues, not both cues.

## Screenshots

__Before__

<img width="872" alt="screen shot 2018-07-18 at 12 06 03 pm" src="https://user-images.githubusercontent.com/1280430/42896683-541d2634-8a83-11e8-824a-91bfb852b0cc.png">

__After__

<img width="878" alt="screen shot 2018-07-18 at 12 03 21 pm" src="https://user-images.githubusercontent.com/1280430/42896697-61004fc0-8a83-11e8-85e7-8d32fda4b49d.png">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
