### PR TITLE
Add visually hidden utility for small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-core:** [MINOR] Added `u-visually-hidden-on-mobile` utility
 
 ### Changed
--
+- **cf-expandables:** [PATCH] Updated expandable docs to use new visually hidden utility
 
 ### Removed
 -

--- a/src/cf-core/src/cf-utilities.less
+++ b/src/cf-core/src/cf-utilities.less
@@ -44,6 +44,30 @@
     clip: rect(0 0 0 0);
 }
 
+.u-visually-hidden-on-mobile {
+    .respond-to-max( @bp-xs-max, {
+        .u-visually-hidden();
+    } );
+}
+
+//
+// Width-specific display
+//
+
+.u-hide-on-mobile {
+    .respond-to-max( @bp-xs-max {
+        display: none;
+    } );
+}
+
+.u-show-on-mobile {
+    display: none;
+
+    .respond-to-max( @bp-xs-max {
+        display: block;
+    } );
+}
+
 //
 // Hide an element.
 //
@@ -240,24 +264,6 @@
 .u-w25pct  { width: 25%; }
 .u-w66pct  { width: unit( ( 2 / 3 ) * 100, % ); }
 .u-w33pct  { width: unit( ( 1 / 3 ) * 100, % ); }
-
-//
-// Width-specific display
-//
-
-.u-hide-on-mobile {
-    .respond-to-max( @bp-xs-max {
-        display: none;
-    } );
-}
-
-.u-show-on-mobile {
-    display: none;
-
-    .respond-to-max( @bp-xs-max {
-        display: block;
-    } );
-}
 
 //
 // Small text utility

--- a/src/cf-expandables/src/cf-expandables.less
+++ b/src/cf-expandables/src/cf-expandables.less
@@ -127,8 +127,11 @@
             padding-bottom: unit( 15px / @base-font-size-px, em );
         }
 
+
+        // TODO: Convert float layout to flexbox
         &-left {
             float: left;
+            width: 85%;
         }
 
         &-right {

--- a/src/cf-expandables/usage.md
+++ b/src/cf-expandables/usage.md
@@ -191,11 +191,11 @@ The following combination is our recommended go-to expandable pattern.
         </h3>
         <span class="o-expandable_header-right o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
-                Show
+                <span class="u-visually-hidden-on-mobile">Show</span>
                 {% include icons/plus-round.svg %}
             </span>
             <span class="o-expandable_cue o-expandable_cue-close">
-                Hide
+                <span class="u-visually-hidden-on-mobile">Hide</span>
                 {% include icons/minus-round.svg %}
             </span>
         </span>
@@ -223,11 +223,11 @@ The following combination is our recommended go-to expandable pattern.
         </h3>
         <span class="o-expandable_header-right o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
-                Show
+                <span class="u-visually-hidden-on-mobile">Show</span>
                 {% raw %}{% include icons/plus-round.svg %}{% endraw %}
             </span>
             <span class="o-expandable_cue o-expandable_cue-close">
-                Hide
+                <span class="u-visually-hidden-on-mobile">Hide</span>
                 {% raw %}{% include icons/minus-round.svg %}{% endraw %}
             </span>
         </span>
@@ -257,11 +257,11 @@ The following combination is our recommended go-to expandable pattern.
         </h3>
         <span class="o-expandable_header-right o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
-                Show
+                <span class="u-visually-hidden-on-mobile">Show</span>
                 {% include icons/plus-round.svg %}
             </span>
             <span class="o-expandable_cue o-expandable_cue-close">
-                Hide
+                <span class="u-visually-hidden-on-mobile">Hide</span>
                 {% include icons/minus-round.svg %}
             </span>
         </span>
@@ -289,11 +289,11 @@ The following combination is our recommended go-to expandable pattern.
         </h3>
         <span class="o-expandable_header-right o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
-                Show
+                <span class="u-visually-hidden-on-mobile">Show</span>
                 {% raw %}{% include icons/plus-round.svg %}{% endraw %}
             </span>
             <span class="o-expandable_cue o-expandable_cue-close">
-                Hide
+                <span class="u-visually-hidden-on-mobile">Hide</span>
                 {% raw %}{% include icons/minus-round.svg %}{% endraw %}
             </span>
         </span>
@@ -320,10 +320,10 @@ In this barebones example there are no visual styles.
 <div class="o-expandable">
     <button class="o-expandable_target" title="Expand content">
         <span class="o-expandable_cue o-expandable_cue-open">
-            Show
+            <span class="u-visually-hidden-on-mobile">Show</span>
         </span>
         <span class="o-expandable_cue o-expandable_cue-close">
-            Hide
+            <span class="u-visually-hidden-on-mobile">Hide</span>
         </span>
     </button>
     <div class="o-expandable_content">
@@ -341,10 +341,10 @@ In this barebones example there are no visual styles.
 <div class="o-expandable">
     <button class="o-expandable_target" title="Expand content">
         <span class="o-expandable_cue o-expandable_cue-open">
-            Show
+            <span class="u-visually-hidden-on-mobile">Show</span>
         </span>
         <span class="o-expandable_cue o-expandable_cue-close">
-            Hide
+            <span class="u-visually-hidden-on-mobile">Hide</span>
         </span>
     </button>
     <div class="o-expandable_content">
@@ -371,11 +371,11 @@ In this barebones example there are no visual styles.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -398,11 +398,11 @@ In this barebones example there are no visual styles.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -425,11 +425,11 @@ In this barebones example there are no visual styles.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -456,11 +456,11 @@ In this barebones example there are no visual styles.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -483,11 +483,11 @@ In this barebones example there are no visual styles.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -510,11 +510,11 @@ In this barebones example there are no visual styles.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -547,11 +547,11 @@ to activate the accordion mode.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -574,11 +574,11 @@ to activate the accordion mode.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -601,11 +601,11 @@ to activate the accordion mode.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -632,11 +632,11 @@ to activate the accordion mode.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -659,11 +659,11 @@ to activate the accordion mode.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -686,11 +686,11 @@ to activate the accordion mode.
             </h3>
             <span class="o-expandable_header-right o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
-                    Show
+                    <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
-                    Hide
+                    <span class="u-visually-hidden-on-mobile">Hide</span>
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>


### PR DESCRIPTION
When hiding text paired with an icon, the text should continue to be read aloud by screen readers. Adding a utility to extend the existing visually hidden utility and scoping it to small screens resolves this need.

## Additions

- Added `u-visually-hidden-on-mobile` utility

## Changes

- Updated expandable to limit width of header-left to avoid pushing the label to the next line
- Updated expandable docs to use new visually hidden utility

## Testing

1. Follow the [testing locally instructions](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally)
1. Run `gulp build` && `npm start`
1. Navigate to http://localhost:3000/components/cf-expandables/
1. View the first default expandable, it should stop the cue from breaking to the next line and the cue text should be hidden on x-small widths.

## Screenshots

<img width="483" alt="screen shot 2018-08-01 at 9 09 46 am" src="https://user-images.githubusercontent.com/1280430/43526787-a3c9ae90-956a-11e8-9fc1-04d89eb08e19.png">

<img width="577" alt="screen shot 2018-08-01 at 9 09 53 am" src="https://user-images.githubusercontent.com/1280430/43526789-a5c7db4a-956a-11e8-8de7-61bd22e19229.png">

## Todos

- Convert the header left/right to use flexbox for layout.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
