### PR TITLE
Fixed missing commas in cf-utilities media queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - **cf-core:** [MINOR] Move less breakpoint variables to their own file.
-- **cf-core:** [MINOR] Fixed missing comma in cf-utilities media queries.
+- **cf-core:** [PATCH] Fixed missing comma in cf-utilities media queries.
 
 ### Removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - **cf-core:** [MINOR] Move less breakpoint variables to their own file.
+- **cf-core:** [MINOR] Fixed missing comma in cf-utilities media queries.
 
 ### Removed
 -

--- a/src/cf-core/src/cf-utilities.less
+++ b/src/cf-core/src/cf-utilities.less
@@ -55,7 +55,7 @@
 //
 
 .u-hide-on-mobile {
-    .respond-to-max( @bp-xs-max {
+    .respond-to-max( @bp-xs-max, {
         display: none;
     } );
 }
@@ -63,7 +63,7 @@
 .u-show-on-mobile {
     display: none;
 
-    .respond-to-max( @bp-xs-max {
+    .respond-to-max( @bp-xs-max, {
         display: block;
     } );
 }


### PR DESCRIPTION
https://github.com/cfpb/capital-framework/commit/0f58d118a45c1f8f1eca4920eb453870ae31f093#diff-52db82dd2cf91af4df8a9ee2440b5086R66 forgot the comma on two media queries.

## Changes

- Adds missing commas in argument list to two calls to `respond-to-max` utilities.

## Testing

1. Not sure how to test if this didn't come up in the docs originally. It's showing up in a project using cf-core@4.7.0.
