### PR TITLE
cf-forms: Fix checkbox and radio button grid stuff in IE

### DIFF
--- a/packages/cf-forms/src/molecules/form-fields.less
+++ b/packages/cf-forms/src/molecules/form-fields.less
@@ -11,6 +11,16 @@
     &__checkbox,
     &__radio {
         .a-label {
+            // We need to turn off autoprefixing for the inline-grid because
+            // IE does not handle an inline-grid like other browsers,
+            // leading to an extremely narrow column of text for the label
+            // and the checkbox or radio widget covering the first part of it.
+            // The Autoprefixer ontrol comment below ensures that the following
+            // property is only picked up by browsers with standard support.
+            // The excalamation mark is necessary for Less to preserve the
+            // comment so that Autoprefixer will see it.
+            /*! autoprefixer: ignore next */
+            display: inline-grid;
             // 30px is width of checkbox/radio button plus the needed padding.
             grid-template-columns: unit( 30px / @base-font-size-px, em ) auto;
             vertical-align: top;
@@ -87,25 +97,6 @@
                     }
                 }
             }
-        }
-    }
-
-    /*
-    We need to turn off autoprefixing for the inline-grid because
-    older IE does not handle an inline-grid like other browsers,
-    leading to an extremely narrow column of text for the label.
-    This ensures it's only picked up by browsers with standard support.
-    Also, autoprefixer ignores rules on a per block basis so that is why
-    this is placed in its own block.
-    We need to ignore the duplicate selector for stylelint too.
-     */
-    /* stylelint-disable-next-line no-duplicate-selectors */
-    &__checkbox,
-    &__radio {
-        /* stylelint-disable-next-line no-duplicate-selectors */
-        .a-label {
-            /* autoprefixer: off */
-            display: inline-grid;
         }
     }
 


### PR DESCRIPTION
Autoprefixer was not correctly being skipped for the `display: inline-grid;` property on the labels of our radio buttons and checkboxes. The Less step was removing the [Autoprefixer control comment](https://github.com/postcss/autoprefixer#control-comments), so Autoprefixer didn't know to skip it. Adding the `!` to the comment opening characters tells Less to keep the comment in so Autoprefixer now sees it.

I also switched from the `/* autoprefixer: off */` method, which required that the rule to be skipped lived in its own block, to `/* autoprefixer: ignore next */`, so we can do away with those extra blocks.

## Changes

- **cf-forms:** Switch from `/* autoprefixer: off */` to `/*! autoprefixer: ignore next */` to correctly exclude the radio & checkbox label `display: inline-grid;` rule from Autoprefixer

## Testing

Follow the instructions on https://github.com/cfpb/capital-framework/blob/master/CONTRIBUTING.md and view a page with checkboxes in IE, for example, inside the filter controls expandable on https://www.consumerfinance.gov/about-us/blog/.

## Screenshots

### Before

![Screen Shot 2019-03-28 at 16 48 49](https://user-images.githubusercontent.com/1044670/55191803-7954bd00-5179-11e9-8ba3-ea8174b0cec5.png)

### After

![Screen Shot 2019-03-28 at 16 49 05](https://user-images.githubusercontent.com/1044670/55191807-7e197100-5179-11e9-970d-d1fce220dc5e.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Internet Explorer 9, 10, and 11
- [x] Edge
- [x] iOS Safari
- [x] Chrome for Android