### PR TITLE
Update gh-pages branch to use yarn instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This site is powered by Jekyll a Ruby based static site generator. For front-end
 $ brew install ruby
 $ brew install node
 $ gem install jekyll
-$ npm install --global gulp-cli
+$ yarn install --global gulp-cli
 ```
 
 
@@ -28,13 +28,13 @@ To install the site's dependencies, navigate to the project directory and run:
 
 ```shell
 $ bundle install
-$ npm install
+$ yarn install
 ```
 
 To launch the site, enter:
 
 ```shell
-$ npm start
+$ yarn start
 ```
 
 This will start the Jekyll server and the Gulp watch task. BrowserSync should launch a new browser window displaying the site at http://localhost:3000.

--- a/scripts/npm/link/index.js
+++ b/scripts/npm/link/index.js
@@ -13,7 +13,7 @@ function getDirectories( srcpath ) {
 }
 
 function npmLink( component ) {
-  exec( 'npm link ' + component,
+  exec( 'yarn link ' + component,
     function( err, out ) {
       if ( err instanceof Error ) {
         throw err;

--- a/scripts/npm/unlink/index.js
+++ b/scripts/npm/unlink/index.js
@@ -13,7 +13,7 @@ function getDirectories( srcpath ) {
 }
 
 function npmUnlink( component ) {
-  exec( 'npm unlink ' + component + ' --no-save',
+  exec( 'yarn unlink ' + component + ' --no-save',
     function( err, out ) {
       if ( err instanceof Error ) {
         throw err;


### PR DESCRIPTION
Updates the `gh-pages` README and link scripts to use yarn instead of npm.

## Testing

1. Following the [steps](https://github.com/cfpb/capital-framework/blob/56410659ca010a9a8aee4b701be885d07542ccc1/README.md#installation) in the README should successfully compile and start the site.

## Notes

- Snyk can be ignored because the cf-components don't exist on the `gh-pages` branch.