### PR TITLE
cf-layout: Fix issues in docs

### DIFF
--- a/docs/_includes/usage/cf-buttons/usage.md
+++ b/docs/_includes/usage/cf-buttons/usage.md
@@ -34,7 +34,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```
 // .btn

--- a/docs/_includes/usage/cf-expandables/usage.md
+++ b/docs/_includes/usage/cf-expandables/usage.md
@@ -41,7 +41,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 
 ```

--- a/docs/_includes/usage/cf-forms/usage.md
+++ b/docs/_includes/usage/cf-forms/usage.md
@@ -47,7 +47,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```less
 // .a-text-input borders

--- a/docs/_includes/usage/cf-layout/usage.md
+++ b/docs/_includes/usage/cf-layout/usage.md
@@ -130,9 +130,6 @@ When using the modifiers described below to create columns,
 the columns will remain stacked for smaller screens and then convert to to
 columns at `801px`.
 
-`.content_line` must come after `.content_hero` (if it exists) but before
-`.content_wrapper`.
-
 _Inline styling is for demonstration purposes only; do not include it in your
 markup._
 
@@ -140,7 +137,6 @@ markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             Main content area
@@ -156,7 +152,6 @@ markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             Main content area

--- a/docs/_includes/usage/cf-layout/usage.md
+++ b/docs/_includes/usage/cf-layout/usage.md
@@ -14,10 +14,7 @@ dependencies of this component.
 
 - [Variables](#variables)
     - [Color variables](#color-variables)
-- [Content layouts](#content-layouts)
-    - [Standard content columns](#standard-content-columns)
-        - [Large gutters modifier](#large-gutters-modifier)
-        - [Content layout column dividers](#content-layout-column-dividers)
+- [Standard content formats](#standard-content-formats)
     - [Content line](#content-line)
     - [Main content and sidebar](#main-content-and-sidebar)
     - [Left-hand navigation layout](#left-hand-navigation-layout)
@@ -27,6 +24,9 @@ dependencies of this component.
     - [Flush bottom modifier](#flush-bottom-modifier)
     - [Flush top modifier (only on small screens)](#flush-top-modifier-only-on-small-screens)
     - [Flush all modifier (only on small screens)](#flush-all-modifier-only-on-small-screens)
+- [Custom content layouts](#custom-content-layouts)
+    - [Large gutters modifier](#large-gutters-modifier)
+    - [Content layout column dividers](#content-layout-column-dividers)
 - [Block](#block)
     - [Standard block example](#standard-block-example)
     - [Border-top modifier](#border-top-modifier)
@@ -107,309 +107,7 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 ```
 
 
-## Content layouts
-
-### Standard content columns
-
-<div class="content-l">
-    <div class="content-l_col content-l_col-1">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Full-width column (spans 12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-2-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Two thirds-width column (spans 8/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-4">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;">
-            Quarter width column (spans 3/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-3-4">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;">
-            Three-quarter width column (spans 9/12 columns)
-        </div>
-    </div>
-</div>
-
-```
-<div class="content-l">
-    <div class="content-l_col content-l_col-1">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Full-width column (spans 12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-2-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Two thirds-width column (spans 8/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-4">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;">
-            Quarter width column (spans 3/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-3-4">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;">
-            Three-quarter width column (spans 9/12 columns)
-        </div>
-    </div>
-</div>
-```
-
-
-#### Large gutters modifier
-
-<div class="content-l content-l__main  content-l__large-gutters">
-    <div class="content-l_col content-l_col-1">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Full-width column (spans 12 columns)
-        </div>
-    </div>
-</div>
-<div class="content-l content-l__main  content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-</div>
-
-```
-<div class="content-l content-l__main  content-l__large-gutters">
-    <div class="content-l_col content-l_col-1">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Full-width column (spans 12 columns)
-        </div>
-    </div>
-</div>
-<div class="content-l content-l__main  content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-</div>
-```
-
-
-#### Content layout column dividers
-
-Adds dividers between specified `.content-l_col-X-X` classes.
-
-Layout dividers work in conjunction with `.content-l_col-X-X` elements and have
-specific needs depending on which column element variant they are attached to.
-For example `.content-l_col-1-2` has different divider needs than
-`.content-l_col-1-3` because they may break to single columns at different
-breakpoints.
-
-Dividers use absolute positioning relative to the `.content-l` element
-and depend on `.content-l` using `position: relative;`.
-This allows vertical dividers to span the height of the tallest column.
-Just be aware that if you have more than one row of columns,
-and each row has columns of different widths, the borders will cause unwanted
-overlapping since they will span the height of the entire `.content-l` element.
-
-<div class="content-l content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-2">
-        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
-        <br>
-        Half-width column (spans 6/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-2 content-l_col__before-divider">
-        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
-        <br>
-        Half-width column (spans 6/12 columns)
-    </div>
-</div>
-<br>
-<div class="content-l content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-3">
-        Third-width column (spans 4/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
-        Third-width column (spans 4/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
-        Third-width column (spans 4/12 columns)
-    </div>
-</div>
-
-```
-<div class="content-l content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-2">
-        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
-        <br>
-        Half-width column (spans 6/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-2 content-l_col__before-divider">
-        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
-        <br>
-        Half-width column (spans 6/12 columns)
-    </div>
-</div>
-<br>
-<!-- Starting a new .content-l so that the dividers from
-     .content-l_col.content-l_col-1-2.content-l_col__before-divider
-     won't overlap the .content-l_col-1-3 columns. -->
-<div class="content-l content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-3">
-        Third-width column (spans 4/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
-        Third-width column (spans 4/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
-        Third-width column (spans 4/12 columns)
-    </div>
-</div>
-```
+## Standard content formats
 
 
 ### Content line
@@ -833,6 +531,312 @@ screens only. 'Small' screens in this case refers to the breakpoint where
         Footer
     </div>
 </footer>
+```
+
+
+## Custom content layouts
+
+The `content-l` ("content layout")
+class can be used to lay content out in a grid.
+
+<div class="content-l">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-2-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Two thirds-width column (spans 8/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Quarter width column (spans 3/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-3-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Three-quarter width column (spans 9/12 columns)
+        </div>
+    </div>
+</div>
+
+```
+<div class="content-l">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-2-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Two thirds-width column (spans 8/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Quarter width column (spans 3/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-3-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Three-quarter width column (spans 9/12 columns)
+        </div>
+    </div>
+</div>
+```
+
+
+### Large gutters modifier
+
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+</div>
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+</div>
+
+```
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+</div>
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+</div>
+```
+
+
+### Content layout column dividers
+
+Adds dividers between specified `.content-l_col-X-X` classes.
+
+Layout dividers work in conjunction with `.content-l_col-X-X` elements and have
+specific needs depending on which column element variant they are attached to.
+For example `.content-l_col-1-2` has different divider needs than
+`.content-l_col-1-3` because they may break to single columns at different
+breakpoints.
+
+Dividers use absolute positioning relative to the `.content-l` element
+and depend on `.content-l` using `position: relative;`.
+This allows vertical dividers to span the height of the tallest column.
+Just be aware that if you have more than one row of columns,
+and each row has columns of different widths, the borders will cause unwanted
+overlapping since they will span the height of the entire `.content-l` element.
+
+<div class="content-l content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-2">
+        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
+        <br>
+        Half-width column (spans 6/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-2 content-l_col__before-divider">
+        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
+        <br>
+        Half-width column (spans 6/12 columns)
+    </div>
+</div>
+<br>
+<div class="content-l content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-3">
+        Third-width column (spans 4/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
+        Third-width column (spans 4/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
+        Third-width column (spans 4/12 columns)
+    </div>
+</div>
+
+```
+<div class="content-l content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-2">
+        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
+        <br>
+        Half-width column (spans 6/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-2 content-l_col__before-divider">
+        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
+        <br>
+        Half-width column (spans 6/12 columns)
+    </div>
+</div>
+<br>
+<!-- Starting a new .content-l so that the dividers from
+     .content-l_col.content-l_col-1-2.content-l_col__before-divider
+     won't overlap the .content-l_col-1-3 columns. -->
+<div class="content-l content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-3">
+        Third-width column (spans 4/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
+        Third-width column (spans 4/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
+        Third-width column (spans 4/12 columns)
+    </div>
+</div>
 ```
 
 

--- a/docs/_includes/usage/cf-layout/usage.md
+++ b/docs/_includes/usage/cf-layout/usage.md
@@ -16,17 +16,17 @@ dependencies of this component.
     - [Color variables](#color-variables)
 - [Content layouts](#content-layouts)
     - [Standard content columns](#standard-content-columns)
-    - [Large gutters modifier](#large-gutters-modifier)
-    - [Content layout column dividers](#content-layout-column-dividers)
+        - [Large gutters modifier](#large-gutters-modifier)
+        - [Content layout column dividers](#content-layout-column-dividers)
     - [Content line](#content-line)
     - [Main content and sidebar](#main-content-and-sidebar)
     - [Left-hand navigation layout](#left-hand-navigation-layout)
     - [Right-hand sidebar layout](#right-hand-sidebar-layout)
+        - [Bleedbar sidebar styling](#bleedbar-sidebar-styling)
     - [Narrow content column option](#narrow-content-column-option)
     - [Flush bottom modifier](#flush-bottom-modifier)
     - [Flush top modifier (only on small screens)](#flush-top-modifier-only-on-small-screens)
     - [Flush all modifier (only on small screens)](#flush-all-modifier-only-on-small-screens)
-    - [Bleedbar sidebar styling](#bleedbar-sidebar-styling)
 - [Block](#block)
     - [Standard block example](#standard-block-example)
     - [Border-top modifier](#border-top-modifier)
@@ -275,7 +275,8 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 </div>
 ```
 
-### Large gutters modifier
+
+#### Large gutters modifier
 
 <div class="content-l content-l__main  content-l__large-gutters">
     <div class="content-l_col content-l_col-1">
@@ -338,7 +339,7 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 ```
 
 
-### Content layout column dividers
+#### Content layout column dividers
 
 Adds dividers between specified `.content-l_col-X-X` classes.
 
@@ -591,6 +592,47 @@ markup._
 ```
 
 
+#### Bleedbar sidebar styling
+
+Simply add class `.content__bleedbar` to `main.content`. Only supports
+sidebars on the right, for now.
+
+_Note that inline styling is for demonstration purposes only; do not include
+it in your markup._
+
+<main class="content content__2-1 content__bleedbar" role="main">
+    <section class="content_hero" style="background: #E3E4E5">
+        Content hero
+    </section>
+    <div class="content_line"></div>
+    <div class="content_wrapper">
+        <section class="content_main">
+            Main content area
+        </section>
+        <aside class="content_sidebar">
+            Bleeding sidebar
+        </aside>
+    </div>
+</main>
+
+```
+<main class="content content__2-1 content__bleedbar" role="main">
+    <section class="content_hero" style="background: #E3E4E5">
+        Content hero
+    </section>
+    <div class="content_line"></div>
+    <div class="content_wrapper">
+        <section class="content_main">
+            Main content area
+        </section>
+        <aside class="content_sidebar">
+            Bleeding sidebar
+        </aside>
+    </div>
+</main>
+```
+
+
 ### Narrow content column option
 
 Add a class of `.content_main__narrow` to `.content_main` to get a one-column
@@ -791,47 +833,6 @@ screens only. 'Small' screens in this case refers to the breakpoint where
         Footer
     </div>
 </footer>
-```
-
-
-### Bleedbar sidebar styling
-
-Simply add class `.content__bleedbar` to `main.content`. Only supports
-sidebars on the right, for now.
-
-_Note that inline styling is for demonstration purposes only; do not include
-it in your markup._
-
-<main class="content content__2-1 content__bleedbar" role="main">
-    <section class="content_hero" style="background: #E3E4E5">
-        Content hero
-    </section>
-    <div class="content_line"></div>
-    <div class="content_wrapper">
-        <section class="content_main">
-            Main content area
-        </section>
-        <aside class="content_sidebar">
-            Bleeding sidebar
-        </aside>
-    </div>
-</main>
-
-```
-<main class="content content__2-1 content__bleedbar" role="main">
-    <section class="content_hero" style="background: #E3E4E5">
-        Content hero
-    </section>
-    <div class="content_line"></div>
-    <div class="content_wrapper">
-        <section class="content_main">
-            Main content area
-        </section>
-        <aside class="content_sidebar">
-            Bleeding sidebar
-        </aside>
-    </div>
-</main>
 ```
 
 

--- a/docs/_includes/usage/cf-layout/usage.md
+++ b/docs/_includes/usage/cf-layout/usage.md
@@ -17,15 +17,16 @@ dependencies of this component.
 - [Content layouts](#content-layouts)
     - [Standard content columns](#standard-content-columns)
     - [Large gutters modifier](#large-gutters-modifier)
-- [Content layout column dividers](#content-layout-column-dividers)
-- [Content bar](#content-bar)
-- [Content line](#content-line)
-- [Main content and sidebar](#main-content-and-sidebar)
-- [Left-hand navigation layout](#left-hand-navigation-layout)
-- [Right-hand sidebar layout](#right-hand-sidebar-layout)
-- [Narrow content column option](#narrow-content-column-option)
-- [Flush bottom modifier](#flush-bottom-modifier)
-- [Flush top modifier (only on small screens)](#flush-top-modifier-only-on-small-screens)
+    - [Content layout column dividers](#content-layout-column-dividers)
+    - [Content line](#content-line)
+    - [Main content and sidebar](#main-content-and-sidebar)
+    - [Left-hand navigation layout](#left-hand-navigation-layout)
+    - [Right-hand sidebar layout](#right-hand-sidebar-layout)
+    - [Narrow content column option](#narrow-content-column-option)
+    - [Flush bottom modifier](#flush-bottom-modifier)
+    - [Flush top modifier (only on small screens)](#flush-top-modifier-only-on-small-screens)
+    - [Flush all modifier (only on small screens)](#flush-all-modifier-only-on-small-screens)
+    - [Bleedbar sidebar styling](#bleedbar-sidebar-styling)
 - [Block](#block)
     - [Standard block example](#standard-block-example)
     - [Border-top modifier](#border-top-modifier)
@@ -34,7 +35,6 @@ dependencies of this component.
     - [Border-left modifier](#border-left-modifier)
     - [Border modifier](#border-modifier)
     - [Flush-top modifier](#flush-top-modifier)
-    - [Flush-top modifier](#flush-bottom-modifier-1)
     - [Flush-bottom modifier](#flush-bottom-modifier-1)
     - [Flush-sides modifier](#flush-sides-modifier)
     - [Flush modifier](#flush-modifier)
@@ -44,7 +44,6 @@ dependencies of this component.
     - [Padded-bottom modifier](#padded-bottom-modifier)
     - [Sub blocks](#sub-blocks)
     - [Mixing content blocks with content layouts](#mixing-content-blocks-with-content-layouts)
-- [Bleedbar sidebar styling](#bleedbar-sidebar-styling)
 - [cf-grid helpers](#cf-grid-helpers)
     - [.wrapper (base)](#wrapper-base)
     - [Column divider modifiers](#column-divider-modifiers)
@@ -65,7 +64,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```
 // .block
@@ -339,7 +338,7 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 ```
 
 
-## Content layout column dividers
+### Content layout column dividers
 
 Adds dividers between specified `.content-l_col-X-X` classes.
 
@@ -412,7 +411,7 @@ overlapping since they will span the height of the entire `.content-l` element.
 ```
 
 
-## Content line
+### Content line
 
 A 1 pixel edge to edge bar that can divide content.
 
@@ -423,7 +422,7 @@ A 1 pixel edge to edge bar that can divide content.
 ```
 
 
-## Main content and sidebar
+### Main content and sidebar
 
 Standard layout for the main content area and sidebar.
 
@@ -432,7 +431,7 @@ When using the modifiers described below to create columns,
 the columns will remain stacked for smaller screens and then convert to to
 columns at `801px`.
 
-`.content_bar` must come after `.content_hero` (if it exists) but before
+`.content_line` must come after `.content_hero` (if it exists) but before
 `.content_wrapper`.
 
 _Inline styling is for demonstration purposes only; do not include it in your
@@ -442,7 +441,7 @@ markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             Main content area
@@ -458,7 +457,7 @@ markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             Main content area
@@ -471,7 +470,7 @@ markup._
 ```
 
 
-## Left-hand navigation layout
+### Left-hand navigation layout
 
 Add a class of `.content__L-R` to `main.content` to determine the width ratio
 of `.content_main` and `.content_sidebar`, where 'L' is the left-hand item and
@@ -482,7 +481,7 @@ left, sidebar on the right, in a ratio of 2:1).
 It is assumed that the content is wider than the sidebar.
 
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar">
             Section navigation
@@ -506,7 +505,7 @@ It is assumed that the content is wider than the sidebar.
 
 ```
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar">
             Section navigation
@@ -530,7 +529,7 @@ It is assumed that the content is wider than the sidebar.
 ```
 
 
-## Right-hand sidebar layout
+### Right-hand sidebar layout
 
 Add a class of `.content__L-R` to `main.content` to determine the width ratio
 of `.content_main` and `.content_sidebar`, where 'L' is the left-hand item and
@@ -544,7 +543,7 @@ _Inline styling is for demonstration purposes only; do not include it in your
 markup._
 
 <main class="content content__2-1" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             <h2>Main content area</h2>
@@ -568,7 +567,7 @@ markup._
 
 ```
 <main class="content content__2-1" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             <h2>Main content area</h2>
@@ -592,7 +591,7 @@ markup._
 ```
 
 
-## Narrow content column option
+### Narrow content column option
 
 Add a class of `.content_main__narrow` to `.content_main` to get a one-column
 (in a 12-column grid) gutter on the right side.
@@ -601,7 +600,7 @@ _Inline styling is for demonstration purposes only; do not include it in your
 markup._
 
 <main class="content content__2-1" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main content_main__narrow">
             <h2>Main content area</h2>
@@ -625,7 +624,7 @@ markup._
 
 ```
 <main class="content content__2-1" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main content_main__narrow">
             <h2>Main content area</h2>
@@ -649,13 +648,13 @@ markup._
 ```
 
 
-## Flush bottom modifier
+### Flush bottom modifier
 
 Add a class of `.content__flush-bottom` to `.content_main` or
 `.content_sidebar` to remove bottom padding.
 
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-bottom">
             Side with no bottom padding...
@@ -681,7 +680,7 @@ Add a class of `.content__flush-bottom` to `.content_main` or
 
 ```
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-bottom">
             Side with no bottom padding...
@@ -707,7 +706,7 @@ Add a class of `.content__flush-bottom` to `.content_main` or
 ```
 
 
-## Flush top modifier (only on small screens)
+### Flush top modifier (only on small screens)
 
 Add a class of `.content__flush-top-on-small` to `.content_main` or
 `.content_sidebar` to remove top `padding` on small screens only. 'Small'
@@ -715,7 +714,7 @@ screens in this case refers to the breakpoint where `.content_main` and
 `.content_sidebar` single column layout.
 
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-top-on-small">
             Side with no top padding on small screens...
@@ -733,7 +732,7 @@ screens in this case refers to the breakpoint where `.content_main` and
 
 ```
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-top-on-small">
             Side with no top padding on small screens...
@@ -751,7 +750,7 @@ screens in this case refers to the breakpoint where `.content_main` and
 ```
 
 
-## Flush all modifier (only on small screens)
+### Flush all modifier (only on small screens)
 
 Add a class of `.content__flush-all-on-small` to `.content_main` or
 `.content_sidebar` to remove all `padding` and border-based gutters on small
@@ -759,7 +758,7 @@ screens only. 'Small' screens in this case refers to the breakpoint where
 `.content_main` and `.content_sidebar` single column layout.
 
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-all-on-small">
             Side with no padding or border-based gutters on small screens...
@@ -777,7 +776,7 @@ screens only. 'Small' screens in this case refers to the breakpoint where
 
 ```
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-all-on-small">
             Side with no padding or border-based gutters on small screens...
@@ -792,6 +791,47 @@ screens only. 'Small' screens in this case refers to the breakpoint where
         Footer
     </div>
 </footer>
+```
+
+
+### Bleedbar sidebar styling
+
+Simply add class `.content__bleedbar` to `main.content`. Only supports
+sidebars on the right, for now.
+
+_Note that inline styling is for demonstration purposes only; do not include
+it in your markup._
+
+<main class="content content__2-1 content__bleedbar" role="main">
+    <section class="content_hero" style="background: #E3E4E5">
+        Content hero
+    </section>
+    <div class="content_line"></div>
+    <div class="content_wrapper">
+        <section class="content_main">
+            Main content area
+        </section>
+        <aside class="content_sidebar">
+            Bleeding sidebar
+        </aside>
+    </div>
+</main>
+
+```
+<main class="content content__2-1 content__bleedbar" role="main">
+    <section class="content_hero" style="background: #E3E4E5">
+        Content hero
+    </section>
+    <div class="content_line"></div>
+    <div class="content_wrapper">
+        <section class="content_main">
+            Main content area
+        </section>
+        <aside class="content_sidebar">
+            Bleeding sidebar
+        </aside>
+    </div>
+</main>
 ```
 
 
@@ -1198,47 +1238,6 @@ and should not be used in production._
         </div>
     </div>
 </div>
-```
-
-
-## Bleedbar sidebar styling
-
-Simply add class `.content__bleedbar` to `main.content`. Only supports
-sidebars on the right, for now.
-
-_Note that inline styling is for demonstration purposes only; do not include
-it in your markup._
-
-<main class="content content__2-1 content__bleedbar" role="main">
-    <section class="content_hero" style="background: #E3E4E5">
-        Content hero
-    </section>
-    <div class="content_bar"></div>
-    <div class="content_wrapper">
-        <section class="content_main">
-            Main content area
-        </section>
-        <aside class="content_sidebar">
-            Bleeding sidebar
-        </aside>
-    </div>
-</main>
-
-```
-<main class="content content__2-1 content__bleedbar" role="main">
-    <section class="content_hero" style="background: #E3E4E5">
-        Content hero
-    </section>
-    <div class="content_bar"></div>
-    <div class="content_wrapper">
-        <section class="content_main">
-            Main content area
-        </section>
-        <aside class="content_sidebar">
-            Bleeding sidebar
-        </aside>
-    </div>
-</main>
 ```
 
 

--- a/docs/_includes/usage/cf-pagination/usage.md
+++ b/docs/_includes/usage/cf-pagination/usage.md
@@ -27,7 +27,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```
 @pagination-text:               @gray;

--- a/docs/_includes/usage/cf-tables/usage.md
+++ b/docs/_includes/usage/cf-tables/usage.md
@@ -36,7 +36,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```less
 @table-head-bg:                 @gray-5;

--- a/docs/_includes/usage/cf-typography/usage.md
+++ b/docs/_includes/usage/cf-typography/usage.md
@@ -78,7 +78,7 @@ otherwise set it to `false` to use the self-hosted font path:
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```
 // Running text elements

--- a/packages/cf-buttons/usage.md
+++ b/packages/cf-buttons/usage.md
@@ -34,7 +34,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```
 // .btn

--- a/packages/cf-expandables/usage.md
+++ b/packages/cf-expandables/usage.md
@@ -41,7 +41,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 
 ```

--- a/packages/cf-forms/usage.md
+++ b/packages/cf-forms/usage.md
@@ -47,7 +47,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```less
 // .a-text-input borders

--- a/packages/cf-layout/usage.md
+++ b/packages/cf-layout/usage.md
@@ -130,9 +130,6 @@ When using the modifiers described below to create columns,
 the columns will remain stacked for smaller screens and then convert to to
 columns at `801px`.
 
-`.content_line` must come after `.content_hero` (if it exists) but before
-`.content_wrapper`.
-
 _Inline styling is for demonstration purposes only; do not include it in your
 markup._
 
@@ -140,7 +137,6 @@ markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             Main content area
@@ -156,7 +152,6 @@ markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             Main content area

--- a/packages/cf-layout/usage.md
+++ b/packages/cf-layout/usage.md
@@ -14,10 +14,7 @@ dependencies of this component.
 
 - [Variables](#variables)
     - [Color variables](#color-variables)
-- [Content layouts](#content-layouts)
-    - [Standard content columns](#standard-content-columns)
-        - [Large gutters modifier](#large-gutters-modifier)
-        - [Content layout column dividers](#content-layout-column-dividers)
+- [Standard content formats](#standard-content-formats)
     - [Content line](#content-line)
     - [Main content and sidebar](#main-content-and-sidebar)
     - [Left-hand navigation layout](#left-hand-navigation-layout)
@@ -27,6 +24,9 @@ dependencies of this component.
     - [Flush bottom modifier](#flush-bottom-modifier)
     - [Flush top modifier (only on small screens)](#flush-top-modifier-only-on-small-screens)
     - [Flush all modifier (only on small screens)](#flush-all-modifier-only-on-small-screens)
+- [Custom content layouts](#custom-content-layouts)
+    - [Large gutters modifier](#large-gutters-modifier)
+    - [Content layout column dividers](#content-layout-column-dividers)
 - [Block](#block)
     - [Standard block example](#standard-block-example)
     - [Border-top modifier](#border-top-modifier)
@@ -107,309 +107,7 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 ```
 
 
-## Content layouts
-
-### Standard content columns
-
-<div class="content-l">
-    <div class="content-l_col content-l_col-1">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Full-width column (spans 12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-2-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Two thirds-width column (spans 8/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-4">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;">
-            Quarter width column (spans 3/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-3-4">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;">
-            Three-quarter width column (spans 9/12 columns)
-        </div>
-    </div>
-</div>
-
-```
-<div class="content-l">
-    <div class="content-l_col content-l_col-1">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Full-width column (spans 12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-2-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Two thirds-width column (spans 8/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-3">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Third-width column (spans 4/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-4">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;">
-            Quarter width column (spans 3/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-3-4">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;">
-            Three-quarter width column (spans 9/12 columns)
-        </div>
-    </div>
-</div>
-```
-
-
-#### Large gutters modifier
-
-<div class="content-l content-l__main  content-l__large-gutters">
-    <div class="content-l_col content-l_col-1">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Full-width column (spans 12 columns)
-        </div>
-    </div>
-</div>
-<div class="content-l content-l__main  content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-</div>
-
-```
-<div class="content-l content-l__main  content-l__large-gutters">
-    <div class="content-l_col content-l_col-1">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Full-width column (spans 12 columns)
-        </div>
-    </div>
-</div>
-<div class="content-l content-l__main  content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-    <div class="content-l_col content-l_col-1-2">
-        <div style="background: #F1F2F2;
-                    text-align: center;
-                    padding: 8px;
-                    margin-bottom: 4px;">
-            Half-width column (spans 6/12 columns)
-        </div>
-    </div>
-</div>
-```
-
-
-#### Content layout column dividers
-
-Adds dividers between specified `.content-l_col-X-X` classes.
-
-Layout dividers work in conjunction with `.content-l_col-X-X` elements and have
-specific needs depending on which column element variant they are attached to.
-For example `.content-l_col-1-2` has different divider needs than
-`.content-l_col-1-3` because they may break to single columns at different
-breakpoints.
-
-Dividers use absolute positioning relative to the `.content-l` element
-and depend on `.content-l` using `position: relative;`.
-This allows vertical dividers to span the height of the tallest column.
-Just be aware that if you have more than one row of columns,
-and each row has columns of different widths, the borders will cause unwanted
-overlapping since they will span the height of the entire `.content-l` element.
-
-<div class="content-l content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-2">
-        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
-        <br>
-        Half-width column (spans 6/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-2 content-l_col__before-divider">
-        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
-        <br>
-        Half-width column (spans 6/12 columns)
-    </div>
-</div>
-<br>
-<div class="content-l content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-3">
-        Third-width column (spans 4/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
-        Third-width column (spans 4/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
-        Third-width column (spans 4/12 columns)
-    </div>
-</div>
-
-```
-<div class="content-l content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-2">
-        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
-        <br>
-        Half-width column (spans 6/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-2 content-l_col__before-divider">
-        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
-        <br>
-        Half-width column (spans 6/12 columns)
-    </div>
-</div>
-<br>
-<!-- Starting a new .content-l so that the dividers from
-     .content-l_col.content-l_col-1-2.content-l_col__before-divider
-     won't overlap the .content-l_col-1-3 columns. -->
-<div class="content-l content-l__large-gutters">
-    <div class="content-l_col content-l_col-1-3">
-        Third-width column (spans 4/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
-        Third-width column (spans 4/12 columns)
-    </div>
-    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
-        Third-width column (spans 4/12 columns)
-    </div>
-</div>
-```
+## Standard content formats
 
 
 ### Content line
@@ -833,6 +531,312 @@ screens only. 'Small' screens in this case refers to the breakpoint where
         Footer
     </div>
 </footer>
+```
+
+
+## Custom content layouts
+
+The `content-l` ("content layout")
+class can be used to lay content out in a grid.
+
+<div class="content-l">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-2-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Two thirds-width column (spans 8/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Quarter width column (spans 3/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-3-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Three-quarter width column (spans 9/12 columns)
+        </div>
+    </div>
+</div>
+
+```
+<div class="content-l">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-2-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Two thirds-width column (spans 8/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-3">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Third-width column (spans 4/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Quarter width column (spans 3/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-3-4">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;">
+            Three-quarter width column (spans 9/12 columns)
+        </div>
+    </div>
+</div>
+```
+
+
+### Large gutters modifier
+
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+</div>
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+</div>
+
+```
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Full-width column (spans 12 columns)
+        </div>
+    </div>
+</div>
+<div class="content-l content-l__main  content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+    <div class="content-l_col content-l_col-1-2">
+        <div style="background: #F1F2F2;
+                    text-align: center;
+                    padding: 8px;
+                    margin-bottom: 4px;">
+            Half-width column (spans 6/12 columns)
+        </div>
+    </div>
+</div>
+```
+
+
+### Content layout column dividers
+
+Adds dividers between specified `.content-l_col-X-X` classes.
+
+Layout dividers work in conjunction with `.content-l_col-X-X` elements and have
+specific needs depending on which column element variant they are attached to.
+For example `.content-l_col-1-2` has different divider needs than
+`.content-l_col-1-3` because they may break to single columns at different
+breakpoints.
+
+Dividers use absolute positioning relative to the `.content-l` element
+and depend on `.content-l` using `position: relative;`.
+This allows vertical dividers to span the height of the tallest column.
+Just be aware that if you have more than one row of columns,
+and each row has columns of different widths, the borders will cause unwanted
+overlapping since they will span the height of the entire `.content-l` element.
+
+<div class="content-l content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-2">
+        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
+        <br>
+        Half-width column (spans 6/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-2 content-l_col__before-divider">
+        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
+        <br>
+        Half-width column (spans 6/12 columns)
+    </div>
+</div>
+<br>
+<div class="content-l content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-3">
+        Third-width column (spans 4/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
+        Third-width column (spans 4/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
+        Third-width column (spans 4/12 columns)
+    </div>
+</div>
+
+```
+<div class="content-l content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-2">
+        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
+        <br>
+        Half-width column (spans 6/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-2 content-l_col__before-divider">
+        <img src="https://dummyimage.com/600x320/addc91/101820" alt="Placeholder image">
+        <br>
+        Half-width column (spans 6/12 columns)
+    </div>
+</div>
+<br>
+<!-- Starting a new .content-l so that the dividers from
+     .content-l_col.content-l_col-1-2.content-l_col__before-divider
+     won't overlap the .content-l_col-1-3 columns. -->
+<div class="content-l content-l__large-gutters">
+    <div class="content-l_col content-l_col-1-3">
+        Third-width column (spans 4/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
+        Third-width column (spans 4/12 columns)
+    </div>
+    <div class="content-l_col content-l_col-1-3 content-l_col__before-divider">
+        Third-width column (spans 4/12 columns)
+    </div>
+</div>
 ```
 
 

--- a/packages/cf-layout/usage.md
+++ b/packages/cf-layout/usage.md
@@ -16,17 +16,17 @@ dependencies of this component.
     - [Color variables](#color-variables)
 - [Content layouts](#content-layouts)
     - [Standard content columns](#standard-content-columns)
-    - [Large gutters modifier](#large-gutters-modifier)
-    - [Content layout column dividers](#content-layout-column-dividers)
+        - [Large gutters modifier](#large-gutters-modifier)
+        - [Content layout column dividers](#content-layout-column-dividers)
     - [Content line](#content-line)
     - [Main content and sidebar](#main-content-and-sidebar)
     - [Left-hand navigation layout](#left-hand-navigation-layout)
     - [Right-hand sidebar layout](#right-hand-sidebar-layout)
+        - [Bleedbar sidebar styling](#bleedbar-sidebar-styling)
     - [Narrow content column option](#narrow-content-column-option)
     - [Flush bottom modifier](#flush-bottom-modifier)
     - [Flush top modifier (only on small screens)](#flush-top-modifier-only-on-small-screens)
     - [Flush all modifier (only on small screens)](#flush-all-modifier-only-on-small-screens)
-    - [Bleedbar sidebar styling](#bleedbar-sidebar-styling)
 - [Block](#block)
     - [Standard block example](#standard-block-example)
     - [Border-top modifier](#border-top-modifier)
@@ -275,7 +275,8 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 </div>
 ```
 
-### Large gutters modifier
+
+#### Large gutters modifier
 
 <div class="content-l content-l__main  content-l__large-gutters">
     <div class="content-l_col content-l_col-1">
@@ -338,7 +339,7 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 ```
 
 
-### Content layout column dividers
+#### Content layout column dividers
 
 Adds dividers between specified `.content-l_col-X-X` classes.
 
@@ -591,6 +592,47 @@ markup._
 ```
 
 
+#### Bleedbar sidebar styling
+
+Simply add class `.content__bleedbar` to `main.content`. Only supports
+sidebars on the right, for now.
+
+_Note that inline styling is for demonstration purposes only; do not include
+it in your markup._
+
+<main class="content content__2-1 content__bleedbar" role="main">
+    <section class="content_hero" style="background: #E3E4E5">
+        Content hero
+    </section>
+    <div class="content_line"></div>
+    <div class="content_wrapper">
+        <section class="content_main">
+            Main content area
+        </section>
+        <aside class="content_sidebar">
+            Bleeding sidebar
+        </aside>
+    </div>
+</main>
+
+```
+<main class="content content__2-1 content__bleedbar" role="main">
+    <section class="content_hero" style="background: #E3E4E5">
+        Content hero
+    </section>
+    <div class="content_line"></div>
+    <div class="content_wrapper">
+        <section class="content_main">
+            Main content area
+        </section>
+        <aside class="content_sidebar">
+            Bleeding sidebar
+        </aside>
+    </div>
+</main>
+```
+
+
 ### Narrow content column option
 
 Add a class of `.content_main__narrow` to `.content_main` to get a one-column
@@ -791,47 +833,6 @@ screens only. 'Small' screens in this case refers to the breakpoint where
         Footer
     </div>
 </footer>
-```
-
-
-### Bleedbar sidebar styling
-
-Simply add class `.content__bleedbar` to `main.content`. Only supports
-sidebars on the right, for now.
-
-_Note that inline styling is for demonstration purposes only; do not include
-it in your markup._
-
-<main class="content content__2-1 content__bleedbar" role="main">
-    <section class="content_hero" style="background: #E3E4E5">
-        Content hero
-    </section>
-    <div class="content_line"></div>
-    <div class="content_wrapper">
-        <section class="content_main">
-            Main content area
-        </section>
-        <aside class="content_sidebar">
-            Bleeding sidebar
-        </aside>
-    </div>
-</main>
-
-```
-<main class="content content__2-1 content__bleedbar" role="main">
-    <section class="content_hero" style="background: #E3E4E5">
-        Content hero
-    </section>
-    <div class="content_line"></div>
-    <div class="content_wrapper">
-        <section class="content_main">
-            Main content area
-        </section>
-        <aside class="content_sidebar">
-            Bleeding sidebar
-        </aside>
-    </div>
-</main>
 ```
 
 

--- a/packages/cf-layout/usage.md
+++ b/packages/cf-layout/usage.md
@@ -17,15 +17,16 @@ dependencies of this component.
 - [Content layouts](#content-layouts)
     - [Standard content columns](#standard-content-columns)
     - [Large gutters modifier](#large-gutters-modifier)
-- [Content layout column dividers](#content-layout-column-dividers)
-- [Content bar](#content-bar)
-- [Content line](#content-line)
-- [Main content and sidebar](#main-content-and-sidebar)
-- [Left-hand navigation layout](#left-hand-navigation-layout)
-- [Right-hand sidebar layout](#right-hand-sidebar-layout)
-- [Narrow content column option](#narrow-content-column-option)
-- [Flush bottom modifier](#flush-bottom-modifier)
-- [Flush top modifier (only on small screens)](#flush-top-modifier-only-on-small-screens)
+    - [Content layout column dividers](#content-layout-column-dividers)
+    - [Content line](#content-line)
+    - [Main content and sidebar](#main-content-and-sidebar)
+    - [Left-hand navigation layout](#left-hand-navigation-layout)
+    - [Right-hand sidebar layout](#right-hand-sidebar-layout)
+    - [Narrow content column option](#narrow-content-column-option)
+    - [Flush bottom modifier](#flush-bottom-modifier)
+    - [Flush top modifier (only on small screens)](#flush-top-modifier-only-on-small-screens)
+    - [Flush all modifier (only on small screens)](#flush-all-modifier-only-on-small-screens)
+    - [Bleedbar sidebar styling](#bleedbar-sidebar-styling)
 - [Block](#block)
     - [Standard block example](#standard-block-example)
     - [Border-top modifier](#border-top-modifier)
@@ -34,7 +35,6 @@ dependencies of this component.
     - [Border-left modifier](#border-left-modifier)
     - [Border modifier](#border-modifier)
     - [Flush-top modifier](#flush-top-modifier)
-    - [Flush-top modifier](#flush-bottom-modifier-1)
     - [Flush-bottom modifier](#flush-bottom-modifier-1)
     - [Flush-sides modifier](#flush-sides-modifier)
     - [Flush modifier](#flush-modifier)
@@ -44,7 +44,6 @@ dependencies of this component.
     - [Padded-bottom modifier](#padded-bottom-modifier)
     - [Sub blocks](#sub-blocks)
     - [Mixing content blocks with content layouts](#mixing-content-blocks-with-content-layouts)
-- [Bleedbar sidebar styling](#bleedbar-sidebar-styling)
 - [cf-grid helpers](#cf-grid-helpers)
     - [.wrapper (base)](#wrapper-base)
     - [Column divider modifiers](#column-divider-modifiers)
@@ -65,7 +64,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```
 // .block
@@ -339,7 +338,7 @@ Color variables referenced in comments are from [cf-core cf-brand-colors.less](h
 ```
 
 
-## Content layout column dividers
+### Content layout column dividers
 
 Adds dividers between specified `.content-l_col-X-X` classes.
 
@@ -412,7 +411,7 @@ overlapping since they will span the height of the entire `.content-l` element.
 ```
 
 
-## Content line
+### Content line
 
 A 1 pixel edge to edge bar that can divide content.
 
@@ -423,7 +422,7 @@ A 1 pixel edge to edge bar that can divide content.
 ```
 
 
-## Main content and sidebar
+### Main content and sidebar
 
 Standard layout for the main content area and sidebar.
 
@@ -432,7 +431,7 @@ When using the modifiers described below to create columns,
 the columns will remain stacked for smaller screens and then convert to to
 columns at `801px`.
 
-`.content_bar` must come after `.content_hero` (if it exists) but before
+`.content_line` must come after `.content_hero` (if it exists) but before
 `.content_wrapper`.
 
 _Inline styling is for demonstration purposes only; do not include it in your
@@ -442,7 +441,7 @@ markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             Main content area
@@ -458,7 +457,7 @@ markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             Main content area
@@ -471,7 +470,7 @@ markup._
 ```
 
 
-## Left-hand navigation layout
+### Left-hand navigation layout
 
 Add a class of `.content__L-R` to `main.content` to determine the width ratio
 of `.content_main` and `.content_sidebar`, where 'L' is the left-hand item and
@@ -482,7 +481,7 @@ left, sidebar on the right, in a ratio of 2:1).
 It is assumed that the content is wider than the sidebar.
 
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar">
             Section navigation
@@ -506,7 +505,7 @@ It is assumed that the content is wider than the sidebar.
 
 ```
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar">
             Section navigation
@@ -530,7 +529,7 @@ It is assumed that the content is wider than the sidebar.
 ```
 
 
-## Right-hand sidebar layout
+### Right-hand sidebar layout
 
 Add a class of `.content__L-R` to `main.content` to determine the width ratio
 of `.content_main` and `.content_sidebar`, where 'L' is the left-hand item and
@@ -544,7 +543,7 @@ _Inline styling is for demonstration purposes only; do not include it in your
 markup._
 
 <main class="content content__2-1" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             <h2>Main content area</h2>
@@ -568,7 +567,7 @@ markup._
 
 ```
 <main class="content content__2-1" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main">
             <h2>Main content area</h2>
@@ -592,7 +591,7 @@ markup._
 ```
 
 
-## Narrow content column option
+### Narrow content column option
 
 Add a class of `.content_main__narrow` to `.content_main` to get a one-column
 (in a 12-column grid) gutter on the right side.
@@ -601,7 +600,7 @@ _Inline styling is for demonstration purposes only; do not include it in your
 markup._
 
 <main class="content content__2-1" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main content_main__narrow">
             <h2>Main content area</h2>
@@ -625,7 +624,7 @@ markup._
 
 ```
 <main class="content content__2-1" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <section class="content_main content_main__narrow">
             <h2>Main content area</h2>
@@ -649,13 +648,13 @@ markup._
 ```
 
 
-## Flush bottom modifier
+### Flush bottom modifier
 
 Add a class of `.content__flush-bottom` to `.content_main` or
 `.content_sidebar` to remove bottom padding.
 
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-bottom">
             Side with no bottom padding...
@@ -681,7 +680,7 @@ Add a class of `.content__flush-bottom` to `.content_main` or
 
 ```
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-bottom">
             Side with no bottom padding...
@@ -707,7 +706,7 @@ Add a class of `.content__flush-bottom` to `.content_main` or
 ```
 
 
-## Flush top modifier (only on small screens)
+### Flush top modifier (only on small screens)
 
 Add a class of `.content__flush-top-on-small` to `.content_main` or
 `.content_sidebar` to remove top `padding` on small screens only. 'Small'
@@ -715,7 +714,7 @@ screens in this case refers to the breakpoint where `.content_main` and
 `.content_sidebar` single column layout.
 
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-top-on-small">
             Side with no top padding on small screens...
@@ -733,7 +732,7 @@ screens in this case refers to the breakpoint where `.content_main` and
 
 ```
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-top-on-small">
             Side with no top padding on small screens...
@@ -751,7 +750,7 @@ screens in this case refers to the breakpoint where `.content_main` and
 ```
 
 
-## Flush all modifier (only on small screens)
+### Flush all modifier (only on small screens)
 
 Add a class of `.content__flush-all-on-small` to `.content_main` or
 `.content_sidebar` to remove all `padding` and border-based gutters on small
@@ -759,7 +758,7 @@ screens only. 'Small' screens in this case refers to the breakpoint where
 `.content_main` and `.content_sidebar` single column layout.
 
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-all-on-small">
             Side with no padding or border-based gutters on small screens...
@@ -777,7 +776,7 @@ screens only. 'Small' screens in this case refers to the breakpoint where
 
 ```
 <main class="content content__1-3" role="main">
-    <div class="content_bar"></div>
+    <div class="content_line"></div>
     <div class="content_wrapper">
         <aside class="content_sidebar content__flush-all-on-small">
             Side with no padding or border-based gutters on small screens...
@@ -792,6 +791,47 @@ screens only. 'Small' screens in this case refers to the breakpoint where
         Footer
     </div>
 </footer>
+```
+
+
+### Bleedbar sidebar styling
+
+Simply add class `.content__bleedbar` to `main.content`. Only supports
+sidebars on the right, for now.
+
+_Note that inline styling is for demonstration purposes only; do not include
+it in your markup._
+
+<main class="content content__2-1 content__bleedbar" role="main">
+    <section class="content_hero" style="background: #E3E4E5">
+        Content hero
+    </section>
+    <div class="content_line"></div>
+    <div class="content_wrapper">
+        <section class="content_main">
+            Main content area
+        </section>
+        <aside class="content_sidebar">
+            Bleeding sidebar
+        </aside>
+    </div>
+</main>
+
+```
+<main class="content content__2-1 content__bleedbar" role="main">
+    <section class="content_hero" style="background: #E3E4E5">
+        Content hero
+    </section>
+    <div class="content_line"></div>
+    <div class="content_wrapper">
+        <section class="content_main">
+            Main content area
+        </section>
+        <aside class="content_sidebar">
+            Bleeding sidebar
+        </aside>
+    </div>
+</main>
 ```
 
 
@@ -1198,47 +1238,6 @@ and should not be used in production._
         </div>
     </div>
 </div>
-```
-
-
-## Bleedbar sidebar styling
-
-Simply add class `.content__bleedbar` to `main.content`. Only supports
-sidebars on the right, for now.
-
-_Note that inline styling is for demonstration purposes only; do not include
-it in your markup._
-
-<main class="content content__2-1 content__bleedbar" role="main">
-    <section class="content_hero" style="background: #E3E4E5">
-        Content hero
-    </section>
-    <div class="content_bar"></div>
-    <div class="content_wrapper">
-        <section class="content_main">
-            Main content area
-        </section>
-        <aside class="content_sidebar">
-            Bleeding sidebar
-        </aside>
-    </div>
-</main>
-
-```
-<main class="content content__2-1 content__bleedbar" role="main">
-    <section class="content_hero" style="background: #E3E4E5">
-        Content hero
-    </section>
-    <div class="content_bar"></div>
-    <div class="content_wrapper">
-        <section class="content_main">
-            Main content area
-        </section>
-        <aside class="content_sidebar">
-            Bleeding sidebar
-        </aside>
-    </div>
-</main>
 ```
 
 

--- a/packages/cf-pagination/usage.md
+++ b/packages/cf-pagination/usage.md
@@ -27,7 +27,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```
 @pagination-text:               @gray;

--- a/packages/cf-tables/usage.md
+++ b/packages/cf-tables/usage.md
@@ -36,7 +36,7 @@ Overwrite them in your own project by duplicating the variable `@key: value`.
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```less
 @table-head-bg:                 @gray-5;

--- a/packages/cf-typography/usage.md
+++ b/packages/cf-typography/usage.md
@@ -78,7 +78,7 @@ otherwise set it to `false` to use the self-hosted font path:
 
 ### Color variables
 
-Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/src/cf-core/src/cf-brand-colors.less).
+Color variables referenced in comments are from [cf-core cf-brand-colors.less](https://github.com/cfpb/capital-framework/blob/master/packages/cf-core/src/cf-brand-colors.less).
 
 ```
 // Running text elements


### PR DESCRIPTION
## Removals
- Remove reference to non-existant `content_bar` class.
- Remove redundant block link in cf-layout table of contents.

## Changes

- Update outdated brand-colors link.
- Correctly nest cf-layout table of contents links.
- Move "Bleedbar sidebar styling" to correct section of cf-layout table of contents.

## Testing

1. `cd docs && gulp docs && bundle exec jekyll serve`
2. Brand colors link should work in http://localhost:4000/capital-framework/components/cf-layout/#color-variables
3. TOC links should work on http://localhost:4000/capital-framework/components/cf-layout/

## Todos

- The cf-grid sections in cf-layout docs seem like they should move to cf-grid.
