### PR TITLE
Add breakpoint JS and move Less breakpoint vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ## Unreleased
 
 ### Added
--
+- **cf-core:** [MINOR] Add JavaScript breakpoint variables.
 
 ### Changed
--
+- **cf-core:** [MINOR] Move less breakpoint variables to their own file.
 
 ### Removed
 -

--- a/src/cf-core/src/cf-core.less
+++ b/src/cf-core/src/cf-core.less
@@ -6,6 +6,7 @@
 @import (less) '../../normalize-css/normalize.css';
 @import (less) '../../normalize-legacy-addon/normalize-legacy-addon.css';
 @import (less) 'cf-brand-colors.less';
+@import (less) 'cf-vars-breakpoints.less';
 @import (less) 'cf-vars.less';
 @import (less) 'cf-media-queries.less';
 @import (less) 'cf-utilities.less';

--- a/src/cf-core/src/cf-vars-breakpoints.js
+++ b/src/cf-core/src/cf-vars-breakpoints.js
@@ -1,0 +1,29 @@
+/* ==========================================================================
+   Capital Framework
+   Breakpoint JavaScript variables.
+   Matched to values for use in JavaScript matched
+   to CSS breakpoints in cf-vars-breakpoints.less
+   All values are pixel based.
+   ========================================================================== */
+
+module.exports = {
+  bpXS: {
+    min: 0,
+    max: 600
+  },
+  bpSM: {
+    min: 601,
+    max: 900
+  },
+  bpMED: {
+    min: 901,
+    max: 1020
+  },
+  bpLG: {
+    min: 1021,
+    max: 1200
+  },
+  bpXL: {
+    min: 1201
+  }
+};

--- a/src/cf-core/src/cf-vars-breakpoints.js
+++ b/src/cf-core/src/cf-vars-breakpoints.js
@@ -1,9 +1,10 @@
 /* ==========================================================================
    Capital Framework
    Breakpoint JavaScript variables.
-   Matched to values for use in JavaScript matched
-   to CSS breakpoints in cf-vars-breakpoints.less
    All values are pixel based.
+
+   NOTE: If any of the values in this file are adjusted,
+         they need to be adjusted in cf-vars-breakpoints.less as well.
    ========================================================================== */
 
 module.exports = {

--- a/src/cf-core/src/cf-vars-breakpoints.less
+++ b/src/cf-core/src/cf-vars-breakpoints.less
@@ -1,6 +1,9 @@
 /* ==========================================================================
    Capital Framework
    Breakpoint Less variables.
+
+   NOTE: If any of the values in this file are adjusted,
+         they need to be adjusted in cf-vars-breakpoints.js as well.
    ========================================================================== */
 
 @bp-xs-max:  600px;

--- a/src/cf-core/src/cf-vars-breakpoints.less
+++ b/src/cf-core/src/cf-vars-breakpoints.less
@@ -1,0 +1,13 @@
+/* ==========================================================================
+   Capital Framework
+   Breakpoint Less variables.
+   ========================================================================== */
+
+@bp-xs-max:  600px;
+@bp-sm-min:  @bp-xs-max + 1px;
+@bp-sm-max:  900px;
+@bp-med-min: @bp-sm-max + 1px;
+@bp-med-max: 1020px;
+@bp-lg-min:  @bp-med-max + 1px;
+@bp-lg-max:  1230px;
+@bp-xl-min:  @bp-lg-max + 1px;

--- a/src/cf-core/src/cf-vars.less
+++ b/src/cf-core/src/cf-vars.less
@@ -55,18 +55,6 @@
 @size-code:              13px; // Custom size only for Mono code blocks
 
 
-// Breakpoint variables
-
-@bp-xs-max:              600px;
-@bp-sm-min:              @bp-xs-max + 1px;
-@bp-sm-max:              900px;
-@bp-med-min:             @bp-sm-max + 1px;
-@bp-med-max:             1020px;
-@bp-lg-min:              @bp-med-max + 1px;
-@bp-lg-max:              1230px;
-@bp-xl-min:              @bp-lg-max + 1px;
-
-
 // Web fonts
 
 @webfont-regular:        Arial;


### PR DESCRIPTION
Address this TODO https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/unprocessed/js/config/breakpoints-config.js#L1 so that JS and Less breakpoint values are stored near each other.

## Additions

- Add JavaScript breakpoint variables.

## Changes

- Move less breakpoint variables to their own file.

## Testing

1. `npm run build` should pass.

## Todo
- Once this is merged and released. References to breakpoints-config.js in cfgov-refresh should be updated to refer to cf-vars-breakpoints.js instead.