### PR TITLE
Fix const in for value for IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 -
 
 ### Changed
--
+- **cf-atomic-component:** [PATCH] Remove const from for loop for IE11.
 
 ### Removed
 - **cf-atomic-component:** [PATCH] Removes unused data-set utility.

--- a/src/cf-atomic-component/src/utilities/object-assign/index.js
+++ b/src/cf-atomic-component/src/utilities/object-assign/index.js
@@ -30,7 +30,8 @@ function assign( destination ) {
   destination = destination || {};
   for ( let i = 1, len = arguments.length; i < len; i++ ) {
     const source = arguments[i] || {};
-    for ( const key in source ) {
+    let key;
+    for ( key in source ) {
       if ( Object.prototype.hasOwnProperty.call( source, key ) ) {
         const value = source[key];
         if ( _isPlainObject( value ) ) {

--- a/src/cf-atomic-component/src/utilities/transition/BaseTransition.js
+++ b/src/cf-atomic-component/src/utilities/transition/BaseTransition.js
@@ -149,7 +149,8 @@ function BaseTransition( element, classes ) {
    * already been applied to this BaseTransition's target element.
    */
   function _flush() {
-    for ( const prop in _classes ) {
+    let prop;
+    for ( prop in _classes ) {
       if ( _classes.hasOwnProperty( prop ) &&
            _classes[prop] !== _classes.BASE_CLASS &&
            _dom.classList.contains( _classes[prop] ) ) {
@@ -222,7 +223,8 @@ function BaseTransition( element, classes ) {
       transition:       'transitionend'
     };
 
-    for ( const transitionEnd in transitions ) {
+    let transitionEnd;
+    for ( transitionEnd in transitions ) {
       if ( transitions.hasOwnProperty( transitionEnd ) &&
            typeof elem.style[transitionEnd] !== 'undefined' ) {
         transition = transitions[transitionEnd];


### PR DESCRIPTION
Turns out IE11 does not support initialization of `const` within a for loop. This changes the code slightly to change `const` values that are initialized in for loops into `let` values before the loop.

## Changes

- Change `const` value into `let` value for IE11 support.

## Testing

1. Follow local testing instructions.
