### PR TITLE
Clarify release management steps, update release script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,10 +189,11 @@ Once you've completed these steps, file a pull request against `gh-pages`.
 
 ## Release management
 
-After changes have been made to components,
-a FEWD can publish the changes to npm by running the following commands locally:
+Ready to publish changes to npm?
+Ensure you're on `master` and `git pull` to confirm you're up-to-date.
+Then run `yarn run release`.
+Lerna will update the changelog, ask for a new version number, create a git tag,
+push to GitHub and publish to npm.
 
-```sh
-yarn run changelog # This will update the changelog, feel free to manually tweak it afterward
-yarn run publish # This will ask for a version level, create a git tag, push to GitHub and publish to npm
-```
+If you'd like to preview the changelog before publishing anything,
+run `yarn run changelog` and open `CHANGELOG.md`.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "cf-unlink": "lerna exec -- yarn unlink",
     "test": "gulp test",
     "changelog": "./scripts/generate-changelog.sh",
-    "publish": "yarn run build && lerna publish",
+    "release": "yarn run build && lerna publish",
+    "version": "yarn run changelog",
     "process-icon-svgs": "svgo -o packages/cf-icons/src/icons --enable=addClassesToSVGElement --enable=removeStyleElement --enable=removeAttrs --config='{ \"plugins\": [ { \"addClassesToSVGElement\": { \"className\": \"cf-icon-svg\" } }, { \"removeAttrs\": { \"attrs\": [ \"fill\", \"path:class\", \"circle:class\" ] } }, { \"cleanupIDs\": { \"force\": \"true\" } } ] }'"
   },
   "devDependencies": {

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -6,3 +6,6 @@ lerna-changelog --from 7.7.0 --next-release-from-metadata > CHANGELOG.md
 
 # Add the pre-Lerna changelog to the bottom of the generated one.
 cat ./scripts/templates/CHANGELOG.legacy.md >> ./CHANGELOG.md
+
+# Add the modified changelog to the staging area
+git add CHANGELOG.md


### PR DESCRIPTION
Doing some more lerna-changelog testing by giving this one a `breaking` label. Also some tweaks below.

## Changes

- `yarn run publish` -> `yarn run release` to avoid a conflict with the [publish script](https://docs.npmjs.com/misc/scripts)
- Added `version` script to update the changelog immediately after package.json is updated.
- Improved release management docs

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Internet Explorer 8, 9, 10, and 11
- [ ] Edge
- [ ] iOS Safari
- [ ] Chrome for Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
