### PR TITLE
cf-forms: Fix issue where path to icons was hardcoded

### DIFF
--- a/docs/src/css/main.less
+++ b/docs/src/css/main.less
@@ -19,8 +19,9 @@
 @import (less) "../../../packages/cf-expandables/src/cf-expandables.less";
 @import (less) "../../../packages/cf-tables/src/cf-tables.less";
 
-// Icon font path
-@cf-icon-path: '../css/fonts';
+// Icon font path.
+// When SVGs are used as e.g. background images, we need a path to them.
+@cf-icon-path: '../icons';
 
 // Webfont variables
 // This is the path for self-hosted fonts.
@@ -33,7 +34,7 @@ html, body {
     height: 100%;
 }
 
-/* for sticky footer */
+// For sticky footer.
 .body-wrapper {
     display: table;
     height: 100%;
@@ -50,7 +51,7 @@ nav ul {
     margin-top: unit( 15px / @base-font-size-px, em );
 }
 
-// custom modules
+// Custom modules.
 @import (less) "header.less";
 @import (less) "hero.less";
 @import (less) "main-content.less";

--- a/packages/cf-forms/src/atoms/select.less
+++ b/packages/cf-forms/src/atoms/select.less
@@ -64,7 +64,7 @@
         background-color: @select-icon-bg;
         content: '';
         pointer-events: none;
-        background-image: url( '../icons/down.svg' );
+        background-image: url( '@{cf-icon-path}/down.svg' );
         background-size: auto @cf-icon-height;
         background-repeat: no-repeat;
         background-position: center center;

--- a/packages/cf-forms/src/cf-forms.less
+++ b/packages/cf-forms/src/cf-forms.less
@@ -6,6 +6,11 @@
 // Theme variables
 //
 
+// Default icon font path.
+// When SVGs are used for background images, we need a path to them.
+// May be overridden when this package is imported into implementing less files.
+@cf-icon-path: '../icons';
+
 // Color variables
 
 // .a-text-input borders

--- a/packages/cf-forms/src/molecules/form-fields.less
+++ b/packages/cf-forms/src/molecules/form-fields.less
@@ -121,7 +121,7 @@
             }
 
             &:checked + .a-label:before {
-                background-image: url( '../icons/approved.svg' );
+                background-image: url( '@{cf-icon-path}/approved.svg' );
                 background-size: auto @cf-icon-height;
                 background-repeat: no-repeat;
                 background-position: center 0;


### PR DESCRIPTION
## Changes

- Fix issue where path to icons was hardcoded for form-fields and select drop-downs.

## Testing

1. `cd docs && gulp && bundle exec jekyll serve`
2.  Visit http://localhost:4000/components/cf-forms and see the checkboxes have checks and selects have a drop-down arrow. 
3. You can change the value for `@cf-icon-path` and re-run the command above to see that the icons break.
