### PR TITLE
Remove git step from changelog generation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,8 @@ Ready to publish changes to npm?
    Pull Requests for specific labels so if you see a PR missing from the changelog,
    ensure it has been labeled `breaking`, `enhancement`, `bug`,
    `documentation` or `internal`.
+1. If you're pleased with the changelog preview,
+   `git checkout CHANGELOG.md` to reset it.
 1. Run `yarn run release` to start the release.
 
 Lerna will update the changelog, ask for a new version number, create a git tag,

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-# Undo any temporary changelog entries that might have been added if the user
-# recently ran `yarn run changelog`
-git checkout CHANGELOG.md
-
 # Back up the current changelog
 mv CHANGELOG.md /tmp/cf-changelog.md
 


### PR DESCRIPTION
The changelog generation script is called at the [`version`](https://docs.npmjs.com/misc/scripts#description) stage of npm's lifecycle (see [package.json](https://github.com/cfpb/capital-framework/blob/master/package.json#L31)). We shouldn't muck with git in the middle of npm's publishing process.

I had added `git checkout CHANGELOG.md` as a courtesy in case the user forgot to reset the CHANGELOG after [previewing it](https://github.com/cfpb/capital-framework/blob/master/CONTRIBUTING.md#release-management). For now, let's remove it and just tell the user to ensure CHANGELOG is clean.

See #902.