### PR TITLE
Improve the changelog's layout, clarify release steps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,7 @@
 
 ## Checklist
 
+- [ ] PR has been tagged with the type of change it includes (breaking, enhancement, bug, documentation or internal)
 - [ ] PR has an informative and human-readable title
 - [ ] Changes are limited to a single goal (no scope creep)
 - [ ] Code can be automatically merged (no conflicts)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,8 +190,11 @@ Once you've completed these steps, file a pull request against `gh-pages`.
 ## Release management
 
 Ready to publish changes to npm?
-Ensure you're on `master` and `git pull` to confirm you're up-to-date.
-Then run `yarn run release`.
+
+1. Ensure you're on `master` and `git pull` to confirm you're up-to-date.
+1. Export a personal access token called [`GITHUB_AUTH`](https://github.com/lerna/lerna-changelog#github-token).
+1. Run `yarn run release` to start the release.
+
 Lerna will update the changelog, ask for a new version number, create a git tag,
 push to GitHub and publish to npm.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,10 +193,8 @@ Ready to publish changes to npm?
 
 1. Ensure you're on `master` and `git pull` to confirm you're up-to-date.
 1. Export a personal access token called [`GITHUB_AUTH`](https://github.com/lerna/lerna-changelog#github-token).
+1. Run `yarn run changelog` and open `CHANGELOG.md` to see a preview of new changelog entries. We use a [tool](https://github.com/lerna/lerna-changelog#usage) that scans our PRs for specific labels so if you see a PR missing from the changelog, ensure it has been labeled `breaking`, `enhancement`, `bug`, `documentation` or `internal`.
 1. Run `yarn run release` to start the release.
 
 Lerna will update the changelog, ask for a new version number, create a git tag,
 push to GitHub and publish to npm.
-
-If you'd like to preview the changelog before publishing anything,
-run `yarn run changelog` and open `CHANGELOG.md`.

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-# First, back up the current changelog
+# Undo any temporary changelog entries that might have been added if the user
+# recently ran `yarn run changelog`
+git checkout CHANGELOG.md
+
+# Back up the current changelog
 mv CHANGELOG.md /tmp/cf-changelog.md
 
 # Generate the latest changelog entries

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -7,6 +7,9 @@ mv CHANGELOG.md /tmp/cf-changelog.md
 # See docs at https://github.com/lerna/lerna-changelog
 lerna-changelog --next-release-from-metadata > CHANGELOG.md
 
+# Add a new line to keep releases spaced nicely
+echo "\n" >> CHANGELOG.md
+
 # Combine the two
 cat /tmp/cf-changelog.md >> CHANGELOG.md
 


### PR DESCRIPTION
## Changes

- Add's a newline to the changelog generation script so that there are two lines between listed releases.
- Instructs contributors to create a `GITHUB_AUTH` token for lerna-changelog.
- Add notes about correctly tagging PRs with labels for lerna-changelog.