### PR TITLE
Fix lerna-changelog command

### DIFF
--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -2,7 +2,7 @@
 
 # Generate a changelog for all PRs after the Lerna migration (git tag v7.7.0)
 # See docs at https://github.com/lerna/lerna-changelog
-lerna-changelog --from v7.7.0 > CHANGELOG.md
+lerna-changelog --from 7.7.0 --next-release-from-metadata > CHANGELOG.md
 
 # Add the pre-Lerna changelog to the bottom of the generated one.
 cat ./scripts/templates/CHANGELOG.legacy.md >> ./CHANGELOG.md


### PR DESCRIPTION
Our git tags are in the format `1.2.3` not `v1.2.3`. Oopsie.

This PR is also being used to test our new changelog process.