### PR TITLE
Replace scrollHeight with children height in ExpandableTransition.expand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-expandables:** [PATCH] Replace scrollHeight with children height in ExpandableTransition.expand
 
 ### Removed
 -

--- a/src/cf-expandables/src/ExpandableTransition.js
+++ b/src/cf-expandables/src/ExpandableTransition.js
@@ -98,8 +98,14 @@ function ExpandableTransition( element ) {
   function expand() {
     this.dispatchEvent( 'expandBegin', { target: this } );
 
-    if ( !previousHeight || element.scrollHeight > previousHeight ) {
-      previousHeight = element.scrollHeight;
+    let childrenHeight = 0;
+    for ( const child of element.children ) {
+      childrenHeight += child.scrollHeight;
+    }
+
+    if ( !previousHeight || childrenHeight !== previousHeight ) {
+      // Magic number of 30 accounts for vertical padding
+      previousHeight = childrenHeight + 30;
     }
 
     element.style.maxHeight = previousHeight + 'px';

--- a/src/cf-expandables/src/ExpandableTransition.js
+++ b/src/cf-expandables/src/ExpandableTransition.js
@@ -99,9 +99,10 @@ function ExpandableTransition( element ) {
     this.dispatchEvent( 'expandBegin', { target: this } );
 
     let childrenHeight = 0;
-    for ( const child of element.children ) {
+
+    Array.prototype.forEach.call( element.children, function( child ) {
       childrenHeight += child.scrollHeight;
-    }
+    } );
 
     if ( !previousHeight || childrenHeight !== previousHeight ) {
       // Magic number of 30 accounts for vertical padding


### PR DESCRIPTION
The purpose of this is to enable expandable heights to be recalculated while open to be _shorter_. Using the previous `scrollHeight` method, open expandables can call `expand` to _grow_ if their contents have changed, but if their contents have shrunk, `scrollHeight` still returns the rendered height from when it was at its maximum.

This is necessary for the correct height adjustments as the multiselect filters are used within a Filterable List Control expandable in cfgov-refresh (e.g., on the [Blog](https://www.consumerfinance.gov/about-us/blog/)).

## Changes

- **cf-expandables:** [PATCH] Replace `scrollHeight` with children height in `ExpandableTransition.expand`

## Testing

- To test that this doesn't negatively impact basic expandables, follow the [local testing instructions](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-in-the-documentation-site) and look at the Expandables page in the docs site.
- `gulp test`

## Todos

- Open the PR in cfgov-refresh to test this on Filterable List Controls.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 8, 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [x] Chrome for Android
