### PR TITLE
Revert "Replace scrollHeight with children height in ExpandableTransition.expand"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
-- **cf-expandables:** [PATCH] Replace scrollHeight with children height in ExpandableTransition.expand
+-
 
 ### Removed
 -

--- a/src/cf-expandables/src/ExpandableTransition.js
+++ b/src/cf-expandables/src/ExpandableTransition.js
@@ -98,15 +98,8 @@ function ExpandableTransition( element ) {
   function expand() {
     this.dispatchEvent( 'expandBegin', { target: this } );
 
-    let childrenHeight = 0;
-
-    Array.prototype.forEach.call( element.children, function( child ) {
-      childrenHeight += child.scrollHeight;
-    } );
-
-    if ( !previousHeight || childrenHeight !== previousHeight ) {
-      // Magic number of 30 accounts for vertical padding
-      previousHeight = childrenHeight + 30;
+    if ( !previousHeight || element.scrollHeight > previousHeight ) {
+      previousHeight = element.scrollHeight;
     }
 
     element.style.maxHeight = previousHeight + 'px';


### PR DESCRIPTION
Reverts cfpb/capital-framework#861

I conflated things and thought that this was needed, but it was only needed if we switched from `max-height` to `height`, which was our original thought for what the problem was with Filterable List Controls, but it turned out not to be the problem at all. Sorry for the noise.