### PR TITLE
Fix CSS classList logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-atomic-component:** [PATCH] Fixes issue where leading period was
+  not removed in class name when passed to classList.contains.
+- **cf-tables:** [PATCH] Fixes issue where TableSortable was using
+  classList API incorrectly.
 
 ### Removed
 -

--- a/src/cf-atomic-component/src/components/AtomicComponent.js
+++ b/src/cf-atomic-component/src/components/AtomicComponent.js
@@ -57,7 +57,8 @@ assign( AtomicComponent.prototype, Events, {
     }
 
     this.modifiers.forEach( function( modifier ) {
-      if ( this.element.classList.contains( modifier.ui.base ) ) {
+      const modifierClass = modifier.ui.base.substring( 1 );
+      if ( this.element.classList.contains( modifierClass ) ) {
         if ( modifier.initialize ) {
           this.initializers.push( modifier.initialize );
           delete modifier.initialize;

--- a/src/cf-tables/src/TableSortable.js
+++ b/src/cf-tables/src/TableSortable.js
@@ -49,9 +49,12 @@ function initialize() {
   this.bindProperties();
   if ( this.ui.sortButton ) {
     this.sortColumnIndex = this.getColumnIndex();
-    this.sortDirection =
-      this.contains( this.ui.sortButton, this.classes.sortDown ) ?
-        DIRECTIONS.DOWN : DIRECTIONS.UP;
+
+    this.sortDirection = DIRECTIONS.UP;
+    if ( this.ui.sortButton.classList.contains( this.classes.sortDown ) ) {
+      this.sortDirection = DIRECTIONS.DOWN;
+    }
+
     this.updateTable();
   }
 }
@@ -198,7 +201,7 @@ function tableDataSorter( direction, sortType ) {
  */
 function onSortableClick( event ) {
   if ( this.ui.sortButton ) {
-    this.removeClass( this.ui.sortButton, this.sortClass );
+    this.ui.sortButton.classList.remove( this.sortClass );
   }
   if ( this.ui.sortButton === event.target ) {
     this.sortDirection = ~this.sortDirection;
@@ -208,7 +211,7 @@ function onSortableClick( event ) {
     this.sortDirection = DIRECTIONS.UP;
   }
   // The active sort class is changing when the sort direction changes.
-  this.addClass( this.ui.sortButton, this.sortClass );
+  this.ui.sortButton.classList.add( this.sortClass );
   this.updateTable();
 
   return this;


### PR DESCRIPTION
## Changes

- **cf-atomic-component:** Fixes issue where leading period was
  not removed in class name when passed to classList.contains.
- **cf-tables:** Fixes issue where TableSortable was using
  classList API incorrectly.

## Testing

 - Check out gh-pages branch for the docs.
 - Copy tmp/cf-atomic-component from this branch to node_modules of the gh-pages branch. 
 - Run `npm run build && npm start`
 - cf-tables should not have an error in dev console at http://localhost:3000/components/cf-tables/.
