### PR TITLE
Properly space expandables' comments

### DIFF
--- a/packages/cf-expandables/src/cf-expandables.less
+++ b/packages/cf-expandables/src/cf-expandables.less
@@ -171,6 +171,7 @@
     //
     // Expandable with a background color modifier
     //
+
     &__background {
         background: @expandable__background;
     }
@@ -178,6 +179,7 @@
     //
     // Expandable with a border modifier
     //
+
     &__border {
         border: 1px solid @expandable__border;
     }


### PR DESCRIPTION
The other comments have spaces. These two did not. This PR is mostly just an excuse to test a change made to our changelog generation script.