### PR TITLE
Normalize (less) keyword usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This will download Capital Framework to your project's `node_modules` folder.
 You can then import the framework into your application's primary Less file:
 
 ```less
-@import (less) "node_modules/capital-framework/src/capital-framework.less";
+@import (less) 'node_modules/capital-framework/src/capital-framework.less';
 
 // the rest of your stylesheet...
 ```

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -80,12 +80,12 @@ you can just download the source files and import them into your project.
   or your compiled Capital Framework CSS will
   not work perfectly in older browsers.
 
-Run `npm install capital-framework`. This will download Capital Framework to your
-project's `node_modules` directory. You can then import the framework into
-your application's primary Less file:
+Run `npm install capital-framework`.
+This will download Capital Framework to your project's `node_modules` directory.
+You can then import the framework into your application's primary Less file:
 
 ```css
-@import (less) "node_modules/capital-framework/src/capital-framework.less";
+@import (less) 'node_modules/capital-framework/src/capital-framework.less';
 
 /* the rest of your stylesheet… */
 ```
@@ -98,8 +98,8 @@ npm install cf-buttons cf-icons
 ```
 
 ```css
-@import (less) "node_modules/cf-buttons/src/cf-buttons.less";
-@import (less) "node_modules/cf-icons/src/cf-icons.less";
+@import (less) 'node_modules/cf-buttons/src/cf-buttons.less';
+@import (less) 'node_modules/cf-icons/src/cf-icons.less';
 
 /* the rest of your stylesheet… */
 ```

--- a/docs/src/css/main.less
+++ b/docs/src/css/main.less
@@ -6,18 +6,18 @@
 // Project-specific Less rules go after the imports.
 
 // Import Capital Framework.
-@import (less) "../../../packages/cf-atomic-component/src/cf-atomic-component.less";
-@import (less) "../../../packages/cf-core/src/cf-core.less";
-@import (less) "../../../packages/cf-grid/src/cf-grid.less";
-@import (less) "../../../packages/cf-icons/src/cf-icons.less";
-@import (less) "../../../packages/cf-typography/src/cf-typography.less";
-@import (less) "../../../packages/cf-layout/src/cf-layout.less";
-@import (less) "../../../packages/cf-buttons/src/cf-buttons.less";
-@import (less) "../../../packages/cf-forms/src/cf-forms.less";
-@import (less) "../../../packages/cf-notifications/src/cf-notifications.less";
-@import (less) "../../../packages/cf-pagination/src/cf-pagination.less";
-@import (less) "../../../packages/cf-expandables/src/cf-expandables.less";
-@import (less) "../../../packages/cf-tables/src/cf-tables.less";
+@import (less) '../../../packages/cf-atomic-component/src/cf-atomic-component.less';
+@import (less) '../../../packages/cf-core/src/cf-core.less';
+@import (less) '../../../packages/cf-grid/src/cf-grid.less';
+@import (less) '../../../packages/cf-icons/src/cf-icons.less';
+@import (less) '../../../packages/cf-typography/src/cf-typography.less';
+@import (less) '../../../packages/cf-layout/src/cf-layout.less';
+@import (less) '../../../packages/cf-buttons/src/cf-buttons.less';
+@import (less) '../../../packages/cf-forms/src/cf-forms.less';
+@import (less) '../../../packages/cf-notifications/src/cf-notifications.less';
+@import (less) '../../../packages/cf-pagination/src/cf-pagination.less';
+@import (less) '../../../packages/cf-expandables/src/cf-expandables.less';
+@import (less) '../../../packages/cf-tables/src/cf-tables.less';
 
 // Webfont variables
 // This is the path for self-hosted fonts.
@@ -48,10 +48,10 @@ nav ul {
 }
 
 // Custom modules.
-@import (less) "header.less";
-@import (less) "hero.less";
-@import (less) "main-content.less";
-@import (less) "footer.less";
-@import (less) "secondary-nav.less";
-@import (less) "code.less";
-@import (less) "grid-demo.less";
+@import (less) 'header.less';
+@import (less) 'hero.less';
+@import (less) 'main-content.less';
+@import (less) 'footer.less';
+@import (less) 'secondary-nav.less';
+@import (less) 'code.less';
+@import (less) 'grid-demo.less';

--- a/packages/cf-atomic-component/src/cf-atomic-component.less
+++ b/packages/cf-atomic-component/src/cf-atomic-component.less
@@ -4,4 +4,4 @@
    ========================================================================== */
 
 // Import utilities.
-@import 'utilities/transition/transition.less';
+@import (less) 'utilities/transition/transition.less';

--- a/packages/cf-buttons/src/atoms/buttons-with-icons.less
+++ b/packages/cf-buttons/src/atoms/buttons-with-icons.less
@@ -1,4 +1,4 @@
-@import '../atoms/buttons.less';
+@import (less) '../atoms/buttons.less';
 
 // Icon locations
 // TODO: Replace magic numbers with calculations based off of the

--- a/packages/cf-buttons/src/cf-buttons.less
+++ b/packages/cf-buttons/src/cf-buttons.less
@@ -47,13 +47,13 @@
 
 // Import external dependencies
 
-@import '../../cf-core/src/cf-core.less';
-@import '../../cf-icons/src/cf-icons.less';
+@import (less) '../../cf-core/src/cf-core.less';
+@import (less) '../../cf-icons/src/cf-icons.less';
 
 
 // Import atomic components of cf-buttons
 
-@import 'atoms/buttons.less';
-@import 'atoms/button-links.less';
-@import 'atoms/buttons-with-icons.less';
-@import 'molecules/button-groups.less';
+@import (less) 'atoms/buttons.less';
+@import (less) 'atoms/button-links.less';
+@import (less) 'atoms/buttons-with-icons.less';
+@import (less) 'molecules/button-groups.less';

--- a/packages/cf-buttons/src/molecules/button-groups.less
+++ b/packages/cf-buttons/src/molecules/button-groups.less
@@ -1,4 +1,4 @@
-@import '../atoms/buttons.less';
+@import (less) '../atoms/buttons.less';
 
 //
 // Button groups

--- a/packages/cf-grid/src-generated/cf-grid-generated.less
+++ b/packages/cf-grid/src-generated/cf-grid-generated.less
@@ -1,6 +1,6 @@
-@import (less) "../../normalize-css/normalize.css";
-@import (less) "../../normalize-legacy-addon/normalize-legacy-addon.css";
-@import (reference) "../src/cf-grid.less";
+@import (less) '../../normalize-css/normalize.css';
+@import (less) '../../normalize-legacy-addon/normalize-legacy-addon.css';
+@import (reference) '../src/cf-grid.less';
 
 /**
  *  A CSS version of cf-grid

--- a/packages/cf-layout/src/cf-layout.less
+++ b/packages/cf-layout/src/cf-layout.less
@@ -608,11 +608,11 @@
 // Import Molecules
 //
 
-@import 'molecules/heroes.less';
+@import (less) 'molecules/heroes.less';
 
 //
 // Import Organisms
 //
 
-@import 'organisms/featured-content-module.less';
-@import 'organisms/wells.less';
+@import (less) 'organisms/featured-content-module.less';
+@import (less) 'organisms/wells.less';


### PR DESCRIPTION
Fixes https://github.com/cfpb/capital-framework/issues/445

## Changes

- Adds (less) keyword to imports where it was missing for consistency across import statements.
- Convert double quotes to single quotes.

## Testing

1. `gulp` should pass.
