### PR TITLE
cf-forms: Remove unused form input variables | add missing one

### DIFF
--- a/packages/cf-forms/src/cf-forms.less
+++ b/packages/cf-forms/src/cf-forms.less
@@ -12,11 +12,9 @@
 @input-border:                            @gray-60;
 @input-border__hover:                     @pacific;
 @input-border__focused:                   @pacific;
-@input-border__active:                    @pacific;
 @input-border__error:                     @red;
 @input-border__warning:                   @gold;
 @input-border__success:                   @green;
-@input-border__selected:                  @pacific;
 
 // .a-text-input backgrounds
 @input-bg:                                @white;
@@ -41,6 +39,7 @@
 
 // .m-form-field
 @form-field-input-border:                 @input-border;
+@form-field-input-border-inset__selected: @white;
 @form-field-input-border__disabled:       @gray-60;
 
 // .m-form-field__lg-target

--- a/packages/cf-forms/src/cf-forms.less
+++ b/packages/cf-forms/src/cf-forms.less
@@ -39,8 +39,8 @@
 
 // .m-form-field
 @form-field-input-border:                 @input-border;
-@form-field-input-border-inset__selected: @white;
 @form-field-input-border__disabled:       @gray-60;
+@form-field-inset:                        @white;
 
 // .m-form-field__lg-target
 @form-field-input-lg-target-bg:           @gray-10;

--- a/packages/cf-forms/src/molecules/form-fields.less
+++ b/packages/cf-forms/src/molecules/form-fields.less
@@ -157,19 +157,21 @@
 
             &:checked + .a-label:before {
                 background-color: @input-bg__selected;
-                box-shadow: inset 0 0 0 2px @form-field-input-border-inset__selected;
+                box-shadow: inset 0 0 0 2px @form-field-inset;
             }
 
             &:focus:checked + .a-label:before,
             &.focus:checked + .a-label:before {
                 border-color: @input-border__focused;
-                box-shadow: 0 0 0 1px @input-border__focused, inset 0 0 0 2px @form-field-input-border-inset__selected;
+                box-shadow: 0 0 0 1px @input-border__focused,
+                            inset 0 0 0 2px @form-field-inset;
             }
 
             &:hover:checked + .a-label:before,
             &.hover:checked + .a-label:before {
                 border-color: @input-border__hover;
-                box-shadow: 0 0 0 1px @input-border__hover, inset 0 0 0 2px @form-field-input-border-inset__selected;
+                box-shadow: 0 0 0 1px @input-border__hover,
+                            inset 0 0 0 2px @form-field-inset;
             }
         }
     }

--- a/packages/cf-forms/src/molecules/form-fields.less
+++ b/packages/cf-forms/src/molecules/form-fields.less
@@ -157,19 +157,19 @@
 
             &:checked + .a-label:before {
                 background-color: @input-bg__selected;
-                box-shadow: inset 0 0 0 2px #fff;
+                box-shadow: inset 0 0 0 2px @form-field-input-border-inset__selected;
             }
 
             &:focus:checked + .a-label:before,
             &.focus:checked + .a-label:before {
                 border-color: @input-border__focused;
-                box-shadow: 0 0 0 1px @input-border__focused, inset 0 0 0 2px #fff;
+                box-shadow: 0 0 0 1px @input-border__focused, inset 0 0 0 2px @form-field-input-border-inset__selected;
             }
 
             &:hover:checked + .a-label:before,
             &.hover:checked + .a-label:before {
                 border-color: @input-border__hover;
-                box-shadow: 0 0 0 1px @input-border__hover, inset 0 0 0 2px #fff;
+                box-shadow: 0 0 0 1px @input-border__hover, inset 0 0 0 2px @form-field-input-border-inset__selected;
             }
         }
     }


### PR DESCRIPTION
## Removals

- Remove unused `@input-border__active` and `@input-border__selected` variables.

## Changes

- Converts `#fff` to a variable like the other colors.

## Testing

1. `cd docs && gulp build && gulp docs && bundle exec jekyll serve`

## Notes

- Possibly we should use the color variables directly, so `@white` instead of `@form-field-input-border-inset__selected`.