### PR TITLE
Mock child process methods in script unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Changed
 - **cf-core:** [MINOR] Move less breakpoint variables to their own file.
 - **cf-core:** [PATCH] Fixed missing comma in cf-utilities media queries.
+- **capital-framework:** [PATCH] Mock child process methods in script unit tests to prevent erroneous package publishing.
 
 ### Removed
 -

--- a/test/unit-test/scripts/npm/prepublish/lib/build-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/build-spec.js
@@ -7,7 +7,7 @@ let execStub;
 
 describe( 'build', () => {
   beforeEach( () => {
-    execStub = jest.spyOn( childProcess, 'exec' );
+    execStub = jest.spyOn( childProcess, 'exec' ).mockImplementation();
   } );
 
   afterEach( () => {

--- a/test/unit-test/scripts/npm/prepublish/lib/changelog-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/changelog-spec.js
@@ -15,7 +15,7 @@ const changelogExpected = fs.readFileSync( changelogExpectPath, 'utf8' );
 describe( 'changelog', () => {
   beforeEach( () => {
     fs.writeFile = jest.fn();
-    writeStub = jest.spyOn( fs, 'writeFile' );
+    writeStub = jest.spyOn( fs, 'writeFile' ).mockImplementation();
   } );
 
   afterEach( () => {

--- a/test/unit-test/scripts/npm/prepublish/lib/confirm-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/confirm-spec.js
@@ -26,7 +26,7 @@ describe( 'confirm', () => {
   } );
 
   it( 'should continue if we’re in a CLI environment', () => {
-    const processSpy = jest.spyOn( process, 'exit' );
+    const processSpy = jest.spyOn( process, 'exit' ).mockImplementation();
     process.env.CONTINUOUS_INTEGRATION = true;
     return util.confirm( opts ).then( () => {
       expect( processSpy ).not.toHaveBeenCalledWith( 1 );

--- a/test/unit-test/scripts/npm/prepublish/lib/git-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/git-spec.js
@@ -15,7 +15,7 @@ let execStub;
 describe( 'checkoutMaster', () => {
   beforeEach( () => {
     childProcess.exec = jest.fn();
-    execStub = jest.spyOn( childProcess, 'exec' );
+    execStub = jest.spyOn( childProcess, 'exec' ).mockImplementation();
   } );
 
   afterEach( () => {
@@ -32,7 +32,7 @@ describe( 'checkoutMaster', () => {
 describe( 'checkBranch', () => {
   beforeEach( () => {
     childProcess.exec = jest.fn();
-    execStub = jest.spyOn( childProcess, 'exec' );
+    execStub = jest.spyOn( childProcess, 'exec' ).mockImplementation();
   } );
 
   afterEach( () => {
@@ -49,7 +49,7 @@ describe( 'checkBranch', () => {
 describe( 'commit', () => {
   beforeEach( () => {
     childProcess.exec = jest.fn();
-    execStub = jest.spyOn( childProcess, 'exec' );
+    execStub = jest.spyOn( childProcess, 'exec' ).mockImplementation();
   } );
 
   afterEach( () => {
@@ -74,7 +74,7 @@ describe( 'commit', () => {
 describe( 'tag', () => {
   beforeEach( () => {
     childProcess.exec = jest.fn();
-    execStub = jest.spyOn( childProcess, 'exec' );
+    execStub = jest.spyOn( childProcess, 'exec' ).mockImplementation();
   } );
 
   afterEach( () => {
@@ -91,7 +91,7 @@ describe( 'tag', () => {
 describe( 'push', () => {
   beforeEach( () => {
     childProcess.exec = jest.fn();
-    execStub = jest.spyOn( childProcess, 'exec' );
+    execStub = jest.spyOn( childProcess, 'exec' ).mockImplementation();
   } );
 
   afterEach( () => {

--- a/test/unit-test/scripts/npm/prepublish/lib/git-token-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/git-token-spec.js
@@ -16,7 +16,7 @@ let execStub;
 describe( 'push', () => {
   beforeEach( () => {
     childProcess.exec = jest.fn();
-    execStub = jest.spyOn( childProcess, 'exec' );
+    execStub = jest.spyOn( childProcess, 'exec' ).mockImplementation();
   } );
 
   afterEach( () => {

--- a/test/unit-test/scripts/npm/prepublish/lib/gitStatus-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/gitStatus-spec.js
@@ -7,7 +7,7 @@ let execStub;
 
 describe( 'gitStatus', () => {
   beforeEach( () => {
-    execStub = jest.spyOn( childProcess, 'exec' );
+    execStub = jest.spyOn( childProcess, 'exec' ).mockImplementation();
   } );
 
   afterEach( () => {

--- a/test/unit-test/scripts/npm/prepublish/lib/print-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/print-spec.js
@@ -9,7 +9,7 @@ let consoleStub;
 
 describe( 'print', () => {
   beforeEach( () => {
-    consoleStub = jest.spyOn( console, 'log' );
+    consoleStub = jest.spyOn( console, 'log' ).mockImplementation();
   } );
 
   afterEach( () => {

--- a/test/unit-test/scripts/npm/prepublish/lib/publish-spec.js
+++ b/test/unit-test/scripts/npm/prepublish/lib/publish-spec.js
@@ -7,7 +7,7 @@ let execStub;
 
 describe( 'publish', () => {
   beforeEach( () => {
-    execStub = jest.spyOn( childProcess, 'exec' );
+    execStub = jest.spyOn( childProcess, 'exec' ).mockImplementation();
   } );
 
   afterEach( () => {


### PR DESCRIPTION
The strange cf-core phantom publishing was caused by the [publish-spec.js](https://github.com/cfpb/capital-framework/blob/d264c1fb245556847d6b116780d96a86a8bd4c57/test/unit-test/scripts/npm/prepublish/lib/publish-spec.js#L17-L24)
file executing the publishing script in Travis as part of the normal
`npm test` command.

Jest spies are unconventional in that they also call the relevant
function, see link below.

> Note: By default, jest.spyOn also calls the spied method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use jest.spyOn(object, methodName).mockImplementation(() => customImplementation) or object[methodName] = jest.fn(() => customImplementation);

https://jestjs.io/docs/en/jest-object#jestspyonobject-methodname
