### PR TITLE
Fix contrast of button hover colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - **cf-pagination:** [PATCH] Fixed color contrast for "Go" link on gray background for cf-pagination module.
+- **cf-buttons:** [PATCH] Update button hover and active colors for accessible contrast.
 
 ### Removed
 -

--- a/src/cf-buttons/src/cf-buttons.less
+++ b/src/cf-buttons/src/cf-buttons.less
@@ -13,7 +13,7 @@
 @btn-text:                      @white;
 @btn-bg:                        @pacific;
 @btn-bg-hover:                  @dark-pacific;
-@btn-bg-active:                 @dark-gray;
+@btn-bg-active:                 @navy;
 
 // .btn__secondary
 @btn__secondary-text:           @white;

--- a/src/cf-buttons/src/cf-buttons.less
+++ b/src/cf-buttons/src/cf-buttons.less
@@ -12,8 +12,8 @@
 // .btn
 @btn-text:                      @white;
 @btn-bg:                        @pacific;
-@btn-bg-hover:                  @pacific-80;
-@btn-bg-active:                 @navy-80;
+@btn-bg-hover:                  @dark-pacific;
+@btn-bg-active:                 @dark-gray;
 
 // .btn__secondary
 @btn__secondary-text:           @white;
@@ -24,8 +24,8 @@
 // .btn__warning
 @btn__warning-text:             @white;
 @btn__warning-bg:               @red;
-@btn__warning-bg-hover:         @red-80;
-@btn__warning-bg-active:        @dark-red;
+@btn__warning-bg-hover:         @dark-red;
+@btn__warning-bg-active:        @dark-gray;
 
 // .btn__disabled
 @btn__disabled-text:            @gray;

--- a/src/cf-buttons/src/cf-buttons.less
+++ b/src/cf-buttons/src/cf-buttons.less
@@ -18,8 +18,8 @@
 // .btn__secondary
 @btn__secondary-text:           @white;
 @btn__secondary-bg:             @gray;
-@btn__secondary-bg-hover:       @gray-80;
-@btn__secondary-bg-active:      @dark-gray;
+@btn__secondary-bg-hover:       @dark-gray;
+@btn__secondary-bg-active:      @black;
 
 // .btn__warning
 @btn__warning-text:             @white;

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -40,8 +40,8 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 // .btn
 @btn-text:                      @white;
 @btn-bg:                        @pacific;
-@btn-bg-hover:                  @pacific-80;
-@btn-bg-active:                 @navy-80;
+@btn-bg-hover:                  @dark-pacific;
+@btn-bg-active:                 @dark-gray;
 
 // .btn__secondary
 @btn__secondary-text:           @white;
@@ -52,8 +52,8 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 // .btn__warning
 @btn__warning-text:             @white;
 @btn__warning-bg:               @red;
-@btn__warning-bg-hover:         @red-80;
-@btn__warning-bg-active:        @dark-red;
+@btn__warning-bg-hover:         @dark-red;
+@btn__warning-bg-active:        @dark-gray;
 
 // .btn__disabled
 @btn__disabled-text:            @gray;

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -41,7 +41,7 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 @btn-text:                      @white;
 @btn-bg:                        @pacific;
 @btn-bg-hover:                  @dark-pacific;
-@btn-bg-active:                 @dark-gray;
+@btn-bg-active:                 @navy;
 
 // .btn__secondary
 @btn__secondary-text:           @white;

--- a/src/cf-buttons/usage.md
+++ b/src/cf-buttons/usage.md
@@ -46,8 +46,8 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 // .btn__secondary
 @btn__secondary-text:           @white;
 @btn__secondary-bg:             @gray;
-@btn__secondary-bg-hover:       @gray-80;
-@btn__secondary-bg-active:      @dark-gray;
+@btn__secondary-bg-hover:       @dark-gray;
+@btn__secondary-bg-active:      @black;
 
 // .btn__warning
 @btn__warning-text:             @white;


### PR DESCRIPTION
And standardizes all button active states to Dark Gray.

cfpb/design-manual#603

## Changes

- **cf-buttons:** [PATCH] Update button hover and active colors for accessible contrast.

## Testing

1. Follow the [local testing guidelines](https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally) in `CONTRIBUTING.md`.
1. Go to http://localhost:3000/components/cf-buttons/ and hover over the primary and destructive button states and see that they change to the Dark variant of those colors.
1. Click and hold them and confirm that they change to dark gray.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
