### PR TITLE
Bump cf-atomic-component dependency to `2.1.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
-- **cf-atomic-component:** [PATCH] Fixes issue where leading period was
-  not removed in class name when passed to classList.contains.
-- **cf-tables:** [PATCH] Fixes issue where TableSortable was using
-  classList API incorrectly.
+- **cf-expandables:** [PATCH] Bump cf-atomic-component dependency to `2.1.0`.
+- **cf-tables:** [PATCH] Bump cf-atomic-component dependency to `2.1.0`.
 
 ### Removed
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **cf-tables:** [PATCH] Bump cf-atomic-component dependency to `2.1.0`.
 
 ### Removed
--
+- **cf-expandables:** [PATCH] Remove classlist-polyfill within cf-expandables
+  package.json.
 
 ## 7.5.0 - 2018-12-10
 

--- a/src/cf-expandables/package.json
+++ b/src/cf-expandables/package.json
@@ -10,10 +10,9 @@
     "test": "case $(pwd) in */capital-framework/src/*) cd ../.. && npm test;; esac"
   },
   "dependencies": {
-    "cf-atomic-component": "^1.4.0",
+    "cf-atomic-component": "^2.1.1",
     "cf-core": "^4.0.0",
-    "cf-icons": "^4.0.0",
-    "classlist-polyfill": "1.0.3"
+    "cf-icons": "^4.0.0"
   },
   "keywords": [
     "expandable"

--- a/src/cf-tables/package.json
+++ b/src/cf-tables/package.json
@@ -10,7 +10,7 @@
     "test": "case $(pwd) in */capital-framework/src/*) cd ../.. && npm test;; esac"
   },
   "dependencies": {
-    "cf-atomic-component": "^1.4.0",
+    "cf-atomic-component": "^2.1.1",
     "cf-core": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
## Changes

- **cf-expandables:** Bump cf-atomic-component dependency to `2.1.1`.
- **cf-expandables:** Remove classlist-polyfill within cf-expandables package.json (overlooked in https://github.com/cfpb/capital-framework/pull/874).
- **cf-tables:** Bump cf-atomic-component dependency to `2.1.1`.

## Testing

1. Pull branch and follow https://github.com/cfpb/capital-framework/blob/canary/CONTRIBUTING.md#testing-components-locally
2. Should have no errors on expandables and table demo page.