### PR TITLE
cf-notifications: Set a max-width

### DIFF
--- a/packages/cf-notifications/src/molecules/notification.less
+++ b/packages/cf-notifications/src/molecules/notification.less
@@ -9,6 +9,9 @@
     background: @notification-bg;
     border: 1px solid @notification-border;
 
+    // This magic number makes for line lengths between 85-95 characters.
+    max-width: 41.8em;
+
     .cf-icon-svg {
         position: absolute;
         fill: @notification-icon;


### PR DESCRIPTION
This incorporates the max-width added to a version of the notification via mixing in `m-full-width-text` https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/regulations3k/jinja2/regulations3k/notification.html#L22

## Changes

- Sets a max-width on the notification. 

## Testing

1. Follow the local testing instructions to view the changes in the docs. 

## Screenshots

Before:

![cf-notifications-before](https://user-images.githubusercontent.com/704760/53982881-014c2780-40e4-11e9-85d4-3b0d8d4c1ea3.png)


After:

![notification-after](https://user-images.githubusercontent.com/704760/53982973-36587a00-40e4-11e9-8f34-4564ba863907.png)

