### PR TITLE
Fix remaining warnings in lint:scripts

### DIFF
--- a/src/cf-atomic-component/src/components/AtomicComponent.js
+++ b/src/cf-atomic-component/src/components/AtomicComponent.js
@@ -193,11 +193,14 @@ assign( AtomicComponent.prototype, Events, classList, {
     this.undelegateEvents();
     this._delegate = new Delegate( this.element );
     for ( key in events ) {
-      method = events[key];
-      if ( isFunction( this[method] ) ) method = this[method];
-      if ( !method ) continue;
-      match = key.match( delegateEventSplitter );
-      this.delegate( match[1], match[2], bind( method, this ) );
+      if ( {}.hasOwnProperty.call( events, key ) ) {
+        method = events[key];
+        if ( isFunction( this[method] ) ) method = this[method];
+        if ( method ) {
+          match = key.match( delegateEventSplitter );
+          this.delegate( match[1], match[2], bind( method, this ) );
+        }
+      }
     }
     this.trigger( 'component:bound' );
 

--- a/src/cf-tables/src/TableSortable.js
+++ b/src/cf-tables/src/TableSortable.js
@@ -148,6 +148,8 @@ function updateTableDom() {
   return tableBody;
 }
 
+// TODO Fix complexity issue
+/* eslint-disable complexity */
 /**
  * Function used to create a function for sorting table data.
  * Passed to Array.sort method.
@@ -186,6 +188,7 @@ function tableDataSorter( direction, sortType ) {
     return order;
   };
 }
+/* eslint-enable complexity */
 
 /**
  * Function used as callback for the sortable click event.


### PR DESCRIPTION
(Except for complexity TODOs)

Didn't get this added to #838 in time.

## Changes

- Linting fixes

## Testing

1. Pull branch
1. `gulp lint:scripts` should return the following output:

   ![screen shot 2018-07-25 at 12 22 44](https://user-images.githubusercontent.com/1044670/43213758-6b663132-9005-11e8-9905-a4f1fc7ee9b8.png)
1. `gulp` should pass

## Todos

- Figure out how to test that the changes to `AtomicComponent.js` are not harmful.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: