### PR TITLE
Remove cf-icon-path variable

### DIFF
--- a/docs/src/css/main.less
+++ b/docs/src/css/main.less
@@ -19,9 +19,6 @@
 @import (less) "../../../packages/cf-expandables/src/cf-expandables.less";
 @import (less) "../../../packages/cf-tables/src/cf-tables.less";
 
-// Icon font path
-@cf-icon-path: '../css/fonts';
-
 // Webfont variables
 // This is the path for self-hosted fonts.
 @cf-fonts-path: '/static/fonts';


### PR DESCRIPTION
This variable should not be needed anymore, since v10 CF removes the cf-icon webfonts. 

## Removals

- Remove cf-icon-path variable
