### PR TITLE
Allow scoping of DOM query in AtomicComponent.init method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-expandables:** [MINOR] Add getLabelText method.
 
 ### Changed
+- **cf-atomic-component:** [PATCH] Allow scoping of DOM query in
+  AtomicComponent.init method.
 - **capital-framework:** [MINOR] Updates `babel-jest`, `babel-loader`,
   `gulp-less`, `jest`, `jest-cli`, `jest-when`, `jsdom`, `require-dir`,
   and `through2`.

--- a/src/cf-atomic-component/src/components/AtomicComponent.js
+++ b/src/cf-atomic-component/src/components/AtomicComponent.js
@@ -273,7 +273,7 @@ AtomicComponent.extend = function( attributes ) {
   assign( child, AtomicComponent );
 
   if ( attributes.hasOwnProperty( 'ui' ) &&
-  attributes.ui.hasOwnProperty( 'base' ) ) {
+       attributes.ui.hasOwnProperty( 'base' ) ) {
     child.selector = attributes.ui.base;
   }
 
@@ -286,15 +286,17 @@ AtomicComponent.extend = function( attributes ) {
 /**
  * Function used to instantiate all instances of the particular
  * atomic component on a page.
+ * @param {HTMLNode} scope - Where to search for components within.
  *
  * @returns {Array} List of AtomicComponent instances.
  */
-AtomicComponent.init = function() {
-  const elements = document.querySelectorAll( this.selector );
+AtomicComponent.init = function( scope ) {
+  const base = scope || document;
+  const elements = base.querySelectorAll( this.selector );
   const components = [];
   let element;
 
-  for ( let i = 0; i < elements.length; ++i ) {
+  for ( let i = 0, len = elements.length; i < len; i++ ) {
     element = elements[i];
     if ( element.hasAttribute( 'data-bound' ) === false ) {
       components.push( new this( element ) );

--- a/src/cf-expandables/src/ExpandableTransition.js
+++ b/src/cf-expandables/src/ExpandableTransition.js
@@ -17,10 +17,7 @@ const CLASSES = {
  *
  * @classdesc Initializes new ExpandableTransition behavior.
  *
- * @param {HTMLNode} element
- *   DOM element to apply move transition to.
- * @param {Object} classes
- *   An Object of custom classes to override the base classes Object
+ * @param {HTMLNode} element - DOM element to apply move transition to.
  * @returns {ExpandableTransition} An instance.
  */
 function ExpandableTransition( element ) {
@@ -46,7 +43,6 @@ function ExpandableTransition( element ) {
     return this;
   }
 
-  /* istanbul ignore next */
   /**
    * Handle the end of a transition.
    */

--- a/test/unit-test/src/cf-atomic-component/src/components/AtomicComponent-spec.js
+++ b/test/unit-test/src/cf-atomic-component/src/components/AtomicComponent-spec.js
@@ -2,11 +2,16 @@ const srcPath = require( '../src-path' );
 let AtomicComponent = require( srcPath + '/components/AtomicComponent' );
 
 const HTML_SNIPPET = `
-  <div id="test-block-a" class="test-class test-class-a">
-    <div id="test-block-b" class="test-class-b">
-      <div id="test-block-c" class="test-class-c"></div>
-   </div>
-  </div>
+<div id="test-block-a" class="test-class">
+  <div id="test-block-b" class="test-class">
+    <div id="test-block-c" class="test-class"></div>
+ </div>
+</div>
+<div id="test-block-d" class="test-class">
+  <div id="test-block-e" class="test-class">
+    <div id="test-block-f" class="test-class"></div>
+ </div>
+</div>
 `;
 
 describe( 'AtomicComponent', () => {
@@ -58,5 +63,37 @@ describe( 'AtomicComponent', () => {
     const element = document.getElementById( 'test-block-a' );
     const atomicComponent = new AtomicComponent( element );
     expect( atomicComponent.element.hasAttribute( 'data-bound' ) ).toBe( true );
+  } );
+
+  it( 'should initialize all instances in the DOM', () => {
+    const TestComponent = AtomicComponent.extend( {
+      ui: {
+        base: '.test-class'
+      }
+    } );
+
+    const testComponents = TestComponent.init();
+    expect( testComponents.length ).toBe( 6 );
+    expect( testComponents[0].element.id ).toBe( 'test-block-a' );
+    expect( testComponents[1].element.id ).toBe( 'test-block-b' );
+    expect( testComponents[2].element.id ).toBe( 'test-block-c' );
+    expect( testComponents[3].element.id ).toBe( 'test-block-d' );
+    expect( testComponents[4].element.id ).toBe( 'test-block-e' );
+    expect( testComponents[5].element.id ).toBe( 'test-block-f' );
+  } );
+
+  it( 'should initialize scoped instances in the DOM', () => {
+    const TestComponent = AtomicComponent.extend( {
+      ui: {
+        base: '.test-class'
+      }
+    } );
+
+    const testComponents = TestComponent.init(
+      document.querySelector( '#test-block-d' )
+    );
+    expect( testComponents.length ).toBe( 2 );
+    expect( testComponents[0].element.id ).toBe( 'test-block-e' );
+    expect( testComponents[1].element.id ).toBe( 'test-block-f' );
   } );
 } );


### PR DESCRIPTION
## Changes

- Allow scoping of DOM query in AtomicComponent.init method by adding `scope` parameter. Also adds associated tests.
- Removes istanbul ignore code comment for _transitionComplete method. It has greater than 90% coverage, but we should be able to see that's uncovered.

## Testing

1. `gulp test:unit` should pass.
2. You can test this in cfgov-refresh by:
  - Visit https://www.consumerfinance.gov/about-us/newsroom/ and apply some Topic filters and see that the "Apply filters" button gets cropped out of view (issue [GHE]/CFGOV/platform/issues/2981).
  - Run `gulp build`.
  - Copy `tmp/cf-expandables` directory from this branch.
  - Paste it into `cfgov-refresh/node_modules/`, replacing the one that's there.
  - Copy `tmp/cf-atomic-component` and `tmp/cf-core` directories from this branch.
  - Create `cfgov-refresh/node_modules/cf-expandables/node_modules/` and paste atomic-component and core into that.
  - Go into FilterableListControls.js and change line 54 from `const _expandables = Expandable.init();` to `const _expandables = Expandable.init( _dom );`.
  - Run `gulp clean && gulp build`
  - Visit http://localhost:8000/about-us/newsroom/ and see that adding Topic filters adjusts the height of the filter.
