### PR TITLE
Update download source links

### DIFF
--- a/docs/_includes/hero.html
+++ b/docs/_includes/hero.html
@@ -15,16 +15,12 @@ $ yo cf
         Download the compiled source:
         <a class="a-link a-link__icon"
            href="https://unpkg.com/capital-framework/capital-framework.min.css">
-          <span class="a-link_text">
-            CSS
-          </span>
+          <span class="a-link_text">CSS</span>
           {% include icons/download.svg %}
         </a>
         <a class="a-link a-link__icon"
            href="https://npmcdn.com/capital-framework/capital-framework.min.js">
-          <span class="a-link_text">
-            JS
-          </span>
+          <span class="a-link_text">JS</span>
           {% include icons/download.svg %}
         </a>
       </p>

--- a/docs/_includes/hero.html
+++ b/docs/_includes/hero.html
@@ -12,9 +12,19 @@ $ yo cf
 
       <p class="hero_p sans">
         Not into the command line?
+        Download the compiled source:
         <a class="a-link a-link__icon"
-           href="https://npmcdn.com/capital-framework/dist/">
-          <span class="a-link_text">Download the compiled source</span>
+           href="https://unpkg.com/capital-framework/capital-framework.min.css">
+          <span class="a-link_text">
+            CSS
+          </span>
+          {% include icons/download.svg %}
+        </a>
+        <a class="a-link a-link__icon"
+           href="https://npmcdn.com/capital-framework/capital-framework.min.js">
+          <span class="a-link_text">
+            JS
+          </span>
           {% include icons/download.svg %}
         </a>
       </p>


### PR DESCRIPTION
Fixes https://github.com/cfpb/capital-framework/issues/896

## Changes

- Updates download source links to link directly to the minified CSS and JS.

## Testing

1. `cd docs && gulp && bundle exec jekyll serve`

## Screenshots

Before:
<img width="634" alt="Screen Shot 2019-06-21 at 12 54 24 PM" src="https://user-images.githubusercontent.com/704760/59938768-ee0b6080-9423-11e9-9b76-b3df7dff50ad.png">

After:
<img width="696" alt="Screen Shot 2019-06-21 at 12 54 12 PM" src="https://user-images.githubusercontent.com/704760/59938760-e9df4300-9423-11e9-9b28-2c62950db95b.png">

