### PR TITLE
Replace first-child selector with first-of-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-expandables:** [PATCH] Replace selector to add top border to first expandable in a group
 
 ### Removed
 -

--- a/src/cf-expandables/src/cf-expandables.less
+++ b/src/cf-expandables/src/cf-expandables.less
@@ -187,7 +187,7 @@
         .o-expandable__padded {
             border-bottom: 1px solid @expandable__border;
 
-            &:first-child {
+            &:first-of-type {
                 border-top: 1px solid @expandable__border;
             }
         }

--- a/src/cf-expandables/usage.md
+++ b/src/cf-expandables/usage.md
@@ -42,7 +42,6 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
 
-
 ```
 // .o-expandable
 @expandable-focus:              @black;
@@ -53,16 +52,9 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 // .o-expandable_link
 @expandable_link-text:          @pacific;
 
-// .o-expandable__padded
-@expandable__padded-bg:         @gray-10;
-@expandable__padded-bg-hover:   @gray-20;
-@expandable__padded-divider:    @gray-40;
-
-// .o-expandable-group
-@expandable-group_header-text:  @gray;
-@expandable-group_header-bg:    @gray-10;
-@expandable-group-bg:           @white;
-@expandable-group-divider:      @gray-80;
+// .o-expandable modifiers
+@expandable__background:        @gray-5;
+@expandable__border:            @gray-40;
 ```
 
 ### Sizing variables
@@ -92,14 +84,35 @@ to the `.o-expandable_content` block.
 
 ### Padded
 
-Adds `padding` and a `background` color to `.o-expandable_header` and
-`.o-expandable_content`.
+Adds `padding` to `.o-expandable_header` and `.o-expandable_content`.
 
 In addition to using the `.o-expandable__padded` modifier you also need to make
 sure you are using `.o-expandable_header`.
 
 ```
 .o-expandable__padded
+```
+
+### Background
+
+Adds `background` color to `.o-expandable_header` and `.o-expandable_content`.
+
+In addition to using the `.o-expandable__background` modifier you also need to make
+sure you are using `.o-expandable_header`.
+
+```
+.o-expandable__background
+```
+
+### Border
+
+Adds 1px `border` to `.o-expandable_header` and `.o-expandable_content`.
+
+In addition to using the `.o-expandable__border` modifier you also need to make
+sure you are using `.o-expandable_header`.
+
+```
+.o-expandable__border
 ```
 
 ### Spaced header


### PR DESCRIPTION
When an expandable group contains a descriptive heading prior to the
expandables, the first-child is the heading rather than the first
expandable resulting in a missing top border on the first expandable.
Also snuck in a doc change that should have gone out with v6.0.0, whoops
:D

## Changes

- Convert selector for the top border so it works with content previous to the expandables.

## Testing

1. We don't use this pattern in the docs, I'd be open to updating the docs in the future though.

## Screenshots

__Before__
<img width="669" alt="screen shot 2018-07-19 at 3 22 06 pm" src="https://user-images.githubusercontent.com/1280430/42968292-7f8218e4-8b68-11e8-8772-61b0f754763a.png">

__After__
<img width="653" alt="screen shot 2018-07-19 at 3 28 38 pm" src="https://user-images.githubusercontent.com/1280430/42968299-830a6b24-8b68-11e8-8378-9eab0708ddfb.png">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Internet Explorer 8, 9, 10, and 11 (first-of-type doesn't work in old IE)
- [x] Edge
- [x] iOS Safari
- [x] Chrome for Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
